### PR TITLE
Rename x402-app-template refs and add user guide

### DIFF
--- a/.claude/skills/architecture/SKILL.md
+++ b/.claude/skills/architecture/SKILL.md
@@ -315,4 +315,4 @@ If `docs/architecture.md` already exists:
 - Every diagram should be self-explanatory. A developer should be able to understand the system from the diagrams alone.
 - The folder/file hierarchy is critical — it locks in the decomposition decisions that the implementation plan builds on.
 - Module retention decisions must be justified. Don't remove something just because the user didn't explicitly mention it — remove it because the architecture doesn't need it.
-- Use the existing x402-app-template structure as the baseline. Only deviate when the spec requires it.
+- Use the existing app-in-a-box structure as the baseline. Only deviate when the spec requires it.

--- a/.claude/skills/specification/SKILL.md
+++ b/.claude/skills/specification/SKILL.md
@@ -66,7 +66,7 @@ For each action identified in Step 1, define the API endpoint:
 - 404: {When and why}
 ```
 
-Follow these conventions (matching x402-app-template patterns):
+Follow these conventions (matching app-in-a-box patterns):
 - Free endpoints: `/api/v1/{resource}`
 - Auth-gated endpoints: `/api/v1/{resource}` with X-API-Key header
 - x402 payment-gated: `/api/x402/{resource}`
@@ -205,6 +205,6 @@ If `docs/specification.md` already exists:
 ## Notes
 
 - The spec must be traceable to requirements. Every endpoint should map to at least one user story.
-- Use the x402-app-template patterns as the reference implementation. The server/ directory already demonstrates the service layer pattern, auth middleware, MCP tool registration, and x402 payment flow.
+- Use the app-in-a-box patterns as the reference implementation. The server/ directory already demonstrates the service layer pattern, auth middleware, MCP tool registration, and x402 payment flow.
 - Don't over-specify. If the requirements are simple, the spec should be simple.
 - MCP tools MUST mirror REST endpoints through a shared service layer — never duplicate business logic.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Thanks for your interest in contributing to x402-app-template.
+Thanks for your interest in contributing to app-in-a-box.
 
 ## Getting Started
 
@@ -32,7 +32,7 @@ ruff check src/ tests/
 
 ## Reporting Issues
 
-Open an issue at [github.com/MangroveTechnologies/x402-app-template/issues](https://github.com/MangroveTechnologies/x402-app-template/issues).
+Open an issue at [github.com/MangroveTechnologies/app-in-a-box/issues](https://github.com/MangroveTechnologies/app-in-a-box/issues).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,299 @@ App-in-a-box is Mangrove-branded by default. To re-skin:
 2. Replace files in `assets/` with your logos and icons
 3. Run `./init.sh` to propagate changes
 
+---
+
+## User Guide
+
+Everything you need to go from zero to a running application.
+
+### Prerequisites
+
+| Tool | Version | Install |
+|------|---------|---------|
+| **Python** | 3.10+ | [python.org](https://www.python.org/downloads/) or `brew install python` |
+| **Docker** | 20+ | [docker.com](https://docs.docker.com/get-docker/) |
+| **Claude Code** | Latest | `npm install -g @anthropic-ai/claude-code` |
+| **Git** | 2.x | [git-scm.com](https://git-scm.com/) |
+
+Claude Code requires an Anthropic API key. Set it before your first session:
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...
+```
+
+Or Claude Code will prompt you to sign in on first launch.
+
+### Step 1: Clone the Repo
+
+```bash
+git clone https://github.com/MangroveTechnologies/app-in-a-box.git my-app
+cd my-app
+```
+
+> **Tip:** Replace `my-app` with your project name. The onboarding agent will rename everything for you.
+
+### Step 2: Start Claude Code
+
+```bash
+claude
+```
+
+Claude detects a fresh app-in-a-box project and begins the onboarding conversation. It will ask you:
+
+1. **What are you building?** — Describe your app in plain language
+2. **Why are you building it?** — The problem it solves
+3. **What's your experience level?** — So the agent calibrates its guidance
+4. **Any preferences?** — Coding style, conventions, libraries
+5. **Project identity** — Name, description, branding
+
+The agent updates `branding.json` and `CLAUDE.md` with your answers. When you approve, it hands off to the next phase.
+
+### Step 3: Design Lifecycle
+
+After onboarding, run each skill in order. Each phase produces a document in `docs/` and waits for your approval before proceeding.
+
+#### `/requirements`
+
+The agent interviews you about what your app needs to do, then produces:
+- User stories (As a ___, I want ___, so that ___)
+- 3+ mermaid user flow diagrams covering 95% of use cases
+- Written to `docs/requirements.md`
+
+Review the diagrams and stories. Edit anything that's off. When satisfied, approve to proceed.
+
+#### `/specification`
+
+From your approved requirements, the agent generates:
+- API endpoint contracts (method, path, request/response, errors)
+- Data models with field types and constraints
+- Auth flows and error handling strategy
+- Written to `docs/specification.md`
+
+#### `/architecture`
+
+From the approved spec, the agent produces:
+- System architecture diagram (mermaid)
+- Data flow diagram
+- Sequence diagrams for key operations
+- Component diagram
+- Folder/file hierarchy
+- Module retention decisions (what stays, what gets removed)
+- Written to `docs/architecture.md`
+
+This is the **subtractive setup** step. App-in-a-box ships with everything (x402 payments, PostgreSQL, Redis, auth middleware). The architecture phase determines what your app actually needs and marks the rest for removal.
+
+#### `/plan`
+
+From the approved architecture, the agent generates:
+- Phased implementation plan with numbered tasks
+- Dependencies between tasks
+- Agent assignments (which subagent handles each task)
+- Cleanup step to remove unused scaffold modules
+- Written to `docs/implementation-plan.md`
+
+### Step 4: Build
+
+After you approve the plan, the product-owner agent activates. It reads `docs/implementation-plan.md` and drives implementation by delegating tasks to the agent workforce (backend-developer, frontend-developer, test-engineer, etc.).
+
+You stay in the loop — the product owner checks in for approval at key milestones.
+
+### Step 5: Run Locally
+
+```bash
+# App only
+docker compose up -d --build
+curl http://localhost:8080/health
+
+# App + PostgreSQL + Redis
+docker compose up -d --build --profile full
+```
+
+Or run without Docker:
+
+```bash
+cd server
+python -m venv venv
+source venv/bin/activate  # or venv\Scripts\activate on Windows
+pip install -r requirements.txt
+ENVIRONMENT=local python -m uvicorn src.app:app --host 0.0.0.0 --port 8080 --reload
+```
+
+### Step 6: Run Tests
+
+```bash
+cd server
+pip install -r requirements.txt
+pytest
+```
+
+Or with Docker:
+
+```bash
+docker compose run --rm app pytest
+```
+
+### Step 7: Deploy
+
+#### GCP Cloud Run (included)
+
+```bash
+cd infra/terraform
+terraform init -backend-config=backend-dev.hcl
+terraform plan -var-file=environment-dev.tfvars
+terraform apply -var-file=environment-dev.tfvars
+```
+
+GitHub Actions CI/CD is pre-configured:
+- **ci.yml** — Runs lint (ruff) + tests (pytest) on every push and PR
+- **deploy-cloudrun.yaml** — Builds and deploys to Cloud Run on push to `main`
+
+---
+
+## Installing the Plugin
+
+The `plugin/` directory contains a Claude Code plugin for **end users** of your app (not for development — development skills live in `.claude/`).
+
+### For Development (Load Locally)
+
+While building your app, load the plugin for a single session:
+
+```bash
+claude --plugin-dir ./plugin
+```
+
+### For Distribution
+
+After your app is deployed, users install your plugin:
+
+```bash
+# Clone or download your published repo
+git clone https://github.com/your-org/your-app.git
+cd your-app
+
+# Add to local plugin marketplace and install
+claude plugin marketplace add ./plugin
+claude plugin install your-app
+```
+
+Or load without installing:
+
+```bash
+claude --plugin-dir /path/to/your-app/plugin
+```
+
+### Plugin Structure
+
+```
+plugin/
+├── .claude-plugin/
+│   └── plugin.json       # Plugin manifest (name, version, author)
+├── .mcp.json              # MCP server connection config
+├── commands/
+│   └── help.md            # /help slash command
+├── skills/
+│   └── app/SKILL.md       # Main skill for tool interactions
+├── hooks/
+│   ├── hooks.json         # Hook definitions
+│   └── context.json       # Context injection on prompt submit
+└── README.md
+```
+
+Customize by editing the files above. Add new slash commands as `.md` files in `commands/`. Update `skills/app/SKILL.md` with descriptions of your app's tools.
+
+---
+
+## Tutorial: Build a Trading App
+
+App-in-a-box includes a hands-on tutorial that walks you through building a trading app against the Mangrove developer API.
+
+```bash
+claude
+> /tutorial
+```
+
+The tutorial covers 8 chapters:
+
+| Chapter | Topic |
+|---------|-------|
+| 0 | Overview and setup |
+| 1 | Your first endpoint |
+| 2 | MCP tool registration |
+| 3 | Service layer pattern |
+| 4 | Authentication |
+| 5 | x402 payments |
+| 6 | Testing |
+| 7 | Docker and local development |
+| 8 | Deployment to Cloud Run |
+
+Reference docs are in `tutorials/trading-app/` if you prefer to read ahead.
+
+---
+
+## Non-Interactive Setup
+
+If you prefer to skip the agent conversation and bootstrap manually:
+
+```bash
+./init.sh --name my-service --gcp-project my-gcp-project --region us-central1
+```
+
+This replaces placeholder values across all config files, updates `branding.json`, and self-deletes. You can then run the design lifecycle skills (`/requirements`, `/specification`, etc.) separately, or skip them entirely and start coding.
+
+---
+
+## Re-skinning / Branding
+
+App-in-a-box is Mangrove-branded by default. To use your own brand:
+
+1. **Edit `branding.json`:**
+   ```json
+   {
+     "project_name": "my-project",
+     "display_name": "My Project",
+     "org_name": "My Org",
+     "tagline": "What my project does",
+     "urls": {
+       "homepage": "https://myproject.com",
+       "docs": "https://docs.myproject.com",
+       "repository": "https://github.com/my-org/my-project"
+     },
+     "colors": {
+       "primary": "#1a1a2e",
+       "secondary": "#16213e",
+       "accent": "#e94560"
+     },
+     "prefix": "my"
+   }
+   ```
+
+2. **Replace files in `assets/`:**
+   - `logo.svg` — Light background logo
+   - `logo-dark.svg` — Dark background logo
+   - `icon.png` — Square icon (120x120 recommended)
+   - `banner.png` — Banner image for README/docs
+
+3. **Run `./init.sh`** or let the `/onboard` skill handle it during agent setup.
+
+---
+
+## FAQ
+
+**Q: Do I need to use every phase of the design lifecycle?**
+No. You can skip straight to coding. The skills are there to help you think through your app before building — especially useful if you're not sure what you need yet.
+
+**Q: Can I use this without Claude Code?**
+Yes. The server is a standard FastAPI app. Run `./init.sh`, edit the code, and deploy normally. The Claude Code skills and plugin are optional.
+
+**Q: What gets removed during the architecture phase?**
+Depends on your app. If you don't need x402 payments, the payment middleware and x402 routes are removed. If you don't need PostgreSQL, the DB config and init scripts are removed. The agent explains what it's removing and why.
+
+**Q: Can I add removed modules back later?**
+Yes. The git history preserves everything. You can also re-clone the template and copy modules back in.
+
+**Q: How do I add a new endpoint?**
+See the "Adding Endpoints" section in [CLAUDE.md](CLAUDE.md). Short version: create a route, create a service, register both, write tests.
+
 ## License
 
 MIT

--- a/init-interactive.sh
+++ b/init-interactive.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# x402-app-template bootstrap script (interactive, human-friendly)
+# app-in-a-box bootstrap script (interactive, human-friendly)
 # Prompts for values, then calls init.sh
 
-echo "=== x402-app-template bootstrap ==="
+echo "=== app-in-a-box bootstrap ==="
 echo ""
 
 read -rp "Service name (e.g. my-service): " NAME

--- a/init.sh
+++ b/init.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# x402-app-template bootstrap script (non-interactive, agent-friendly)
+# app-in-a-box bootstrap script (non-interactive, agent-friendly)
 # Usage: ./init.sh --name my-service --gcp-project my-gcp-project [--region us-central1]
 
 NAME=""
@@ -34,13 +34,13 @@ find . -type f \( -name "*.py" -o -name "*.json" -o -name "*.yaml" -o -name "*.y
   -exec sed -i "s/YOUR_TERRAFORM_STATE_BUCKET/${GCP_PROJECT}-terraform-state/g" {} +
 
 # Update pyproject.toml project name
-sed -i "s/x402-app-template/$NAME/g" server/pyproject.toml
+sed -i "s/app-in-a-box/$NAME/g" server/pyproject.toml
 
 # Update FastAPI title
-sed -i "s/x402 App Template/$NAME/g" server/src/app.py
+sed -i "s/App-in-a-Box/$NAME/g" server/src/app.py
 
 # Update MCP server name
-sed -i "s/x402-app-template/$NAME/g" server/src/mcp/server.py
+sed -i "s/app-in-a-box/$NAME/g" server/src/mcp/server.py
 
 # Derive display name from service name (capitalize, replace hyphens with spaces)
 SERVICE_NAME="$NAME"

--- a/server/db/init.sql
+++ b/server/db/init.sql
@@ -1,4 +1,4 @@
--- Database initialization for x402-app-template (full profile).
+-- Database initialization for app-in-a-box (full profile).
 -- Run automatically by docker-compose when using --profile full.
 
 CREATE TABLE IF NOT EXISTS notes (

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -3,9 +3,9 @@ requires = ["setuptools>=68.0"]
 build-backend = "setuptools.backends._legacy:_Backend"
 
 [project]
-name = "x402-app-template"
+name = "app-in-a-box"
 version = "0.1.0"
-description = "FastAPI + MCP service template for GCP Cloud Run"
+description = "General-purpose FastAPI + Claude Code development template"
 requires-python = ">=3.11"
 
 [tool.pytest.ini_options]

--- a/server/src/app.py
+++ b/server/src/app.py
@@ -54,7 +54,7 @@ async def lifespan(application: FastAPI):
 
 
 app = FastAPI(
-    title="x402 App Template",
+    title="App-in-a-Box",
     description=(
         "FastAPI + MCP service template with three-tier access control.\n\n"
         "## For Agents\n\n"

--- a/server/src/mcp/server.py
+++ b/server/src/mcp/server.py
@@ -17,7 +17,7 @@ def create_mcp_server() -> FastMCP:
     if _mcp_server is not None:
         return _mcp_server
 
-    _mcp_server = FastMCP("x402-app-template")
+    _mcp_server = FastMCP("app-in-a-box")
 
     from src.mcp.tools import register
     register(_mcp_server)

--- a/server/tests/test_docs.py
+++ b/server/tests/test_docs.py
@@ -57,7 +57,7 @@ def test_openapi_spec_available(client):
     assert resp.status_code == 200
     spec = resp.json()
     assert spec["openapi"].startswith("3.")
-    assert spec["info"]["title"] == "x402 App Template"
+    assert spec["info"]["title"] == "App-in-a-Box"
 
 
 def test_swagger_ui_available(client):

--- a/server/tests/test_mcp.py
+++ b/server/tests/test_mcp.py
@@ -8,7 +8,7 @@ from src.mcp.server import create_mcp_server
 
 def test_mcp_server_creates_successfully():
     server = create_mcp_server()
-    assert server.name == "x402-app-template"
+    assert server.name == "app-in-a-box"
 
 
 def test_mcp_server_is_singleton():


### PR DESCRIPTION
## Summary
- Renames all internal `x402-app-template` references to `app-in-a-box` (MCP server name, pyproject, tests, init scripts, skills, CONTRIBUTING)
- Extends README with comprehensive user guide: prerequisites, clone-to-deploy walkthrough, plugin install, tutorial, branding, deployment, FAQ

## Test plan
- [x] All 45 tests pass locally (MCP server name + OpenAPI title assertions updated)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)