### PR TITLE
defi-agent: system architecture + spec refinements

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,4 +1,4 @@
-# Architecture: Hank (defi-agent)
+# Architecture: defi-agent
 
 **Generated:** 2026-04-17
 **Status:** Draft
@@ -6,12 +6,16 @@
 
 ## Overview
 
-Hank is a local-first FastAPI + MCP service that wraps two Mangrove SDKs, holds wallet keys on-disk (encrypted), and runs strategies on in-process cron jobs. The architecture is deliberately minimal:
+defi-agent is a local FastAPI + MCP service that wraps two Mangrove SDKs and runs strategies on in-process cron jobs. The architecture is deliberately minimal:
+
 - **One process.** FastAPI app serves REST + MCP + runs the scheduler in-process.
 - **One datastore.** SQLite for everything — business data and the APScheduler jobstore share a DB file.
 - **Two external dependencies.** `mangroveai` and `mangrovemarkets` SDKs. That's it.
+- **Zero local logic where the SDK already does the work.** Strategy evaluation, risk gates, position sizing, cooldowns, volatility adjustments — all of that lives in Mangrove's execution engine. The agent calls the SDK and executes the returned orders. It does not reimplement any of that logic.
 
-No Postgres, no Redis, no x402, no message queues, no separate scheduler service. All removable complexity is removed.
+No Postgres, no Redis, no x402, no message queues, no separate scheduler service.
+
+Cloud deployment is out of scope for v1. See [Roadmap](#roadmap).
 
 ---
 
@@ -23,25 +27,25 @@ graph TB
         ClaudeCode[Claude Code<br/>or MCP client]
         HTTPClient[Python script / curl /<br/>any HTTP client]
 
-        subgraph "Hank process"
+        subgraph "defi-agent process"
             subgraph "API Layer"
-                REST[REST routes<br/>/api/v1/hank/*]
+                REST[REST routes<br/>/api/v1/agent/*]
                 MCP[MCP tools<br/>/mcp]
             end
             AuthMW[Auth middleware<br/>X-API-Key]
-            Services[Service layer<br/>15 modules]
+            Services[Service layer]
             Scheduler[APScheduler<br/>in-process]
         end
 
         subgraph "Local storage"
-            SQLite[(SQLite<br/>hank.db)]
+            SQLite[(SQLite<br/>agent.db)]
             Keychain[(OS Keychain<br/>master key)]
         end
     end
 
-    subgraph "Mangrove Cloud"
-        MangroveAI[mangroveai API<br/>strategies, backtest,<br/>signals, market, KB]
-        MangroveMkts[mangrovemarkets<br/>MCP Server<br/>DEX, wallet, portfolio]
+    subgraph "Mangrove APIs"
+        MangroveAI[mangroveai SDK<br/>strategies, backtest,<br/>evaluate, signals,<br/>market, KB]
+        MangroveMkts[mangrovemarkets SDK<br/>DEX, wallet, portfolio]
     end
 
     ClaudeCode -->|MCP over HTTP| MCP
@@ -52,21 +56,21 @@ graph TB
     Scheduler -->|cron tick| Services
     Services --> SQLite
     Services -->|encrypt/decrypt| Keychain
-    Services -->|mangroveai SDK| MangroveAI
-    Services -->|mangrovemarkets SDK| MangroveMkts
+    Services --> MangroveAI
+    Services --> MangroveMkts
 ```
 
 ### Component responsibilities
 
 | Component | Responsibility |
 |-----------|---------------|
-| REST routes | HTTP handlers under `/api/v1/hank/*`; delegate to service layer |
+| REST routes | HTTP handlers under `/api/v1/agent/*`; delegate to service layer |
 | MCP tools | FastMCP tool handlers at `/mcp`; delegate to service layer |
-| Auth middleware | Validate `X-API-Key` against `HANK_API_KEY`; bypass for discovery |
-| Service layer | All business logic; called by REST + MCP + scheduler |
+| Auth middleware | Validate `X-API-Key` against configured API key; bypass for discovery |
+| Service layer | Orchestration — no strategy/risk logic; that's all in Mangrove |
 | Scheduler | APScheduler BackgroundScheduler, SQLite jobstore |
 | SQLite | Wallets (encrypted), strategies cache, allocations, evaluations, trades, positions, APScheduler jobs |
-| OS Keychain | Stores the Fernet master key; env var `HANK_MASTER_KEY` is a fallback |
+| OS Keychain | Stores the Fernet master key; config-resolved secret is the fallback |
 
 ---
 
@@ -96,23 +100,26 @@ Auth is enforced once at the boundary. The service layer is protocol-agnostic �
 
 ```mermaid
 flowchart LR
-    A[APScheduler<br/>cron tick] --> B[strategy_evaluator]
-    B --> C[Load strategy from SQLite]
-    C --> D[Fetch market data<br/>via mangroveai SDK]
-    D --> E[Load open positions<br/>from SQLite]
-    E --> F[Evaluate signals<br/>pure function]
-    F --> G[OrderIntent array]
-    G --> H[order_executor]
-    H --> I{Strategy<br/>mode?}
-    I -->|paper| J[Simulate fill<br/>at mid/mark price]
-    I -->|live| K[DEX swap via<br/>mangrovemarkets SDK]
-    K --> L[Sign locally<br/>broadcast poll]
-    J --> M[trade_log]
-    L --> M
-    M --> N[(SQLite:<br/>evaluations, trades,<br/>positions)]
+    A[APScheduler<br/>cron tick] --> B[strategy_service]
+    B --> C[Fetch latest market data<br/>mangroveai.crypto_assets]
+    C --> D[mangroveai.execution.evaluate<br/>strategy_id + current data]
+    D --> E[SDK applies:<br/>signal eval, position sizing,<br/>risk gates, cooldowns,<br/>vol adjustment]
+    E --> F[OrderIntent array<br/>from SDK]
+    F --> G[order_executor]
+    G --> H{Strategy<br/>mode?}
+    H -->|paper| I[Simulate fill<br/>at mid/mark price]
+    H -->|live| J[DEX swap via<br/>mangrovemarkets SDK]
+    J --> K[Sign locally,<br/>broadcast, poll]
+    I --> L[trade_log]
+    K --> L
+    L --> M[(SQLite:<br/>evaluations, trades,<br/>positions)]
 ```
 
-`strategy_evaluator` is deliberately a pure function — no SDK calls, no DB writes, no network. That makes it trivially testable and swappable. All side effects live in `order_executor` and `trade_log`.
+**Critical:** the agent does not evaluate strategies locally. Signal evaluation, risk gates (`max_risk_per_trade`, `max_open_positions`, `max_trades_per_day`), position sizing, volatility adjustment, and cooldown enforcement all live in Mangrove's SDK (`mangroveai.execution.evaluate()`). The agent's job is:
+1. Fetch current market data
+2. Call the SDK evaluate endpoint
+3. Branch the returned `OrderIntent[]` to paper or live execution
+4. Log everything
 
 ---
 
@@ -120,11 +127,10 @@ flowchart LR
 
 ```mermaid
 sequenceDiagram
-    participant U as User / Agent
+    participant U as User / Caller
     participant API as REST or MCP
     participant SS as strategy_service
     participant CG as candidate_generator
-    participant BS as backtest_service
     participant SDK as mangroveai SDK
     participant DB as SQLite
 
@@ -136,10 +142,8 @@ sequenceDiagram
     CG-->>SS: 5-10 candidate strategies
 
     loop for each candidate
-        SS->>BS: quick_backtest(candidate)
-        BS->>SDK: backtesting.run(mode=quick, ...)
-        SDK-->>BS: metrics
-        BS-->>SS: result
+        SS->>SDK: backtesting.run(mode=quick, ...)
+        SDK-->>SS: metrics
     end
 
     SS->>SS: filter (win_rate>0.51, trades>=10)
@@ -149,18 +153,17 @@ sequenceDiagram
         SS-->>API: 422 STRATEGY_NO_VIABLE_CANDIDATES
         API-->>U: error + suggestion
     else has survivors
-        SS->>BS: full_backtest(winner)
-        BS->>SDK: backtesting.run(mode=full, ...)
-        SDK-->>BS: full metrics + trade history
+        SS->>SDK: backtesting.run(mode=full, winner)
+        SDK-->>SS: full metrics + trade history
         SS->>SDK: strategies.create(winner)
         SDK-->>SS: mangrove_id
-        SS->>DB: INSERT strategies + generation_report
+        SS->>DB: INSERT strategies cache + generation_report
         SS-->>API: StrategyDetail + report
         API-->>U: 201 Created
     end
 ```
 
-Candidate generation uses **deterministic heuristics** — a rules table mapping goal keywords (momentum, mean_reversion, breakout, trend) to signal categories, with random sampling within each category for diversity. No LLM call from the server; the intelligence is in the mapping + the user's choice of goal language.
+Candidate generation uses **deterministic heuristics** — a rules table mapping goal keywords (momentum, mean_reversion, breakout, trend) to signal categories, with random sampling within each category for diversity. No LLM call from the server. Intelligence lives in the mapping + the user's choice of goal language.
 
 ---
 
@@ -174,6 +177,7 @@ sequenceDiagram
     participant WM as wallet_manager
     participant AS as allocation_service
     participant SCH as scheduler_service
+    participant SDK as mangroveai SDK
     participant DB as SQLite
 
     U->>API: PATCH /strategies/{id}/status<br/>{status: live, confirm: true,<br/>allocation: {...}}
@@ -184,7 +188,8 @@ sequenceDiagram
     WM-->>SS: yes
     SS->>AS: record_allocation(strategy, allocation)
     AS->>DB: INSERT into allocations
-    SS->>SS: update strategy status in mangroveai SDK + cache
+    SS->>SDK: strategies.update_status(mangrove_id, live)
+    SDK-->>SS: ok
     SS->>SCH: register_job(strategy_id, timeframe)
     SCH->>DB: INSERT into apscheduler_jobs
     SCH-->>SS: job_id
@@ -192,7 +197,71 @@ sequenceDiagram
     API-->>U: 200 OK
 ```
 
-From here, the scheduler fires independently — no user involvement until they deactivate.
+From here, the scheduler fires independently on the strategy's timeframe — no user involvement until they deactivate.
+
+---
+
+## Sequence — Cron Tick (strategy evaluation)
+
+```mermaid
+sequenceDiagram
+    participant SCH as APScheduler
+    participant SS as strategy_service
+    participant MD as market_data
+    participant SDK as mangroveai.execution
+    participant OE as order_executor
+    participant Mkts as mangrovemarkets SDK
+    participant WM as wallet_manager
+    participant TL as trade_log
+    participant DB as SQLite
+
+    SCH->>SS: tick(strategy_id)
+    SS->>DB: load strategy
+    SS->>MD: get_latest(asset, timeframe)
+    MD-->>SS: current market data
+    SS->>SDK: execution.evaluate(strategy_id, market_data)
+    SDK-->>SS: [OrderIntent] (0..N, with risk gates already applied)
+
+    alt order_intents empty
+        SS->>TL: log evaluation (no_action)
+        TL->>DB: INSERT evaluations
+    else has orders
+        SS->>OE: execute(order_intents, strategy.mode)
+        loop per order
+            alt mode == paper
+                OE->>MD: mid price
+                MD-->>OE: price
+                OE->>TL: log simulated trade
+                TL->>DB: INSERT trades (status=simulated)
+            else mode == live
+                OE->>Mkts: dex.get_quote(...)
+                Mkts-->>OE: Quote
+                OE->>Mkts: dex.approve_token if needed
+                Mkts-->>OE: UnsignedTx | None
+                opt approval needed
+                    OE->>WM: sign(tx, wallet)
+                    WM-->>OE: signed_tx
+                    OE->>Mkts: dex.broadcast + tx_status
+                end
+                OE->>Mkts: dex.prepare_swap
+                Mkts-->>OE: UnsignedTx
+                OE->>WM: sign(tx, wallet)
+                WM-->>OE: signed_tx
+                OE->>Mkts: dex.broadcast
+                Mkts-->>OE: tx_hash
+                loop poll
+                    OE->>Mkts: dex.tx_status
+                    Mkts-->>OE: status
+                end
+                OE->>TL: log live trade
+                TL->>DB: INSERT trades (status=confirmed)
+            end
+        end
+        OE->>DB: UPDATE positions
+    end
+```
+
+The evaluator logic is entirely inside `mangroveai.execution.evaluate()`. The agent's `strategy_service` is a thin orchestrator: fetch data, call SDK, dispatch results to the executor.
 
 ---
 
@@ -244,7 +313,21 @@ sequenceDiagram
     API-->>U: 200 OK
 ```
 
-The full 6-step flow, mediated entirely by Hank; the SDK never touches the private key. The key is decrypted in `wallet_manager.sign()` and zeroed from memory immediately after.
+The full 6-step flow, mediated entirely by the agent. The SDK never touches the private key. The key is decrypted in `wallet_manager.sign()` and zeroed from memory immediately after.
+
+---
+
+## Chain Support — v1
+
+v1 is **EVM-only** for live execution. Specifically, whatever chains the `mangrovemarkets` DEX service supports: Ethereum (1), Base (8453), Arbitrum (42161), Polygon (137), Optimism (10), BNB (56), Avalanche (43114), zkSync (324), Gnosis (100), Linea (59144).
+
+| Chain family | Wallet create | Live DEX swap | Strategy execution |
+|--------------|---------------|---------------|---------------------|
+| EVM | ✅ | ✅ | ✅ live or paper |
+| XRPL | 🟡 Stub ("not yet supported in v1") | ❌ | ❌ |
+| Solana | ❌ Skip entirely | ❌ Upstream not supported | ❌ |
+
+Rationale: Mangrove's DEX integration wraps 1inch, which is EVM-only in Mangrove's SDK. Solana requires upstream work in `mangrovemarkets` before the agent can support it. XRPL gets a clean "not supported in v1" stub so the API shape doesn't break when it's added later.
 
 ---
 
@@ -254,7 +337,7 @@ The full 6-step flow, mediated entirely by Hank; the SDK never touches the priva
 graph TB
     subgraph "server/src"
         App[app.py<br/>FastAPI + lifespan]
-        Config[config/<br/>per-env JSON]
+        Config[config.py + config/*.json<br/>existing template pattern]
 
         subgraph "api/"
             Router[router.py]
@@ -279,11 +362,10 @@ graph TB
 
         subgraph "services/"
             SWallet[wallet_manager.py]
-            SStrat[strategy_service.py]
+            SStrat[strategy_service.py<br/>cron-tick orchestrator]
             SCG[candidate_generator.py]
             SBT[backtest_service.py]
-            SEval[strategy_evaluator.py]
-            SExec[order_executor.py]
+            SExec[order_executor.py<br/>paper or live dispatch]
             SSched[scheduler_service.py]
             SLog[trade_log.py]
             SAlloc[allocation_service.py]
@@ -296,18 +378,17 @@ graph TB
         end
 
         subgraph "shared/"
-            AuthMW[auth/middleware.py]
-            DB[db/sqlite.py]
-            Crypto[crypto/fernet.py]
-            Clients[clients/mangrove.py<br/>SDK singletons]
-            Errors[errors.py]
+            AuthMW[auth/middleware.py<br/>existing]
+            DB[db/sqlite.py<br/>new]
+            Crypto[crypto/fernet.py<br/>new]
+            Clients[clients/mangrove.py<br/>SDK singletons, new]
+            Errors[errors.py<br/>new]
         end
 
         subgraph "models/"
             MReq[requests.py]
             MResp[responses.py]
             MDB[db_models.py]
-            MDomain[domain.py<br/>OrderIntent, etc.]
         end
     end
 
@@ -327,9 +408,9 @@ graph TB
     MCPTools -.same services.-> SWallet & SStrat & SDex
 
     SStrat --> SCG & SBT & SSched & SAlloc
-    SSched --> SEval
-    SEval -.pure, no side effects.-> MDomain
-    SSched --> SExec
+    SStrat --> Clients
+    SSched --> SStrat
+    SStrat --> SExec
     SExec --> SDex & SLog
 
     SWallet --> Crypto
@@ -341,8 +422,73 @@ graph TB
 Key properties:
 - **Routes never call SDKs directly.** Always through the service layer.
 - **MCP tools and REST routes call the same services.** Logic lives in one place.
-- **`strategy_evaluator` is pure.** No SDK calls, no DB writes — it takes data in and returns `OrderIntent[]`.
+- **`strategy_service` is thin.** Loads strategy + market data, calls `mangroveai.execution.evaluate()`, dispatches returned orders to the executor. Does not evaluate signals, size positions, or enforce risk gates locally — those live in the SDK.
 - **SDK clients are singletons** initialized at startup (`shared/clients/mangrove.py`), shared across services.
+
+---
+
+## Configuration
+
+The agent uses the existing app-in-a-box config pattern — no invented `.env` files, no parallel config layer.
+
+### How the config system works
+
+- `server/src/config/{environment}-config.json` holds all configuration for that env
+- `ENVIRONMENT` env var selects which file to load (`local`, `dev`, `test`, `prod`)
+- `server/src/config/configuration-keys.json` declares the required keys
+- Values can be literal strings/numbers, or `secret:NAME:PROPERTY` references that resolve through GCP Secret Manager (a mechanism that stays in the template but isn't used by local deployments)
+- Local dev: put values directly in `local-config.json` (gitignored)
+
+### Configuration keys for defi-agent
+
+Replace the template's `configuration-keys.json` with:
+
+```json
+{
+  "required": [
+    "AUTH_ENABLED",
+    "API_KEY",
+    "MANGROVE_API_KEY",
+    "MANGROVEMARKETS_BASE_URL",
+    "DB_PATH",
+    "KEYRING_SERVICE_NAME",
+    "MASTER_KEY_ENV_FALLBACK",
+    "BACKTEST_CANDIDATE_COUNT",
+    "BACKTEST_MIN_WIN_RATE",
+    "BACKTEST_MIN_TRADES",
+    "BACKTEST_DEFAULT_LOOKBACK_MONTHS",
+    "LOG_RETENTION_DAYS"
+  ],
+  "full_app_keys": []
+}
+```
+
+### Example `local-config.json`
+
+```json
+{
+  "AUTH_ENABLED": true,
+  "API_KEY": "local-dev-key",
+  "MANGROVE_API_KEY": "dev_...",
+  "MANGROVEMARKETS_BASE_URL": "http://localhost:8080",
+  "DB_PATH": "./agent.db",
+  "KEYRING_SERVICE_NAME": "defi-agent",
+  "MASTER_KEY_ENV_FALLBACK": "",
+  "BACKTEST_CANDIDATE_COUNT": 7,
+  "BACKTEST_MIN_WIN_RATE": 0.51,
+  "BACKTEST_MIN_TRADES": 10,
+  "BACKTEST_DEFAULT_LOOKBACK_MONTHS": 3,
+  "LOG_RETENTION_DAYS": 90
+}
+```
+
+Secrets (API keys, master key fallback) can optionally be referenced as `"secret:mangrove-api-key:value"` when running in an environment that has Secret Manager configured — the local deployment puts literal values in the file.
+
+The Fernet master key itself is **not** in config. It's stored in the OS Keychain under the service name `defi-agent`. The `MASTER_KEY_ENV_FALLBACK` config key exists for environments without a keychain — if set (non-empty), the agent uses that value instead of the keychain. Local dev leaves it empty.
+
+### Full app keys (empty for v1)
+
+`full_app_keys` is empty — no Postgres or Redis. If v2 adds them, they go here.
 
 ---
 
@@ -354,7 +500,7 @@ app-in-a-box/
 │   ├── agents/
 │   │   └── product-owner.md                    # Drives build after /plan
 │   ├── hooks/
-│   │   └── check-onboard.sh                    # SessionStart hook
+│   │   └── check-onboard.sh
 │   ├── rules/
 │   │   └── git-workflow.md
 │   ├── skills/
@@ -368,13 +514,15 @@ app-in-a-box/
 ├── server/
 │   ├── src/
 │   │   ├── app.py                              # FastAPI factory, scheduler lifespan
+│   │   ├── config.py                           # Existing config loader (unchanged)
 │   │   ├── config/
-│   │   │   ├── local-config.json               # Defaults for local dev
+│   │   │   ├── configuration-keys.json         # Updated: agent's required keys
+│   │   │   ├── local-config.json               # Local dev values
 │   │   │   ├── dev-config.json
-│   │   │   ├── prod-config.json
-│   │   │   └── loader.py                       # Env → config JSON selector
+│   │   │   ├── test-config.json
+│   │   │   └── prod-config.json                # Kept but unused in v1
 │   │   ├── api/
-│   │   │   ├── router.py                       # Aggregates routes, mounts /api/v1/hank
+│   │   │   ├── router.py                       # Aggregates routes, mounts /api/v1/agent
 │   │   │   └── routes/
 │   │   │       ├── discovery.py                # health, status, tool catalog
 │   │   │       ├── wallet.py                   # create, list, balances, portfolio, history
@@ -391,11 +539,10 @@ app-in-a-box/
 │   │   │   └── registry.py                     # register_tool helper
 │   │   ├── services/
 │   │   │   ├── wallet_manager.py               # Key gen, Fernet encrypt, local signing
-│   │   │   ├── strategy_service.py             # Strategy CRUD (wraps mangroveai)
+│   │   │   ├── strategy_service.py             # Cron orchestrator: data → SDK evaluate → executor
 │   │   │   ├── candidate_generator.py          # Goal → 5-10 signal combos
 │   │   │   ├── backtest_service.py             # Quick + full, filter + IRR rank
-│   │   │   ├── strategy_evaluator.py           # PURE: (strategy, mkt, pos) → OrderIntent[]
-│   │   │   ├── order_executor.py               # OrderIntent → DEX (live) or simulated (paper)
+│   │   │   ├── order_executor.py               # paper (simulate) or live (DEX swap)
 │   │   │   ├── scheduler_service.py            # APScheduler wrapper
 │   │   │   ├── trade_log.py                    # SQLite writes
 │   │   │   ├── allocation_service.py           # Per-strategy fund accounting
@@ -406,7 +553,7 @@ app-in-a-box/
 │   │   │   ├── portfolio_service.py            # Wraps mangrovemarkets.portfolio
 │   │   │   └── kb_service.py                   # Wraps mangroveai.kb
 │   │   ├── shared/
-│   │   │   ├── auth/middleware.py              # X-API-Key validation
+│   │   │   ├── auth/middleware.py              # X-API-Key validation (existing)
 │   │   │   ├── db/
 │   │   │   │   ├── sqlite.py                   # Connection helper, migrations
 │   │   │   │   └── migrations/                 # SQL schema files
@@ -418,33 +565,28 @@ app-in-a-box/
 │   │   ├── models/
 │   │   │   ├── requests.py                     # Pydantic request models
 │   │   │   ├── responses.py                    # Pydantic response models
-│   │   │   ├── domain.py                       # OrderIntent, SignalRule, ExecutionConfig
-│   │   │   └── db_models.py                    # Row adapters / ORM-lite
+│   │   │   └── db_models.py                    # Row adapters
 │   │   └── health.py                           # Health probe payload
 │   ├── tests/
 │   │   ├── conftest.py
-│   │   ├── unit/                               # Pure unit tests (evaluator, candidate_gen)
-│   │   ├── integration/                        # DB + SDK-mocked integration tests
-│   │   └── e2e/                                # Full flow, uses dev Mangrove env
-│   ├── db/
-│   │   └── init.sql                            # Not used in v1 (SQLite auto-init)
+│   │   ├── unit/
+│   │   ├── integration/
+│   │   └── e2e/
 │   ├── Dockerfile
 │   └── requirements.txt
-├── plugin/                                     # (Future) Claude Code plugin wrapper
 ├── tutorials/                                  # Workshop curriculum (separate deliverable)
 │   └── bots-and-bytes/
 ├── docs/
-│   ├── api-reference.md                        # Consolidated Mangrove API surface
-│   ├── user-stories.md                         # Approved requirements
-│   ├── specification.md                        # Approved spec
+│   ├── api-reference.md
+│   ├── user-stories.md
+│   ├── specification.md
 │   ├── architecture.md                         # This document
 │   ├── implementation-plan.md                  # Generated by /plan
 │   └── configuration.md
-├── assets/                                     # Branding (kept as-is from template)
+├── assets/
 ├── branding.json
-├── docker-compose.yml                          # Local dev stack (app only, no postgres/redis)
-├── .env.example                                # MANGROVE_API_KEY, HANK_API_KEY, etc.
-├── init.sh                                     # Template init (kept)
+├── docker-compose.yml                          # Local dev stack (app only)
+├── init.sh
 ├── CLAUDE.md
 ├── README.md
 └── LICENSE
@@ -454,8 +596,6 @@ app-in-a-box/
 
 ## Module Decisions
 
-Based on Hank's architecture, here's what we keep from the app-in-a-box template and what we remove:
-
 | Module | Status | Reason |
 |--------|--------|--------|
 | **FastAPI app factory** | ✅ Keep | Core of the dual-protocol service pattern |
@@ -463,70 +603,58 @@ Based on Hank's architecture, here's what we keep from the app-in-a-box template
 | **REST routes** | ✅ Keep | Core — universal HTTP access |
 | **API key auth middleware** | ✅ Keep | Single-user auth model |
 | **Service layer pattern** | ✅ Keep | Shared business logic between REST + MCP |
-| **Per-environment JSON config** | ✅ Keep | Matches local/dev/prod deployment modes |
+| **Per-environment JSON config** | ✅ Keep | Existing pattern; no `.env` files or parallel systems |
+| **configuration-keys.json** | ✅ Keep, update contents | Replace x402 keys with agent keys |
 | **SQLite (built-in)** | ✅ Keep | Single datastore for all state |
 | **APScheduler** | ✅ Add (new) | In-process cron; not in template |
 | **Fernet encryption + OS keychain** | ✅ Add (new) | Wallet key protection |
-| **PostgreSQL** | ❌ Remove | SQLite suffices. No multi-user, no high concurrency. Remove `--profile full`, `db/init.sql` postgres schema, `notes.py` route. |
-| **Redis** | ❌ Remove | No caching layer needed; APScheduler jobstore goes in SQLite. |
-| **x402 payment middleware + routes** | ❌ Remove | Hank is a local bot, not a monetized service. Remove `shared/x402/`, `routes/easter_egg.py`. |
-| **Items demo route** | ❌ Remove | Template scaffolding; replaced by real routes. |
-| **Notes demo route** | ❌ Remove | Template scaffolding; replaced by real routes. |
-| **Easter egg route** | ❌ Remove | x402 demo; Hank has no payment surface. |
-| **Echo route** | ❌ Remove | Template scaffolding; no purpose in Hank. |
-| **Terraform (GCP)** | 🟡 Optional | Keep for the optional Cloud Run demo path; not required for local use. Move to `infra/terraform/` and document as "demo only." |
-| **Docker Compose (app-only profile)** | ✅ Keep | Primary local dev entry point. |
+| **PostgreSQL** | ❌ Remove | SQLite suffices. Remove `--profile full`, `db/init.sql` postgres schema, `notes.py` route. |
+| **Redis** | ❌ Remove | No caching; APScheduler jobstore goes in SQLite. |
+| **x402 payment middleware + routes** | ❌ Remove | Local agent, no payment surface. Remove `shared/x402/`, `routes/easter_egg.py`, x402 keys from `configuration-keys.json`. |
+| **Items demo route** | ❌ Remove | Template scaffolding. |
+| **Notes demo route** | ❌ Remove | Template scaffolding. |
+| **Easter egg route** | ❌ Remove | x402 demo, not applicable. |
+| **Echo route** | ❌ Remove | Template scaffolding. |
+| **Terraform (GCP)** | ❌ Remove | Cloud is out of scope for v1. Delete `infra/terraform/`. |
+| **GitHub Actions: `deploy-cloudrun.yaml`** | ❌ Remove | Cloud is out of scope for v1. |
+| **GitHub Actions: `ci.yml`** | ✅ Keep | Lint + test on push/PR. |
+| **Docker Compose (app-only)** | ✅ Keep | Primary local dev entry point. |
 | **Docker Compose (full profile)** | ❌ Remove | Postgres + Redis not needed. |
 
 ---
 
 ## Technology Choices
 
-| Layer | Choice | Alternatives considered | Rationale |
-|-------|--------|-------------------------|-----------|
-| Web framework | FastAPI | Flask, Starlette | Template default; great OpenAPI; async-native; plays well with FastMCP |
-| MCP library | FastMCP | Raw MCP SDK | Template default; FastAPI-integrated; tool registration is a one-liner |
-| Storage | SQLite | Postgres, DuckDB | Local-first means no external DB. Full ACID, WAL mode for concurrency, built into Python. |
-| Scheduler | APScheduler (BackgroundScheduler, SQLAlchemy jobstore) | Celery, RQ, system cron | In-process, no broker required, persistent jobstore (survives restart), Python-native |
-| Key encryption | Fernet (from `cryptography` lib) | age, nacl | Battle-tested, standard-compliant, simple API |
-| Master key storage | OS Keychain via `keyring` | env var only, prompt per-session | Zero-config for local users; env var fallback for Cloud Run |
-| Config | Per-env JSON + env var overrides | pydantic-settings | Template pattern; keeps secrets out of code |
-| HTTP client (SDKs) | `httpx` (built into SDKs) | — | Chosen by upstream SDKs; not our decision |
-| Test framework | pytest | unittest | Template default; fixtures are great |
+| Layer | Choice | Rationale |
+|-------|--------|-----------|
+| Web framework | FastAPI | Template default; great OpenAPI; async-native; plays well with FastMCP |
+| MCP library | FastMCP | Template default; FastAPI-integrated; tool registration is a one-liner |
+| Storage | SQLite | Local-first means no external DB. Full ACID, WAL mode for concurrency, built into Python. |
+| Scheduler | APScheduler (BackgroundScheduler, SQLAlchemy jobstore) | In-process, no broker required, persistent jobstore, Python-native |
+| Key encryption | Fernet (from `cryptography`) | Battle-tested, standard-compliant, simple API |
+| Master key storage | OS Keychain via `keyring`, config-referenced fallback | Zero-config for local users |
+| Config | Existing template pattern (`config/*.json` + `configuration-keys.json`) | No parallel system; consistent with rest of template |
+| HTTP client | `httpx` via SDKs | Built into upstream SDKs |
+| Test framework | pytest | Template default |
 
 ---
 
-## Deployment Architecture
+## Deployment
 
-### Local (default)
+### Local (the only supported mode for v1)
 
 ```mermaid
 graph LR
-    User[User's terminal<br/>Claude Code] -->|MCP/HTTP| Docker[Docker Compose<br/>hank container]
-    Docker -->|reads/writes| Volume[./hank.db<br/>mounted volume]
+    User[User's terminal<br/>Claude Code] -->|MCP/HTTP| Docker[Docker Compose<br/>defi-agent container]
+    Docker -->|mounted volume| Volume[./agent.db]
     Docker -->|reads| Keychain[OS Keychain]
-    Docker -->|HTTPS| Mangrove[Mangrove APIs]
+    Docker -->|HTTPS| Mangrove[Mangrove SDKs]
 ```
 
-One `docker compose up` command; no cloud account required. State persists across restarts via bind-mounted volume.
+One `docker compose up` command. No cloud account required. State persists across restarts via bind-mounted volume.
 
-### Cloud Run (optional, demo)
+For users without Docker, running directly against Python 3.10+ is also supported: `uvicorn src.app:app --reload`.
 
-```mermaid
-graph LR
-    User[User's terminal] -->|HTTPS/MCP| CR[Cloud Run<br/>hank container]
-    CR -->|reads/writes| Ephemeral[Ephemeral fs<br/>hank.db]
-    CR -->|env var| SecretMgr[GCP Secret Mgr<br/>HANK_MASTER_KEY]
-    CR -->|HTTPS| Mangrove[Mangrove APIs]
+### Roadmap
 
-    style Ephemeral stroke-dasharray: 5 5
-```
-
-Wallet state and trade logs are wiped on each redeploy. Suitable for demo URLs; not for real trading.
-
-### Not in v1
-
-- Multi-region deployment
-- Cloud SQL / persistent cloud storage
-- Background worker pools (not needed — scheduler is in-process)
-- Horizontal scaling (single-user means single-process is fine)
+Future deployment modes (Cloud Run with persistent storage, Cloud SQL backing, multi-region) are **out of scope for v1**. They will be addressed in a subsequent release once the local pattern is stable and the workshop curriculum is shipped.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -537,7 +537,7 @@ app-in-a-box/
 │   │   │       ├── strategies.py               # create, list, get, patch status, backtest, evaluate
 │   │   │       ├── logs.py                     # evaluations, trades
 │   │   │       ├── kb.py                       # search, glossary
-│   │   │       └── easter_egg.py               # Existing x402 demo route (kept)
+│   │   │       └── hello_mangrove.py           # x402 demo route (renamed from template's easter_egg.py)
 │   │   ├── mcp/
 │   │   │   ├── server.py                       # FastMCP setup
 │   │   │   ├── tools.py                        # Tool definitions (mirror REST)
@@ -612,7 +612,7 @@ app-in-a-box/
 | **Redis** | ❌ Remove | No caching; APScheduler jobstore goes in SQLite. |
 | **x402 payment middleware** | ✅ Keep | Will be enabled later. Stays wired up so future endpoints can move to the payment tier without scaffolding work. |
 | **`shared/x402/` config + server** | ✅ Keep | Same reason. |
-| **`routes/easter_egg.py` (x402 demo)** | ✅ Keep | Smoke test for the payment path; harmless to ship. |
+| **`routes/hello_mangrove.py` (x402 demo, renamed from `easter_egg.py`)** | ✅ Keep | Smoke test for the payment path; harmless to ship. |
 | **x402 config keys in `configuration-keys.json`** | ✅ Keep | Required at startup by the payment middleware. |
 | **Items demo route** | ❌ Remove | Template scaffolding. |
 | **Notes demo route** | ❌ Remove | Template scaffolding (Postgres-backed). |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -207,8 +207,7 @@ From here, the scheduler fires independently on the strategy's timeframe — no 
 sequenceDiagram
     participant SCH as APScheduler
     participant SS as strategy_service
-    participant MD as market_data
-    participant SDK as mangroveai.execution
+    participant SDK as mangroveai SDK
     participant OE as order_executor
     participant Mkts as mangrovemarkets SDK
     participant WM as wallet_manager
@@ -217,8 +216,8 @@ sequenceDiagram
 
     SCH->>SS: tick(strategy_id)
     SS->>DB: load strategy
-    SS->>MD: get_latest(asset, timeframe)
-    MD-->>SS: current market data
+    SS->>SDK: crypto_assets.get_ohlcv(asset, timeframe)
+    SDK-->>SS: current market data
     SS->>SDK: execution.evaluate(strategy_id, market_data)
     SDK-->>SS: [OrderIntent] (0..N, with risk gates already applied)
 
@@ -229,8 +228,8 @@ sequenceDiagram
         SS->>OE: execute(order_intents, strategy.mode)
         loop per order
             alt mode == paper
-                OE->>MD: mid price
-                MD-->>OE: price
+                OE->>SDK: crypto_assets.get_market_data(asset)
+                SDK-->>OE: current price
                 OE->>TL: log simulated trade
                 TL->>DB: INSERT trades (status=simulated)
             else mode == live
@@ -267,49 +266,52 @@ The evaluator logic is entirely inside `mangroveai.execution.evaluate()`. The ag
 
 ## Sequence — DEX Swap (user-initiated)
 
+User-initiated swaps and cron-driven swaps share the same execution path: the route handler builds an `OrderIntent` from the request and calls `order_executor.execute_one(intent, mode='live')`. There is no separate `dex_service`.
+
 ```mermaid
 sequenceDiagram
     participant U as User
     participant API as REST or MCP
-    participant DS as dex_service
+    participant OE as order_executor
     participant WM as wallet_manager
     participant SDK as mangrovemarkets SDK
     participant Chain as Blockchain
 
     U->>API: POST /dex/swap<br/>{..., confirm: true}
-    API->>DS: execute_swap(req)
-    DS->>SDK: dex.get_quote(...)
-    SDK-->>DS: Quote
-    DS->>SDK: dex.approve_token(...)
-    SDK-->>DS: UnsignedTransaction | None
+    API->>API: build OrderIntent from request
+    API->>OE: execute_one(intent, mode=live)
+    OE->>SDK: dex.get_quote(...)
+    SDK-->>OE: Quote
+    OE->>SDK: dex.approve_token(...)
+    SDK-->>OE: UnsignedTransaction | None
 
     opt needs approval
-        DS->>WM: sign(tx, wallet)
+        OE->>WM: sign(tx, wallet)
         WM->>WM: decrypt seed in memory
-        WM-->>DS: signed_tx
-        DS->>SDK: dex.broadcast(signed_tx)
+        WM-->>OE: signed_tx
+        OE->>SDK: dex.broadcast(signed_tx)
         SDK->>Chain: submit tx
         Chain-->>SDK: tx_hash
-        SDK-->>DS: BroadcastResult
+        SDK-->>OE: BroadcastResult
         loop poll
-            DS->>SDK: dex.tx_status(hash)
-            SDK-->>DS: status
+            OE->>SDK: dex.tx_status(hash)
+            SDK-->>OE: status
         end
     end
 
-    DS->>SDK: dex.prepare_swap(quote_id, wallet)
-    SDK-->>DS: UnsignedTransaction
-    DS->>WM: sign(tx, wallet)
-    WM-->>DS: signed_tx
-    DS->>SDK: dex.broadcast(signed_tx)
+    OE->>SDK: dex.prepare_swap(quote_id, wallet)
+    SDK-->>OE: UnsignedTransaction
+    OE->>WM: sign(tx, wallet)
+    WM-->>OE: signed_tx
+    OE->>SDK: dex.broadcast(signed_tx)
     SDK->>Chain: submit tx
     Chain-->>SDK: tx_hash
     loop poll
-        DS->>SDK: dex.tx_status(hash)
-        SDK-->>DS: status
+        OE->>SDK: dex.tx_status(hash)
+        SDK-->>OE: status
     end
-    DS->>DS: log to trades table
-    DS-->>API: SwapResult (tx_hash, fill, ...)
+    OE->>OE: log to trades table
+    OE-->>API: SwapResult (tx_hash, fill, ...)
     API-->>U: 200 OK
 ```
 
@@ -365,20 +367,15 @@ graph TB
             SStrat[strategy_service.py<br/>cron-tick orchestrator]
             SCG[candidate_generator.py]
             SBT[backtest_service.py]
-            SExec[order_executor.py<br/>paper or live dispatch]
+            SExec[order_executor.py<br/>single DEX execution path<br/>paper or live]
             SSched[scheduler_service.py]
             SLog[trade_log.py]
             SAlloc[allocation_service.py]
-            SSig[signal_service.py]
-            SMD[market_data.py]
-            SOC[on_chain.py]
-            SDex[dex_service.py]
-            SPort[portfolio_service.py]
-            SKb[kb_service.py]
         end
 
         subgraph "shared/"
             AuthMW[auth/middleware.py<br/>existing]
+            X402[x402/<br/>existing payment middleware<br/>kept for future endpoints]
             DB[db/sqlite.py<br/>new]
             Crypto[crypto/fernet.py<br/>new]
             Clients[clients/mangrove.py<br/>SDK singletons, new]
@@ -395,28 +392,35 @@ graph TB
     App --> Router
     App --> MCPServer
     App --> SSched
+    App --> X402
     Router --> RWallet & RDex & RMarket & ROnChain & RSignals & RStrat & RLogs & RKb & RDiscovery
     MCPServer --> MCPTools
     MCPTools --> MCPReg
 
-    RWallet & RDex --> SWallet & SDex & SPort
-    RMarket & ROnChain --> SMD & SOC
-    RSignals --> SSig
+    RWallet --> SWallet
+    RWallet -.portfolio,balances.-> Clients
+    RDex -.venues,pairs,quote.-> Clients
+    RDex -->|user-initiated swap| SExec
+    RMarket -.OHLCV, market data.-> Clients
+    ROnChain -.smart money, whale.-> Clients
+    RSignals -.list, get.-> Clients
+    RKb -.search, glossary.-> Clients
     RStrat --> SStrat
     RLogs --> SLog
-    RKb --> SKb
-    MCPTools -.same services.-> SWallet & SStrat & SDex
+    MCPTools -.same services and clients.-> SWallet & SStrat & SExec & Clients
 
     SStrat --> SCG & SBT & SSched & SAlloc
     SStrat --> Clients
     SSched --> SStrat
     SStrat --> SExec
-    SExec --> SDex & SLog
+    SExec --> SLog
+    SExec --> Clients
+    SExec --> SWallet
 
     SWallet --> Crypto
     SWallet --> DB
-    SStrat & SLog & SAlloc --> DB
-    SStrat & SBT & SSig & SMD & SOC & SDex & SPort & SKb --> Clients
+    SLog & SAlloc --> DB
+    SCG & SBT --> Clients
 ```
 
 Key properties:
@@ -532,35 +536,31 @@ app-in-a-box/
 │   │   │       ├── signals.py                  # list, get
 │   │   │       ├── strategies.py               # create, list, get, patch status, backtest, evaluate
 │   │   │       ├── logs.py                     # evaluations, trades
-│   │   │       └── kb.py                       # search, glossary
+│   │   │       ├── kb.py                       # search, glossary
+│   │   │       └── easter_egg.py               # Existing x402 demo route (kept)
 │   │   ├── mcp/
 │   │   │   ├── server.py                       # FastMCP setup
 │   │   │   ├── tools.py                        # Tool definitions (mirror REST)
 │   │   │   └── registry.py                     # register_tool helper
-│   │   ├── services/
+│   │   ├── services/                           # Only services that ADD orchestration
 │   │   │   ├── wallet_manager.py               # Key gen, Fernet encrypt, local signing
 │   │   │   ├── strategy_service.py             # Cron orchestrator: data → SDK evaluate → executor
 │   │   │   ├── candidate_generator.py          # Goal → 5-10 signal combos
 │   │   │   ├── backtest_service.py             # Quick + full, filter + IRR rank
-│   │   │   ├── order_executor.py               # paper (simulate) or live (DEX swap)
+│   │   │   ├── order_executor.py               # SINGLE swap path: cron-driven OR user-initiated
 │   │   │   ├── scheduler_service.py            # APScheduler wrapper
 │   │   │   ├── trade_log.py                    # SQLite writes
-│   │   │   ├── allocation_service.py           # Per-strategy fund accounting
-│   │   │   ├── signal_service.py               # Wraps mangroveai.signals
-│   │   │   ├── market_data.py                  # Wraps mangroveai.crypto_assets
-│   │   │   ├── on_chain.py                     # Wraps mangroveai.on_chain
-│   │   │   ├── dex_service.py                  # Wraps mangrovemarkets.dex
-│   │   │   ├── portfolio_service.py            # Wraps mangrovemarkets.portfolio
-│   │   │   └── kb_service.py                   # Wraps mangroveai.kb
+│   │   │   └── allocation_service.py           # Per-strategy fund accounting
 │   │   ├── shared/
 │   │   │   ├── auth/middleware.py              # X-API-Key validation (existing)
+│   │   │   ├── x402/                           # Existing payment middleware (kept; no v1 endpoints use it yet)
 │   │   │   ├── db/
 │   │   │   │   ├── sqlite.py                   # Connection helper, migrations
 │   │   │   │   └── migrations/                 # SQL schema files
 │   │   │   ├── crypto/
 │   │   │   │   └── fernet.py                   # Master key mgmt + Fernet wrapper
 │   │   │   ├── clients/
-│   │   │   │   └── mangrove.py                 # SDK singletons
+│   │   │   │   └── mangrove.py                 # SDK singletons (called directly by routes)
 │   │   │   └── errors.py                       # Error codes, exception → HTTP mapping
 │   │   ├── models/
 │   │   │   ├── requests.py                     # Pydantic request models
@@ -610,16 +610,19 @@ app-in-a-box/
 | **Fernet encryption + OS keychain** | ✅ Add (new) | Wallet key protection |
 | **PostgreSQL** | ❌ Remove | SQLite suffices. Remove `--profile full`, `db/init.sql` postgres schema, `notes.py` route. |
 | **Redis** | ❌ Remove | No caching; APScheduler jobstore goes in SQLite. |
-| **x402 payment middleware + routes** | ❌ Remove | Local agent, no payment surface. Remove `shared/x402/`, `routes/easter_egg.py`, x402 keys from `configuration-keys.json`. |
+| **x402 payment middleware** | ✅ Keep | Will be enabled later. Stays wired up so future endpoints can move to the payment tier without scaffolding work. |
+| **`shared/x402/` config + server** | ✅ Keep | Same reason. |
+| **`routes/easter_egg.py` (x402 demo)** | ✅ Keep | Smoke test for the payment path; harmless to ship. |
+| **x402 config keys in `configuration-keys.json`** | ✅ Keep | Required at startup by the payment middleware. |
 | **Items demo route** | ❌ Remove | Template scaffolding. |
-| **Notes demo route** | ❌ Remove | Template scaffolding. |
-| **Easter egg route** | ❌ Remove | x402 demo, not applicable. |
+| **Notes demo route** | ❌ Remove | Template scaffolding (Postgres-backed). |
 | **Echo route** | ❌ Remove | Template scaffolding. |
 | **Terraform (GCP)** | ❌ Remove | Cloud is out of scope for v1. Delete `infra/terraform/`. |
 | **GitHub Actions: `deploy-cloudrun.yaml`** | ❌ Remove | Cloud is out of scope for v1. |
 | **GitHub Actions: `ci.yml`** | ✅ Keep | Lint + test on push/PR. |
 | **Docker Compose (app-only)** | ✅ Keep | Primary local dev entry point. |
 | **Docker Compose (full profile)** | ❌ Remove | Postgres + Redis not needed. |
+| **Pass-through service modules** (`signal_service`, `market_data`, `on_chain`, `kb_service`, `dex_service`, `portfolio_service`) | ❌ Don't create | Routes call SDK clients directly; wrapping the SDK adds nothing. |
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,532 @@
+# Architecture: Hank (defi-agent)
+
+**Generated:** 2026-04-17
+**Status:** Draft
+**Based on:** `docs/specification.md`
+
+## Overview
+
+Hank is a local-first FastAPI + MCP service that wraps two Mangrove SDKs, holds wallet keys on-disk (encrypted), and runs strategies on in-process cron jobs. The architecture is deliberately minimal:
+- **One process.** FastAPI app serves REST + MCP + runs the scheduler in-process.
+- **One datastore.** SQLite for everything — business data and the APScheduler jobstore share a DB file.
+- **Two external dependencies.** `mangroveai` and `mangrovemarkets` SDKs. That's it.
+
+No Postgres, no Redis, no x402, no message queues, no separate scheduler service. All removable complexity is removed.
+
+---
+
+## System Architecture
+
+```mermaid
+graph TB
+    subgraph "User's Machine"
+        ClaudeCode[Claude Code<br/>or MCP client]
+        HTTPClient[Python script / curl /<br/>any HTTP client]
+
+        subgraph "Hank process"
+            subgraph "API Layer"
+                REST[REST routes<br/>/api/v1/hank/*]
+                MCP[MCP tools<br/>/mcp]
+            end
+            AuthMW[Auth middleware<br/>X-API-Key]
+            Services[Service layer<br/>15 modules]
+            Scheduler[APScheduler<br/>in-process]
+        end
+
+        subgraph "Local storage"
+            SQLite[(SQLite<br/>hank.db)]
+            Keychain[(OS Keychain<br/>master key)]
+        end
+    end
+
+    subgraph "Mangrove Cloud"
+        MangroveAI[mangroveai API<br/>strategies, backtest,<br/>signals, market, KB]
+        MangroveMkts[mangrovemarkets<br/>MCP Server<br/>DEX, wallet, portfolio]
+    end
+
+    ClaudeCode -->|MCP over HTTP| MCP
+    HTTPClient -->|HTTPS| REST
+    REST --> AuthMW
+    MCP --> AuthMW
+    AuthMW --> Services
+    Scheduler -->|cron tick| Services
+    Services --> SQLite
+    Services -->|encrypt/decrypt| Keychain
+    Services -->|mangroveai SDK| MangroveAI
+    Services -->|mangrovemarkets SDK| MangroveMkts
+```
+
+### Component responsibilities
+
+| Component | Responsibility |
+|-----------|---------------|
+| REST routes | HTTP handlers under `/api/v1/hank/*`; delegate to service layer |
+| MCP tools | FastMCP tool handlers at `/mcp`; delegate to service layer |
+| Auth middleware | Validate `X-API-Key` against `HANK_API_KEY`; bypass for discovery |
+| Service layer | All business logic; called by REST + MCP + scheduler |
+| Scheduler | APScheduler BackgroundScheduler, SQLite jobstore |
+| SQLite | Wallets (encrypted), strategies cache, allocations, evaluations, trades, positions, APScheduler jobs |
+| OS Keychain | Stores the Fernet master key; env var `HANK_MASTER_KEY` is a fallback |
+
+---
+
+## Data Flow — Request Path
+
+```mermaid
+flowchart LR
+    A[Request<br/>REST or MCP] --> B{Discovery<br/>endpoint?}
+    B -->|Yes| C[Service layer]
+    B -->|No| D{Valid<br/>X-API-Key?}
+    D -->|No| E[401<br/>AUTH_INVALID_API_KEY]
+    D -->|Yes| C
+    C --> F{Needs<br/>local state?}
+    F -->|Yes| G[(SQLite)]
+    F -->|Needs Mangrove?| H[SDK call]
+    F -->|Needs key?| I[Keychain<br/>decrypt → sign]
+    G --> J[Response]
+    H --> J
+    I --> J
+```
+
+Auth is enforced once at the boundary. The service layer is protocol-agnostic — it doesn't know or care whether the caller came in via REST or MCP.
+
+---
+
+## Data Flow — Automated Evaluation Loop
+
+```mermaid
+flowchart LR
+    A[APScheduler<br/>cron tick] --> B[strategy_evaluator]
+    B --> C[Load strategy from SQLite]
+    C --> D[Fetch market data<br/>via mangroveai SDK]
+    D --> E[Load open positions<br/>from SQLite]
+    E --> F[Evaluate signals<br/>pure function]
+    F --> G[OrderIntent array]
+    G --> H[order_executor]
+    H --> I{Strategy<br/>mode?}
+    I -->|paper| J[Simulate fill<br/>at mid/mark price]
+    I -->|live| K[DEX swap via<br/>mangrovemarkets SDK]
+    K --> L[Sign locally<br/>broadcast poll]
+    J --> M[trade_log]
+    L --> M
+    M --> N[(SQLite:<br/>evaluations, trades,<br/>positions)]
+```
+
+`strategy_evaluator` is deliberately a pure function — no SDK calls, no DB writes, no network. That makes it trivially testable and swappable. All side effects live in `order_executor` and `trade_log`.
+
+---
+
+## Sequence — Autonomous Strategy Creation
+
+```mermaid
+sequenceDiagram
+    participant U as User / Agent
+    participant API as REST or MCP
+    participant SS as strategy_service
+    participant CG as candidate_generator
+    participant BS as backtest_service
+    participant SDK as mangroveai SDK
+    participant DB as SQLite
+
+    U->>API: POST /strategies/autonomous<br/>{goal, asset, timeframe}
+    API->>SS: create_autonomous(req)
+    SS->>CG: generate_candidates(goal, asset, timeframe)
+    CG->>SDK: signals.list(category filters)
+    SDK-->>CG: signal catalog
+    CG-->>SS: 5-10 candidate strategies
+
+    loop for each candidate
+        SS->>BS: quick_backtest(candidate)
+        BS->>SDK: backtesting.run(mode=quick, ...)
+        SDK-->>BS: metrics
+        BS-->>SS: result
+    end
+
+    SS->>SS: filter (win_rate>0.51, trades>=10)
+    SS->>SS: rank by IRR
+
+    alt no survivors
+        SS-->>API: 422 STRATEGY_NO_VIABLE_CANDIDATES
+        API-->>U: error + suggestion
+    else has survivors
+        SS->>BS: full_backtest(winner)
+        BS->>SDK: backtesting.run(mode=full, ...)
+        SDK-->>BS: full metrics + trade history
+        SS->>SDK: strategies.create(winner)
+        SDK-->>SS: mangrove_id
+        SS->>DB: INSERT strategies + generation_report
+        SS-->>API: StrategyDetail + report
+        API-->>U: 201 Created
+    end
+```
+
+Candidate generation uses **deterministic heuristics** — a rules table mapping goal keywords (momentum, mean_reversion, breakout, trend) to signal categories, with random sampling within each category for diversity. No LLM call from the server; the intelligence is in the mapping + the user's choice of goal language.
+
+---
+
+## Sequence — Strategy Activation (→ live)
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant API as REST or MCP
+    participant SS as strategy_service
+    participant WM as wallet_manager
+    participant AS as allocation_service
+    participant SCH as scheduler_service
+    participant DB as SQLite
+
+    U->>API: PATCH /strategies/{id}/status<br/>{status: live, confirm: true,<br/>allocation: {...}}
+    API->>SS: update_status(id, live, allocation)
+    SS->>SS: validate transition (paper→live OK)
+    SS->>WM: wallet_exists(allocation.wallet_address)
+    WM->>DB: SELECT from wallets
+    WM-->>SS: yes
+    SS->>AS: record_allocation(strategy, allocation)
+    AS->>DB: INSERT into allocations
+    SS->>SS: update strategy status in mangroveai SDK + cache
+    SS->>SCH: register_job(strategy_id, timeframe)
+    SCH->>DB: INSERT into apscheduler_jobs
+    SCH-->>SS: job_id
+    SS-->>API: StrategyDetail (status=live)
+    API-->>U: 200 OK
+```
+
+From here, the scheduler fires independently — no user involvement until they deactivate.
+
+---
+
+## Sequence — DEX Swap (user-initiated)
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant API as REST or MCP
+    participant DS as dex_service
+    participant WM as wallet_manager
+    participant SDK as mangrovemarkets SDK
+    participant Chain as Blockchain
+
+    U->>API: POST /dex/swap<br/>{..., confirm: true}
+    API->>DS: execute_swap(req)
+    DS->>SDK: dex.get_quote(...)
+    SDK-->>DS: Quote
+    DS->>SDK: dex.approve_token(...)
+    SDK-->>DS: UnsignedTransaction | None
+
+    opt needs approval
+        DS->>WM: sign(tx, wallet)
+        WM->>WM: decrypt seed in memory
+        WM-->>DS: signed_tx
+        DS->>SDK: dex.broadcast(signed_tx)
+        SDK->>Chain: submit tx
+        Chain-->>SDK: tx_hash
+        SDK-->>DS: BroadcastResult
+        loop poll
+            DS->>SDK: dex.tx_status(hash)
+            SDK-->>DS: status
+        end
+    end
+
+    DS->>SDK: dex.prepare_swap(quote_id, wallet)
+    SDK-->>DS: UnsignedTransaction
+    DS->>WM: sign(tx, wallet)
+    WM-->>DS: signed_tx
+    DS->>SDK: dex.broadcast(signed_tx)
+    SDK->>Chain: submit tx
+    Chain-->>SDK: tx_hash
+    loop poll
+        DS->>SDK: dex.tx_status(hash)
+        SDK-->>DS: status
+    end
+    DS->>DS: log to trades table
+    DS-->>API: SwapResult (tx_hash, fill, ...)
+    API-->>U: 200 OK
+```
+
+The full 6-step flow, mediated entirely by Hank; the SDK never touches the private key. The key is decrypted in `wallet_manager.sign()` and zeroed from memory immediately after.
+
+---
+
+## Component Diagram — Server Internals
+
+```mermaid
+graph TB
+    subgraph "server/src"
+        App[app.py<br/>FastAPI + lifespan]
+        Config[config/<br/>per-env JSON]
+
+        subgraph "api/"
+            Router[router.py]
+            subgraph "routes/"
+                RWallet[wallet.py]
+                RDex[dex.py]
+                RMarket[market.py]
+                ROnChain[on_chain.py]
+                RSignals[signals.py]
+                RStrat[strategies.py]
+                RLogs[logs.py]
+                RKb[kb.py]
+                RDiscovery[discovery.py]
+            end
+        end
+
+        subgraph "mcp/"
+            MCPServer[server.py]
+            MCPTools[tools.py]
+            MCPReg[registry.py]
+        end
+
+        subgraph "services/"
+            SWallet[wallet_manager.py]
+            SStrat[strategy_service.py]
+            SCG[candidate_generator.py]
+            SBT[backtest_service.py]
+            SEval[strategy_evaluator.py]
+            SExec[order_executor.py]
+            SSched[scheduler_service.py]
+            SLog[trade_log.py]
+            SAlloc[allocation_service.py]
+            SSig[signal_service.py]
+            SMD[market_data.py]
+            SOC[on_chain.py]
+            SDex[dex_service.py]
+            SPort[portfolio_service.py]
+            SKb[kb_service.py]
+        end
+
+        subgraph "shared/"
+            AuthMW[auth/middleware.py]
+            DB[db/sqlite.py]
+            Crypto[crypto/fernet.py]
+            Clients[clients/mangrove.py<br/>SDK singletons]
+            Errors[errors.py]
+        end
+
+        subgraph "models/"
+            MReq[requests.py]
+            MResp[responses.py]
+            MDB[db_models.py]
+            MDomain[domain.py<br/>OrderIntent, etc.]
+        end
+    end
+
+    App --> Router
+    App --> MCPServer
+    App --> SSched
+    Router --> RWallet & RDex & RMarket & ROnChain & RSignals & RStrat & RLogs & RKb & RDiscovery
+    MCPServer --> MCPTools
+    MCPTools --> MCPReg
+
+    RWallet & RDex --> SWallet & SDex & SPort
+    RMarket & ROnChain --> SMD & SOC
+    RSignals --> SSig
+    RStrat --> SStrat
+    RLogs --> SLog
+    RKb --> SKb
+    MCPTools -.same services.-> SWallet & SStrat & SDex
+
+    SStrat --> SCG & SBT & SSched & SAlloc
+    SSched --> SEval
+    SEval -.pure, no side effects.-> MDomain
+    SSched --> SExec
+    SExec --> SDex & SLog
+
+    SWallet --> Crypto
+    SWallet --> DB
+    SStrat & SLog & SAlloc --> DB
+    SStrat & SBT & SSig & SMD & SOC & SDex & SPort & SKb --> Clients
+```
+
+Key properties:
+- **Routes never call SDKs directly.** Always through the service layer.
+- **MCP tools and REST routes call the same services.** Logic lives in one place.
+- **`strategy_evaluator` is pure.** No SDK calls, no DB writes — it takes data in and returns `OrderIntent[]`.
+- **SDK clients are singletons** initialized at startup (`shared/clients/mangrove.py`), shared across services.
+
+---
+
+## Project Structure
+
+```
+app-in-a-box/
+├── .claude/                                    # Development framework
+│   ├── agents/
+│   │   └── product-owner.md                    # Drives build after /plan
+│   ├── hooks/
+│   │   └── check-onboard.sh                    # SessionStart hook
+│   ├── rules/
+│   │   └── git-workflow.md
+│   ├── skills/
+│   │   ├── onboard/SKILL.md
+│   │   ├── requirements/SKILL.md
+│   │   ├── specification/SKILL.md
+│   │   ├── architecture/SKILL.md
+│   │   ├── plan/SKILL.md
+│   │   └── tutorial/SKILL.md                   # Workshop curriculum
+│   └── settings.json
+├── server/
+│   ├── src/
+│   │   ├── app.py                              # FastAPI factory, scheduler lifespan
+│   │   ├── config/
+│   │   │   ├── local-config.json               # Defaults for local dev
+│   │   │   ├── dev-config.json
+│   │   │   ├── prod-config.json
+│   │   │   └── loader.py                       # Env → config JSON selector
+│   │   ├── api/
+│   │   │   ├── router.py                       # Aggregates routes, mounts /api/v1/hank
+│   │   │   └── routes/
+│   │   │       ├── discovery.py                # health, status, tool catalog
+│   │   │       ├── wallet.py                   # create, list, balances, portfolio, history
+│   │   │       ├── dex.py                      # venues, pairs, quote, swap
+│   │   │       ├── market.py                   # ohlcv, data, trending, global
+│   │   │       ├── on_chain.py                 # smart_money, whale, holders
+│   │   │       ├── signals.py                  # list, get
+│   │   │       ├── strategies.py               # create, list, get, patch status, backtest, evaluate
+│   │   │       ├── logs.py                     # evaluations, trades
+│   │   │       └── kb.py                       # search, glossary
+│   │   ├── mcp/
+│   │   │   ├── server.py                       # FastMCP setup
+│   │   │   ├── tools.py                        # Tool definitions (mirror REST)
+│   │   │   └── registry.py                     # register_tool helper
+│   │   ├── services/
+│   │   │   ├── wallet_manager.py               # Key gen, Fernet encrypt, local signing
+│   │   │   ├── strategy_service.py             # Strategy CRUD (wraps mangroveai)
+│   │   │   ├── candidate_generator.py          # Goal → 5-10 signal combos
+│   │   │   ├── backtest_service.py             # Quick + full, filter + IRR rank
+│   │   │   ├── strategy_evaluator.py           # PURE: (strategy, mkt, pos) → OrderIntent[]
+│   │   │   ├── order_executor.py               # OrderIntent → DEX (live) or simulated (paper)
+│   │   │   ├── scheduler_service.py            # APScheduler wrapper
+│   │   │   ├── trade_log.py                    # SQLite writes
+│   │   │   ├── allocation_service.py           # Per-strategy fund accounting
+│   │   │   ├── signal_service.py               # Wraps mangroveai.signals
+│   │   │   ├── market_data.py                  # Wraps mangroveai.crypto_assets
+│   │   │   ├── on_chain.py                     # Wraps mangroveai.on_chain
+│   │   │   ├── dex_service.py                  # Wraps mangrovemarkets.dex
+│   │   │   ├── portfolio_service.py            # Wraps mangrovemarkets.portfolio
+│   │   │   └── kb_service.py                   # Wraps mangroveai.kb
+│   │   ├── shared/
+│   │   │   ├── auth/middleware.py              # X-API-Key validation
+│   │   │   ├── db/
+│   │   │   │   ├── sqlite.py                   # Connection helper, migrations
+│   │   │   │   └── migrations/                 # SQL schema files
+│   │   │   ├── crypto/
+│   │   │   │   └── fernet.py                   # Master key mgmt + Fernet wrapper
+│   │   │   ├── clients/
+│   │   │   │   └── mangrove.py                 # SDK singletons
+│   │   │   └── errors.py                       # Error codes, exception → HTTP mapping
+│   │   ├── models/
+│   │   │   ├── requests.py                     # Pydantic request models
+│   │   │   ├── responses.py                    # Pydantic response models
+│   │   │   ├── domain.py                       # OrderIntent, SignalRule, ExecutionConfig
+│   │   │   └── db_models.py                    # Row adapters / ORM-lite
+│   │   └── health.py                           # Health probe payload
+│   ├── tests/
+│   │   ├── conftest.py
+│   │   ├── unit/                               # Pure unit tests (evaluator, candidate_gen)
+│   │   ├── integration/                        # DB + SDK-mocked integration tests
+│   │   └── e2e/                                # Full flow, uses dev Mangrove env
+│   ├── db/
+│   │   └── init.sql                            # Not used in v1 (SQLite auto-init)
+│   ├── Dockerfile
+│   └── requirements.txt
+├── plugin/                                     # (Future) Claude Code plugin wrapper
+├── tutorials/                                  # Workshop curriculum (separate deliverable)
+│   └── bots-and-bytes/
+├── docs/
+│   ├── api-reference.md                        # Consolidated Mangrove API surface
+│   ├── user-stories.md                         # Approved requirements
+│   ├── specification.md                        # Approved spec
+│   ├── architecture.md                         # This document
+│   ├── implementation-plan.md                  # Generated by /plan
+│   └── configuration.md
+├── assets/                                     # Branding (kept as-is from template)
+├── branding.json
+├── docker-compose.yml                          # Local dev stack (app only, no postgres/redis)
+├── .env.example                                # MANGROVE_API_KEY, HANK_API_KEY, etc.
+├── init.sh                                     # Template init (kept)
+├── CLAUDE.md
+├── README.md
+└── LICENSE
+```
+
+---
+
+## Module Decisions
+
+Based on Hank's architecture, here's what we keep from the app-in-a-box template and what we remove:
+
+| Module | Status | Reason |
+|--------|--------|--------|
+| **FastAPI app factory** | ✅ Keep | Core of the dual-protocol service pattern |
+| **MCP server (FastMCP)** | ✅ Keep | Core — AI agents prefer MCP |
+| **REST routes** | ✅ Keep | Core — universal HTTP access |
+| **API key auth middleware** | ✅ Keep | Single-user auth model |
+| **Service layer pattern** | ✅ Keep | Shared business logic between REST + MCP |
+| **Per-environment JSON config** | ✅ Keep | Matches local/dev/prod deployment modes |
+| **SQLite (built-in)** | ✅ Keep | Single datastore for all state |
+| **APScheduler** | ✅ Add (new) | In-process cron; not in template |
+| **Fernet encryption + OS keychain** | ✅ Add (new) | Wallet key protection |
+| **PostgreSQL** | ❌ Remove | SQLite suffices. No multi-user, no high concurrency. Remove `--profile full`, `db/init.sql` postgres schema, `notes.py` route. |
+| **Redis** | ❌ Remove | No caching layer needed; APScheduler jobstore goes in SQLite. |
+| **x402 payment middleware + routes** | ❌ Remove | Hank is a local bot, not a monetized service. Remove `shared/x402/`, `routes/easter_egg.py`. |
+| **Items demo route** | ❌ Remove | Template scaffolding; replaced by real routes. |
+| **Notes demo route** | ❌ Remove | Template scaffolding; replaced by real routes. |
+| **Easter egg route** | ❌ Remove | x402 demo; Hank has no payment surface. |
+| **Echo route** | ❌ Remove | Template scaffolding; no purpose in Hank. |
+| **Terraform (GCP)** | 🟡 Optional | Keep for the optional Cloud Run demo path; not required for local use. Move to `infra/terraform/` and document as "demo only." |
+| **Docker Compose (app-only profile)** | ✅ Keep | Primary local dev entry point. |
+| **Docker Compose (full profile)** | ❌ Remove | Postgres + Redis not needed. |
+
+---
+
+## Technology Choices
+
+| Layer | Choice | Alternatives considered | Rationale |
+|-------|--------|-------------------------|-----------|
+| Web framework | FastAPI | Flask, Starlette | Template default; great OpenAPI; async-native; plays well with FastMCP |
+| MCP library | FastMCP | Raw MCP SDK | Template default; FastAPI-integrated; tool registration is a one-liner |
+| Storage | SQLite | Postgres, DuckDB | Local-first means no external DB. Full ACID, WAL mode for concurrency, built into Python. |
+| Scheduler | APScheduler (BackgroundScheduler, SQLAlchemy jobstore) | Celery, RQ, system cron | In-process, no broker required, persistent jobstore (survives restart), Python-native |
+| Key encryption | Fernet (from `cryptography` lib) | age, nacl | Battle-tested, standard-compliant, simple API |
+| Master key storage | OS Keychain via `keyring` | env var only, prompt per-session | Zero-config for local users; env var fallback for Cloud Run |
+| Config | Per-env JSON + env var overrides | pydantic-settings | Template pattern; keeps secrets out of code |
+| HTTP client (SDKs) | `httpx` (built into SDKs) | — | Chosen by upstream SDKs; not our decision |
+| Test framework | pytest | unittest | Template default; fixtures are great |
+
+---
+
+## Deployment Architecture
+
+### Local (default)
+
+```mermaid
+graph LR
+    User[User's terminal<br/>Claude Code] -->|MCP/HTTP| Docker[Docker Compose<br/>hank container]
+    Docker -->|reads/writes| Volume[./hank.db<br/>mounted volume]
+    Docker -->|reads| Keychain[OS Keychain]
+    Docker -->|HTTPS| Mangrove[Mangrove APIs]
+```
+
+One `docker compose up` command; no cloud account required. State persists across restarts via bind-mounted volume.
+
+### Cloud Run (optional, demo)
+
+```mermaid
+graph LR
+    User[User's terminal] -->|HTTPS/MCP| CR[Cloud Run<br/>hank container]
+    CR -->|reads/writes| Ephemeral[Ephemeral fs<br/>hank.db]
+    CR -->|env var| SecretMgr[GCP Secret Mgr<br/>HANK_MASTER_KEY]
+    CR -->|HTTPS| Mangrove[Mangrove APIs]
+
+    style Ephemeral stroke-dasharray: 5 5
+```
+
+Wallet state and trade logs are wiped on each redeploy. Suitable for demo URLs; not for real trading.
+
+### Not in v1
+
+- Multi-region deployment
+- Cloud SQL / persistent cloud storage
+- Background worker pools (not needed — scheduler is in-process)
+- Horizontal scaling (single-user means single-process is fine)

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -24,11 +24,11 @@ Cloud deployment (Cloud Run, persistent cloud storage) is **out of scope for v1*
 |------|-----------|---------------|
 | Free | `/health`, `/api/v1/agent/tools`, `/api/v1/agent/status` | No credentials |
 | Auth | Everything else (default tier for v1 agent endpoints) | `X-API-Key: <configured-key>` header |
-| x402 | Reserved — currently the template's `easter_egg.py` route only; no v1 agent endpoints land here yet | x402 payment OR `X-API-Key` bypass |
+| x402 | Reserved — currently the `hello_mangrove.py` demo route only (renamed from the template's `easter_egg.py`); no v1 agent endpoints land here yet | x402 payment OR `X-API-Key` bypass |
 
 Single-user model: the API key (config key `API_KEY`) is a shared secret between the user's Claude Code config and the agent. No RBAC, no user accounts.
 
-x402 stays wired up — middleware, routes, config keys, the demo `easter_egg` endpoint — so future agent endpoints can be moved to the payment tier without scaffolding work. The choice of which agent endpoints to monetize is deferred.
+x402 stays wired up — middleware, routes, config keys, the `hello_mangrove` demo endpoint — so future agent endpoints can be moved to the payment tier without scaffolding work. The choice of which agent endpoints to monetize is deferred.
 
 ---
 
@@ -856,7 +856,7 @@ x402 keys from the template stay required — payment middleware needs them at s
     "X402_NETWORK",
     "X402_PAY_TO",
     "X402_USDC_CONTRACT",
-    "X402_EASTER_EGG_PRICE",
+    "X402_HELLO_MANGROVE_PRICE",
     "X402_CDP_API_KEY_ID",
     "X402_CDP_API_KEY_SECRET"
   ],
@@ -884,7 +884,7 @@ x402 keys from the template stay required — payment middleware needs them at s
   "X402_NETWORK": "eip155:84532",
   "X402_PAY_TO": "0xde991861bB3e7078015826Fad749de398F6ec1f6",
   "X402_USDC_CONTRACT": "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
-  "X402_EASTER_EGG_PRICE": "50000",
+  "X402_HELLO_MANGROVE_PRICE": "50000",
   "X402_CDP_API_KEY_ID": "",
   "X402_CDP_API_KEY_SECRET": ""
 }

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -23,10 +23,12 @@ Cloud deployment (Cloud Run, persistent cloud storage) is **out of scope for v1*
 | Tier | Endpoints | How to access |
 |------|-----------|---------------|
 | Free | `/health`, `/api/v1/agent/tools`, `/api/v1/agent/status` | No credentials |
-| Auth | Everything else | `X-API-Key: <configured-key>` header |
-| x402 | None (v1) | — |
+| Auth | Everything else (default tier for v1 agent endpoints) | `X-API-Key: <configured-key>` header |
+| x402 | Reserved — currently the template's `easter_egg.py` route only; no v1 agent endpoints land here yet | x402 payment OR `X-API-Key` bypass |
 
 Single-user model: the API key (config key `API_KEY`) is a shared secret between the user's Claude Code config and the agent. No RBAC, no user accounts.
+
+x402 stays wired up — middleware, routes, config keys, the demo `easter_egg` endpoint — so future agent endpoints can be moved to the payment tier without scaffolding work. The choice of which agent endpoints to monetize is deferred.
 
 ---
 
@@ -831,7 +833,9 @@ client = MangroveMarkets(base_url=os.environ["MANGROVEMARKETS_BASE_URL"])
 
 The agent uses the existing app-in-a-box config system — no invented `.env` files, no parallel layer. Values live in `server/src/config/{environment}-config.json`, with required keys declared in `server/src/config/configuration-keys.json`. The `ENVIRONMENT` env var selects which file to load. Secret values can be referenced using the existing `secret:NAME:PROPERTY` syntax; literal values are fine for local dev.
 
-### `configuration-keys.json` (agent-specific)
+### `configuration-keys.json` (agent + x402, both required)
+
+x402 keys from the template stay required — payment middleware needs them at startup even if no agent endpoints are payment-gated yet.
 
 ```json
 {
@@ -847,7 +851,14 @@ The agent uses the existing app-in-a-box config system — no invented `.env` fi
     "BACKTEST_MIN_WIN_RATE",
     "BACKTEST_MIN_TRADES",
     "BACKTEST_DEFAULT_LOOKBACK_MONTHS",
-    "LOG_RETENTION_DAYS"
+    "LOG_RETENTION_DAYS",
+    "X402_FACILITATOR_URL",
+    "X402_NETWORK",
+    "X402_PAY_TO",
+    "X402_USDC_CONTRACT",
+    "X402_EASTER_EGG_PRICE",
+    "X402_CDP_API_KEY_ID",
+    "X402_CDP_API_KEY_SECRET"
   ],
   "full_app_keys": []
 }
@@ -868,7 +879,14 @@ The agent uses the existing app-in-a-box config system — no invented `.env` fi
   "BACKTEST_MIN_WIN_RATE": 0.51,
   "BACKTEST_MIN_TRADES": 10,
   "BACKTEST_DEFAULT_LOOKBACK_MONTHS": 3,
-  "LOG_RETENTION_DAYS": 90
+  "LOG_RETENTION_DAYS": 90,
+  "X402_FACILITATOR_URL": "https://x402.org/facilitator",
+  "X402_NETWORK": "eip155:84532",
+  "X402_PAY_TO": "0xde991861bB3e7078015826Fad749de398F6ec1f6",
+  "X402_USDC_CONTRACT": "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+  "X402_EASTER_EGG_PRICE": "50000",
+  "X402_CDP_API_KEY_ID": "",
+  "X402_CDP_API_KEY_SECRET": ""
 }
 ```
 
@@ -885,22 +903,22 @@ The agent uses the existing app-in-a-box config system — no invented `.env` fi
 
 All routes and MCP tools delegate to these services. Never duplicate business logic between the two interfaces.
 
+**Service principle:** if a service would just forward arguments to an SDK call and return the result, it doesn't exist. Routes call the SDK clients directly (via `shared/clients/mangrove.py` singletons). Services exist only when they add orchestration the SDK doesn't provide.
+
+The 8 services that stay:
+
 | Module | Responsibility |
 |--------|---------------|
-| `services/wallet_manager.py` | Key gen, encryption, decryption, local signing |
-| `services/strategy_service.py` | Strategy CRUD (wraps `mangroveai.strategies`) + cron-tick orchestration: fetch market data, call `mangroveai.execution.evaluate()`, dispatch returned orders to `order_executor`. **No local signal evaluation or risk logic** — the SDK handles all of that. |
-| `services/candidate_generator.py` | Autonomous: goal → 5–10 signal combos (deterministic heuristics over `mangroveai.signals` catalog) |
+| `services/wallet_manager.py` | Key gen, Fernet encryption, local signing of unsigned txs from the SDK |
+| `services/strategy_service.py` | Cron-tick orchestration: fetch market data, call `mangroveai.execution.evaluate()`, dispatch returned orders to `order_executor`. Strategy CRUD against `mangroveai.strategies` + local cache writes. No local signal evaluation or risk logic. |
+| `services/candidate_generator.py` | Autonomous: goal → 5–10 signal combos (deterministic heuristics over the `mangroveai.signals` catalog) |
 | `services/backtest_service.py` | Quick + full backtest orchestration; filter + rank by IRR |
-| `services/signal_service.py` | Signal discovery (wraps `mangroveai.signals`) |
-| `services/market_data.py` | OHLCV, market data, trending, global (wraps `mangroveai.crypto_assets`) |
-| `services/on_chain.py` | Smart money, whale activity, holders (wraps `mangroveai.on_chain`) |
-| `services/dex_service.py` | DEX venue/pair/quote/swap (wraps `mangrovemarkets.dex`) |
-| `services/portfolio_service.py` | Portfolio value, P&L, history (wraps `mangrovemarkets.portfolio`) |
-| `services/kb_service.py` | KB search and glossary (wraps `mangroveai.kb`) |
-| `services/order_executor.py` | OrderIntent (from SDK) → DEX swap (live) or simulated fill (paper) |
+| `services/order_executor.py` | The single execution path for all DEX swaps. Takes an `OrderIntent` (from `strategy_service` for cron-driven trades, or built from a user request for the `POST /dex/swap` route). Orchestrates the full 6-step flow against `mangrovemarkets.dex` (quote → conditional approve → sign → broadcast → poll → prepare → sign → broadcast → poll). Branches paper vs live. |
 | `services/scheduler_service.py` | APScheduler wrapper: register, cancel, list active jobs |
 | `services/trade_log.py` | SQLite writes: evaluations, trades, positions |
 | `services/allocation_service.py` | Local allocation accounting for live strategies |
+
+**Routes that call SDKs directly (no service layer):** signal listing, market data (OHLCV, current data, trending, global), on-chain analytics, KB search/glossary, portfolio (value, P&L, tokens, DeFi, history), DEX venue/pair listing, DEX quote. Each route handler imports the appropriate SDK client from `shared/clients/mangrove.py`, calls the method, returns the response. Adding a wrapper service for these would only duplicate the SDK's interface.
 
 **Architectural note:** there is no `strategy_evaluator.py` module. Strategy evaluation (signal firing, position sizing, risk gates, cooldowns, volatility adjustments) is entirely the responsibility of `mangroveai.execution.evaluate()`. The agent calls the SDK and executes whatever `OrderIntent[]` comes back. Reimplementing any of that logic locally would duplicate upstream work and inevitably drift out of sync.
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -1,4 +1,4 @@
-# Technical Specification: Hank (defi-agent)
+# Technical Specification: defi-agent
 
 **Generated:** 2026-04-17
 **Status:** Draft
@@ -6,51 +6,43 @@
 
 ## Overview
 
-Hank is a FastAPI + MCP service that wraps the `mangroveai` and `mangrovemarkets` Python SDKs with local state, autonomous strategy generation, cron-based execution, and a full audit trail.
+defi-agent is a FastAPI + MCP service that wraps the `mangroveai` and `mangrovemarkets` Python SDKs with local state, autonomous strategy generation, cron-based execution, and a full audit trail.
 
-Hank exposes the same functionality two ways:
+It exposes the same functionality two ways:
 - **MCP tools at `/mcp`** (Streamable HTTP transport) — preferred for AI agents because of structured tool discovery and typed invocation.
-- **REST endpoints at `/api/v1/hank/*`** — universal; any HTTP client (Python scripts, cron jobs, curl, notebooks, tests) can use them without an MCP library.
+- **REST endpoints at `/api/v1/agent/*`** — universal; any HTTP client (Python scripts, cron jobs, curl, notebooks, tests) can use them without an MCP library.
 
-Both protocols share a single service layer — `create_wallet` (MCP tool) and `POST /api/v1/hank/wallet/create` (REST endpoint) call the same Python function. No duplicated business logic.
+Both protocols share a single service layer — `create_wallet` (MCP tool) and `POST /api/v1/agent/wallet/create` (REST endpoint) call the same Python function. No duplicated business logic.
 
-Hank is single-user and **local-first**. It runs on the user's own machine via Docker Compose — no cloud account required. It holds wallet keys locally (encrypted), registers APScheduler cron jobs at strategy activation, and logs every evaluation and trade to local SQLite.
+The agent runs on the user's own machine via Docker Compose (or `uvicorn` directly) — single-user, local-only for v1. It holds wallet keys locally (encrypted), registers APScheduler cron jobs at strategy activation, and logs every evaluation and trade to local SQLite.
 
-### Deployment modes
-
-| Mode | State persistence | Requirements | Use case |
-|------|-------------------|--------------|----------|
-| **Local (default)** | `hank.db` in user's filesystem — persists across restarts | Docker Compose, Python 3.10+ | Daily use, development, real trading |
-| **Cloud Run (optional, demo)** | `hank.db` in ephemeral container filesystem — **wiped on every redeploy** | GCP account (optional) | Workshop demo only; fresh state each session |
-| **Cloud Run (persistent)** | **Not v1.** Requires swapping SQLite for Cloud SQL or mounting a GCS volume | — | Future |
-
-**Most users will run Hank locally.** No GCP/AWS account is required. The Cloud Run option exists only for demo scenarios (e.g., the April 24 workshop) where a throwaway public URL is useful. If a user deploys to Cloud Run and redeploys, all state is lost by design — persistent cloud deploy is out of scope for v1.
+Cloud deployment (Cloud Run, persistent cloud storage) is **out of scope for v1** and will be addressed in a subsequent release.
 
 ## Access Tiers
 
 | Tier | Endpoints | How to access |
 |------|-----------|---------------|
-| Free | `/health`, `/api/v1/hank/tools`, `/api/v1/hank/status` | No credentials |
-| Auth | Everything else | `X-API-Key: $HANK_API_KEY` header |
+| Free | `/health`, `/api/v1/agent/tools`, `/api/v1/agent/status` | No credentials |
+| Auth | Everything else | `X-API-Key: <configured-key>` header |
 | x402 | None (v1) | — |
 
-Single-user model: `HANK_API_KEY` is a shared secret between the user's Claude Code config and Hank. No RBAC, no user accounts.
+Single-user model: the API key (config key `API_KEY`) is a shared secret between the user's Claude Code config and the agent. No RBAC, no user accounts.
 
 ---
 
 ## API Contracts
 
-All endpoints are JSON over HTTPS. Base path: `/api/v1/hank`. Every endpoint has a mirrored MCP tool with identical semantics (see [MCP Tools](#mcp-tools)).
+All endpoints are JSON over HTTPS. Base path: `/api/v1/agent`. Every endpoint has a mirrored MCP tool with identical semantics (see [MCP Tools](#mcp-tools)).
 
 ### Discovery (free)
 
 #### `GET /health`
-Returns `{ status, service, version, timestamp }`. Used by Cloud Run health checks.
+Returns `{ status, service, version, timestamp }`.
 
-#### `GET /api/v1/hank/tools`
+#### `GET /api/v1/agent/tools`
 Returns the full MCP tool catalog (tool names, descriptions, parameters, access tier).
 
-#### `GET /api/v1/hank/status`
+#### `GET /api/v1/agent/status`
 Returns service state:
 ```json
 {
@@ -58,7 +50,7 @@ Returns service state:
   "wallets_count": 2,
   "strategies": {"draft": 3, "inactive": 1, "paper": 2, "live": 1, "archived": 5},
   "active_cron_jobs": 3,
-  "db_path": "./hank.db",
+  "db_path": "./agent.db",
   "uptime_seconds": 12345
 }
 ```
@@ -67,13 +59,15 @@ Returns service state:
 
 ### Wallet (auth)
 
-#### `POST /api/v1/hank/wallet/create`
+#### `POST /api/v1/agent/wallet/create`
 Create + encrypt + store a wallet locally.
+
+**v1 scope:** EVM chains only for live execution. XRPL accepted but returns a clear "not supported in v1" error; Solana not supported at all.
 
 **Request:**
 ```json
 {
-  "chain": "string — evm | xrpl",
+  "chain": "string — evm | xrpl (stubbed, returns 501)",
   "network": "string — mainnet | testnet",
   "chain_id": "int | null — required for evm",
   "label": "string | null — human-friendly name"
@@ -99,31 +93,31 @@ Create + encrypt + store a wallet locally.
 >
 > ⚠️ **Important:** the seed phrase will appear in your chat transcript, which Claude Code writes to disk under `~/.claude/projects/.../*.jsonl`. If you do not want the seed phrase persisted there, (1) copy it to a secure location, (2) delete the corresponding session transcript file, and (3) back it up offline (paper, hardware wallet, password manager). Never screenshot without securing the image.
 
-**Errors:** 400 `VALIDATION_ERROR`, 409 `WALLET_ALREADY_EXISTS`, 502 `SDK_ERROR`.
+**Errors:** 400 `VALIDATION_ERROR`, 409 `WALLET_ALREADY_EXISTS`, 501 `CHAIN_NOT_SUPPORTED_IN_V1` (for XRPL), 502 `SDK_ERROR`.
 
-#### `GET /api/v1/hank/wallet/list`
+#### `GET /api/v1/agent/wallet/list`
 List all stored wallets (addresses + metadata only, no keys).
 
-#### `GET /api/v1/hank/wallet/{address}/balances?chain_id=<int>`
+#### `GET /api/v1/agent/wallet/{address}/balances?chain_id=<int>`
 Returns token balances via `mangrovemarkets.dex.balances()`.
 
-#### `GET /api/v1/hank/wallet/{address}/portfolio?chain_id=<int>`
+#### `GET /api/v1/agent/wallet/{address}/portfolio?chain_id=<int>`
 Returns aggregate portfolio: value, P&L, tokens, DeFi positions (via `mangrovemarkets.portfolio.*`).
 
-#### `GET /api/v1/hank/wallet/{address}/history?limit=<int>`
+#### `GET /api/v1/agent/wallet/{address}/history?limit=<int>`
 Returns transaction history via `mangrovemarkets.portfolio.history()`.
 
 ---
 
 ### DEX (auth)
 
-#### `GET /api/v1/hank/dex/venues`
+#### `GET /api/v1/agent/dex/venues`
 List supported DEX venues via `mangrovemarkets.dex.supported_venues()`.
 
-#### `GET /api/v1/hank/dex/pairs?venue_id=<str>`
+#### `GET /api/v1/agent/dex/pairs?venue_id=<str>`
 List trading pairs for a venue.
 
-#### `POST /api/v1/hank/dex/quote`
+#### `POST /api/v1/agent/dex/quote`
 **Request:**
 ```json
 {
@@ -136,7 +130,7 @@ List trading pairs for a venue.
 ```
 **Response (200):** Mirrors `mangrovemarkets.dex.Quote` model.
 
-#### `POST /api/v1/hank/dex/swap`
+#### `POST /api/v1/agent/dex/swap`
 Execute the full 6-step swap flow. **Requires `confirm: true`** in the request body — protects against agent-initiated swaps without user approval.
 
 **Request:**
@@ -146,7 +140,7 @@ Execute the full 6-step swap flow. **Requires `confirm: true`** in the request b
   "output_token": "string",
   "amount": "number",
   "chain_id": "int",
-  "wallet_address": "string — must be in Hank's wallet store",
+  "wallet_address": "string — must be in the agent's wallet store",
   "slippage": "number — default 1.0 (percent)",
   "mev_protection": "boolean — default false",
   "confirm": "boolean — must be true"
@@ -163,7 +157,7 @@ Execute the full 6-step swap flow. **Requires `confirm: true`** in the request b
   "fill_price": "number",
   "fees": "object",
   "approval_tx_hash": "string | null",
-  "trade_log_id": "string — UUID in Hank's local trades table"
+  "trade_log_id": "string — UUID in the agent's local trades table"
 }
 ```
 
@@ -175,42 +169,42 @@ Internal flow: quote → `approve_token` (returns None if already approved) → 
 
 ### Market Data (auth)
 
-#### `GET /api/v1/hank/market/ohlcv?symbol=<str>&timeframe=<str>&lookback_days=<int>`
+#### `GET /api/v1/agent/market/ohlcv?symbol=<str>&timeframe=<str>&lookback_days=<int>`
 Returns OHLCV via `mangroveai.crypto_assets.get_ohlcv()`.
 
-#### `GET /api/v1/hank/market/data?symbol=<str>`
+#### `GET /api/v1/agent/market/data?symbol=<str>`
 Current market data (price, market cap, volume, 24h/7d change).
 
-#### `GET /api/v1/hank/market/trending`
+#### `GET /api/v1/agent/market/trending`
 Trending assets.
 
-#### `GET /api/v1/hank/market/global`
+#### `GET /api/v1/agent/market/global`
 Global market cap, BTC dominance, 24h change.
 
-#### `GET /api/v1/hank/on-chain/smart-money?symbol=<str>&chain=<str>`
+#### `GET /api/v1/agent/on-chain/smart-money?symbol=<str>&chain=<str>`
 Smart money sentiment via `mangroveai.on_chain.get_smart_money_sentiment()`.
 
-#### `GET /api/v1/hank/on-chain/whale-activity?symbol=<str>&hours_back=<int>`
+#### `GET /api/v1/agent/on-chain/whale-activity?symbol=<str>&hours_back=<int>`
 Whale activity summary.
 
-#### `GET /api/v1/hank/on-chain/token-holders/{symbol}`
+#### `GET /api/v1/agent/on-chain/token-holders/{symbol}`
 Holder distribution and concentration.
 
 ---
 
 ### Signals (auth)
 
-#### `GET /api/v1/hank/signals?category=<str>&search=<str>&limit=<int>`
+#### `GET /api/v1/agent/signals?category=<str>&search=<str>&limit=<int>`
 List/search signals via `mangroveai.signals.list()` with optional filtering.
 
-#### `GET /api/v1/hank/signals/{name}`
+#### `GET /api/v1/agent/signals/{name}`
 Signal detail with parameter spec.
 
 ---
 
 ### Strategies (auth)
 
-#### `POST /api/v1/hank/strategies/autonomous`
+#### `POST /api/v1/agent/strategies/autonomous`
 Autonomous strategy creation: skill picks candidates → quick backtest → filter → rank by IRR → full backtest → persist.
 
 **Request:**
@@ -249,7 +243,7 @@ Autonomous strategy creation: skill picks candidates → quick backtest → filt
 
 **Errors:** 400 `VALIDATION_ERROR`, 422 `STRATEGY_NO_VIABLE_CANDIDATES`, 502 `SDK_ERROR`.
 
-#### `POST /api/v1/hank/strategies/manual`
+#### `POST /api/v1/agent/strategies/manual`
 Manual strategy creation with explicit entry/exit rules.
 
 **Request:**
@@ -274,13 +268,13 @@ Manual strategy creation with explicit entry/exit rules.
 
 Validation: entry must be exactly 1 TRIGGER + 0+ FILTERs; exit must be 0–1 TRIGGERs + 0+ FILTERs.
 
-#### `GET /api/v1/hank/strategies?status=<str>&limit=<int>&offset=<int>`
+#### `GET /api/v1/agent/strategies?status=<str>&limit=<int>&offset=<int>`
 List strategies with optional status filter.
 
-#### `GET /api/v1/hank/strategies/{id}`
+#### `GET /api/v1/agent/strategies/{id}`
 Full strategy details.
 
-#### `PATCH /api/v1/hank/strategies/{id}/status`
+#### `PATCH /api/v1/agent/strategies/{id}/status`
 **Single source of truth for strategy lifecycle.** This is the only way to activate, deactivate, or archive a strategy. Side effects (register/cancel cron jobs, allocate/release funds) are driven by the status transition.
 
 **Request:**
@@ -307,7 +301,7 @@ Side effects by target status:
 
 **Errors:** 400 `STRATEGY_INVALID_STATUS_TRANSITION`, 400 `CONFIRMATION_REQUIRED`, 400 `ALLOCATION_INSUFFICIENT`, 404 `WALLET_NOT_FOUND`.
 
-#### `POST /api/v1/hank/strategies/{id}/backtest`
+#### `POST /api/v1/agent/strategies/{id}/backtest`
 **Request:**
 ```json
 {
@@ -319,37 +313,37 @@ Side effects by target status:
 ```
 **Response:** Full backtest metrics + trade history.
 
-#### `POST /api/v1/hank/strategies/{id}/evaluate`
+#### `POST /api/v1/agent/strategies/{id}/evaluate`
 Manually trigger a single evaluation tick (for debugging/power users). Same code path the cron job runs.
 
 ---
 
 ### Execution Logs (auth)
 
-#### `GET /api/v1/hank/strategies/{id}/evaluations?limit=<int>&offset=<int>`
+#### `GET /api/v1/agent/strategies/{id}/evaluations?limit=<int>&offset=<int>`
 Returns evaluation log for a strategy, newest first.
 
-#### `GET /api/v1/hank/strategies/{id}/trades?limit=<int>&offset=<int>`
+#### `GET /api/v1/agent/strategies/{id}/trades?limit=<int>&offset=<int>`
 Returns trades for a strategy, newest first.
 
-#### `GET /api/v1/hank/trades?limit=<int>&strategy_id=<str>&mode=<str>`
+#### `GET /api/v1/agent/trades?limit=<int>&strategy_id=<str>&mode=<str>`
 All trades across strategies, with optional filters.
 
 ---
 
 ### Knowledge Base (auth)
 
-#### `GET /api/v1/hank/kb/search?q=<str>&limit=<int>`
+#### `GET /api/v1/agent/kb/search?q=<str>&limit=<int>`
 Full-text search via `mangroveai.kb.search.*`.
 
-#### `GET /api/v1/hank/kb/glossary/{term}`
+#### `GET /api/v1/agent/kb/glossary/{term}`
 Glossary term lookup with backlinks.
 
 ---
 
 ## MCP Tools
 
-Every REST endpoint has a mirrored MCP tool with identical semantics. Tool names use plain `verb_resource` form (e.g. `create_strategy_autonomous`, `list_trades`, `get_market_data`) — no `hank_` prefix; the MCP server namespace is enough.
+Every REST endpoint has a mirrored MCP tool with identical semantics. Tool names use plain `verb_resource` form (e.g. `create_strategy_autonomous`, `list_trades`, `get_market_data`) — no project prefix; the MCP server namespace is enough.
 
 Tool descriptions include parameters, return shapes, and access tier. All tools enforce the same auth as their REST counterparts.
 
@@ -466,7 +460,7 @@ class StrategyCreateManualRequest(BaseModel):
     execution_config: ExecutionConfig | None = None
 
 class StrategyDetail(BaseModel):
-    id: str                                    # Hank's local UUID
+    id: str                                    # agent's local UUID
     mangrove_id: str                           # Mangrove's strategy ID
     name: str
     asset: str
@@ -504,13 +498,14 @@ class OrderIntent(BaseModel):
     take_profit: float | None = None
 
 class Evaluation(BaseModel):
+    """A record of one cron-tick evaluation. OrderIntents come from the SDK,
+    not from local logic — the agent does not evaluate strategies itself."""
     id: str
     strategy_id: str
     timestamp: datetime
-    market_snapshot: dict                        # last bar + indicators
-    signals_fired: list[dict]
-    order_intents: list[OrderIntent]
-    positions_snapshot: list[Position]
+    market_snapshot: dict                        # last bar of data passed to SDK
+    sdk_response: dict                           # verbatim response from mangroveai.execution.evaluate()
+    order_intents: list[OrderIntent]             # extracted from sdk_response for easy querying
     duration_ms: int
     status: Literal["ok", "error", "skipped"]
     error_msg: str | None
@@ -587,7 +582,7 @@ CREATE INDEX idx_wallets_chain ON wallets(chain, chain_id);
 
 -- Strategies: local cache of Mangrove strategies (Mangrove is source of truth)
 CREATE TABLE strategies (
-    id TEXT PRIMARY KEY,                          -- Hank's UUID
+    id TEXT PRIMARY KEY,                          -- agent's UUID
     mangrove_id TEXT UNIQUE NOT NULL,             -- Mangrove's strategy ID
     name TEXT NOT NULL,
     asset TEXT NOT NULL,
@@ -621,10 +616,9 @@ CREATE TABLE evaluations (
     id TEXT PRIMARY KEY,
     strategy_id TEXT NOT NULL REFERENCES strategies(id),
     timestamp TEXT NOT NULL,
-    market_snapshot_json TEXT NOT NULL,
-    signals_fired_json TEXT NOT NULL,
-    order_intents_json TEXT NOT NULL,
-    positions_snapshot_json TEXT NOT NULL,
+    market_snapshot_json TEXT NOT NULL,           -- data sent to the SDK
+    sdk_response_json TEXT NOT NULL,              -- verbatim response from mangroveai.execution.evaluate()
+    order_intents_json TEXT NOT NULL,             -- extracted from sdk_response for querying
     duration_ms INTEGER NOT NULL,
     status TEXT NOT NULL,                         -- ok | error | skipped
     error_msg TEXT
@@ -696,10 +690,10 @@ Standard error response:
 | Code | HTTP | When |
 |------|------|------|
 | `AUTH_MISSING_API_KEY` | 401 | `X-API-Key` header not provided |
-| `AUTH_INVALID_API_KEY` | 401 | Key doesn't match `HANK_API_KEY` |
+| `AUTH_INVALID_API_KEY` | 401 | Key doesn't match the configured `API_KEY` |
 | `VALIDATION_ERROR` | 400 | Pydantic validation failed; details in `message` |
 | `CONFIRMATION_REQUIRED` | 400 | Live deploy/stop/withdraw without `confirm: true` |
-| `WALLET_NOT_FOUND` | 404 | Address not in Hank's wallet store |
+| `WALLET_NOT_FOUND` | 404 | Address not in the agent's wallet store |
 | `WALLET_ALREADY_EXISTS` | 409 | Wallet with that address already stored |
 | `STRATEGY_NOT_FOUND` | 404 | Strategy ID not found |
 | `STRATEGY_INVALID_STATUS_TRANSITION` | 400 | Illegal transition (e.g., draft → live) |
@@ -710,9 +704,10 @@ Standard error response:
 | `SIGNING_ERROR` | 500 | Local signing failed (bad key, wallet corruption) |
 | `EVALUATION_ERROR` | 500 | Strategy evaluator raised; details logged |
 | `SCHEDULER_ERROR` | 500 | APScheduler job registration/cancellation failed |
+| `CHAIN_NOT_SUPPORTED_IN_V1` | 501 | User requested XRPL/Solana wallet creation or live execution |
 | `INTERNAL_ERROR` | 500 | Catch-all; details in server logs |
 
-All errors carry a `correlation_id` for cross-referencing against Hank's logs.
+All errors carry a `correlation_id` for cross-referencing against the agent's logs.
 
 ---
 
@@ -721,9 +716,9 @@ All errors carry a `correlation_id` for cross-referencing against Hank's logs.
 **Model:** single-user API key authentication.
 
 **Flow:**
-1. User sets `HANK_API_KEY` env var (local) or GCP Secret (Cloud Run).
+1. The `API_KEY` config value is loaded at startup via the template's config loader (see [Configuration](#configuration)).
 2. Requests include `X-API-Key: <key>`.
-3. Middleware validates against `HANK_API_KEY`; rejects with 401 if missing or invalid.
+3. Middleware validates against the configured `API_KEY`; rejects with 401 if missing or invalid.
 4. Free tier endpoints bypass the middleware.
 
 **MCP auth:** MCP is served over Streamable HTTP transport. The MCP client (Claude Code, Claude Desktop, custom agent) sends the API key as a standard HTTP header on every request to `/mcp`.
@@ -732,18 +727,18 @@ Client-side configuration example (`.mcp.json` in a Claude Code project):
 ```json
 {
   "mcpServers": {
-    "hank": {
+    "defi-agent": {
       "transport": "http",
       "url": "http://localhost:8080/mcp",
       "headers": {
-        "X-API-Key": "${HANK_API_KEY}"
+        "X-API-Key": "<your-configured-api-key>"
       }
     }
   }
 }
 ```
 
-Server-side, Hank's FastAPI middleware inspects `X-API-Key` identically for REST and MCP requests — the MCP mount at `/mcp` is just another FastAPI route group. If the key is missing or invalid, the MCP tool call returns an MCP-level error with `code: AUTH_INVALID_API_KEY` (mapped to 401 for REST). Discovery tools (`status`, `list_tools`) bypass auth.
+Server-side, the agent's FastAPI middleware inspects `X-API-Key` identically for REST and MCP requests — the MCP mount at `/mcp` is just another FastAPI route group. If the key is missing or invalid, the MCP tool call returns an MCP-level error with `code: AUTH_INVALID_API_KEY` (mapped to 401 for REST). Discovery tools (`status`, `list_tools`) bypass auth.
 
 **Storage:** No user accounts, no sessions, no tokens. Single shared secret per deployment.
 
@@ -765,9 +760,9 @@ from mangroveai import MangroveAI
 client = MangroveAI()  # reads env
 ```
 
-**Failure handling:** SDK raises `APIError`, `NotFoundError`, `RateLimitError`. Hank's service layer catches these and re-raises as `SDKError` (502) with the original correlation_id preserved.
+**Failure handling:** SDK raises `APIError`, `NotFoundError`, `RateLimitError`. The agent's service layer catches these and re-raises as `SDKError` (502) with the original correlation_id preserved.
 
-**Retry:** SDK's built-in retry handles 429/5xx. Hank does not add additional retry.
+**Retry:** SDK's built-in retry handles 429/5xx. The agent does not add additional retry.
 
 ---
 
@@ -785,7 +780,7 @@ from mangrovemarkets import MangroveMarkets
 client = MangroveMarkets(base_url=os.environ["MANGROVEMARKETS_BASE_URL"])
 ```
 
-**Signing:** The SDK never touches private keys. `prepare_swap()` and `approve_token()` return unsigned transaction payloads; Hank's `wallet_manager` decrypts the key in memory, signs the payload, then calls `broadcast()` with the signed tx. Key is zeroed from memory immediately after.
+**Signing:** The SDK never touches private keys. `prepare_swap()` and `approve_token()` return unsigned transaction payloads; the agent's `wallet_manager` decrypts the key in memory, signs the payload, then calls `broadcast()` with the signed tx. Key is zeroed from memory immediately after.
 
 **Failure handling:** Same pattern as `mangroveai`.
 
@@ -797,7 +792,7 @@ client = MangroveMarkets(base_url=os.environ["MANGROVEMARKETS_BASE_URL"])
 
 **Master key source (priority order):**
 1. OS Keychain via `keyring` library (macOS Keychain, GNOME Keyring, Windows Credential Manager) — default
-2. `HANK_MASTER_KEY` env var — fallback for Cloud Run / CI
+2. Config value `MASTER_KEY_ENV_FALLBACK` (resolved via the template's config loader, can reference a secret) — fallback for CI or other environments without a keychain
 
 **Scheme:**
 - Master key generated once on first wallet creation, stored in keychain
@@ -810,7 +805,7 @@ client = MangroveMarkets(base_url=os.environ["MANGROVEMARKETS_BASE_URL"])
 
 **Library:** `apscheduler` with `BackgroundScheduler` and SQLAlchemy job store.
 
-**Job store:** the same SQLite DB as Hank's data (`HANK_DB_PATH`) — survives process restarts.
+**Job store:** the same SQLite DB as the agent's data (config value `DB_PATH`) — survives process restarts.
 
 **Timeframe mapping:**
 | Strategy timeframe | Cron expression |
@@ -834,47 +829,55 @@ client = MangroveMarkets(base_url=os.environ["MANGROVEMARKETS_BASE_URL"])
 
 ## Configuration
 
-### Required environment variables
+The agent uses the existing app-in-a-box config system — no invented `.env` files, no parallel layer. Values live in `server/src/config/{environment}-config.json`, with required keys declared in `server/src/config/configuration-keys.json`. The `ENVIRONMENT` env var selects which file to load. Secret values can be referenced using the existing `secret:NAME:PROPERTY` syntax; literal values are fine for local dev.
 
-| Variable | Purpose |
-|----------|---------|
-| `MANGROVE_API_KEY` | Shared between both SDKs; `prod_*` or `dev_*` prefix |
-| `HANK_API_KEY` | Hank's own auth |
-| `ENVIRONMENT` | `local` \| `dev` \| `test` \| `prod` |
-
-### Optional environment variables
-
-| Variable | Default |
-|----------|---------|
-| `MANGROVEAI_BASE_URL` | auto-detect from API key prefix |
-| `MANGROVEMARKETS_BASE_URL` | `http://localhost:8080` |
-| `HANK_DB_PATH` | `./hank.db` |
-| `HANK_MASTER_KEY` | OS keychain |
-
-### Per-environment config JSON (`server/src/config/{env}-config.json`)
+### `configuration-keys.json` (agent-specific)
 
 ```json
 {
-  "service_name": "hank",
-  "log_level": "INFO",
-  "backtest": {
-    "autonomous_candidate_count": 7,
-    "candidate_filter": {
-      "min_win_rate": 0.51,
-      "min_total_trades": 10
-    },
-    "default_lookback_months": 3
-  },
-  "scheduler": {
-    "max_instances": 1,
-    "coalesce": true,
-    "misfire_grace_time_seconds": 60
-  },
-  "logs": {
-    "retention_days": 90
-  }
+  "required": [
+    "AUTH_ENABLED",
+    "API_KEY",
+    "MANGROVE_API_KEY",
+    "MANGROVEMARKETS_BASE_URL",
+    "DB_PATH",
+    "KEYRING_SERVICE_NAME",
+    "MASTER_KEY_ENV_FALLBACK",
+    "BACKTEST_CANDIDATE_COUNT",
+    "BACKTEST_MIN_WIN_RATE",
+    "BACKTEST_MIN_TRADES",
+    "BACKTEST_DEFAULT_LOOKBACK_MONTHS",
+    "LOG_RETENTION_DAYS"
+  ],
+  "full_app_keys": []
 }
 ```
+
+### Example `local-config.json`
+
+```json
+{
+  "AUTH_ENABLED": true,
+  "API_KEY": "local-dev-key",
+  "MANGROVE_API_KEY": "dev_...",
+  "MANGROVEMARKETS_BASE_URL": "http://localhost:8080",
+  "DB_PATH": "./agent.db",
+  "KEYRING_SERVICE_NAME": "defi-agent",
+  "MASTER_KEY_ENV_FALLBACK": "",
+  "BACKTEST_CANDIDATE_COUNT": 7,
+  "BACKTEST_MIN_WIN_RATE": 0.51,
+  "BACKTEST_MIN_TRADES": 10,
+  "BACKTEST_DEFAULT_LOOKBACK_MONTHS": 3,
+  "LOG_RETENTION_DAYS": 90
+}
+```
+
+### Notes
+
+- `API_KEY`, `MANGROVE_API_KEY`, and `MASTER_KEY_ENV_FALLBACK` are the secret-sensitive values. In environments with Secret Manager configured, they can be written as `"secret:mangrove-api-key:value"`; local deployments use literal strings.
+- `MASTER_KEY_ENV_FALLBACK` is intentionally non-required at runtime — if empty, the agent uses the OS keychain. Set it only for environments without a keychain (e.g., CI).
+- `full_app_keys` is empty for v1 (no Postgres or Redis).
+- The `MANGROVEAI_BASE_URL` is auto-detected by the SDK from the `MANGROVE_API_KEY` prefix (`prod_*` vs `dev_*`); no separate config key needed.
 
 ---
 
@@ -885,8 +888,8 @@ All routes and MCP tools delegate to these services. Never duplicate business lo
 | Module | Responsibility |
 |--------|---------------|
 | `services/wallet_manager.py` | Key gen, encryption, decryption, local signing |
-| `services/strategy_service.py` | Strategy CRUD (wraps `mangroveai.strategies`), local cache sync |
-| `services/candidate_generator.py` | Autonomous skill: goal → 5–10 signal combos (uses `mangroveai.signals` + `mangroveai.kb`) |
+| `services/strategy_service.py` | Strategy CRUD (wraps `mangroveai.strategies`) + cron-tick orchestration: fetch market data, call `mangroveai.execution.evaluate()`, dispatch returned orders to `order_executor`. **No local signal evaluation or risk logic** — the SDK handles all of that. |
+| `services/candidate_generator.py` | Autonomous: goal → 5–10 signal combos (deterministic heuristics over `mangroveai.signals` catalog) |
 | `services/backtest_service.py` | Quick + full backtest orchestration; filter + rank by IRR |
 | `services/signal_service.py` | Signal discovery (wraps `mangroveai.signals`) |
 | `services/market_data.py` | OHLCV, market data, trending, global (wraps `mangroveai.crypto_assets`) |
@@ -894,11 +897,12 @@ All routes and MCP tools delegate to these services. Never duplicate business lo
 | `services/dex_service.py` | DEX venue/pair/quote/swap (wraps `mangrovemarkets.dex`) |
 | `services/portfolio_service.py` | Portfolio value, P&L, history (wraps `mangrovemarkets.portfolio`) |
 | `services/kb_service.py` | KB search and glossary (wraps `mangroveai.kb`) |
-| `services/strategy_evaluator.py` | Pure function: (strategy, market_data, positions) → OrderIntent[] |
-| `services/order_executor.py` | OrderIntent → DEX swap (live) or simulated fill (paper) |
+| `services/order_executor.py` | OrderIntent (from SDK) → DEX swap (live) or simulated fill (paper) |
 | `services/scheduler_service.py` | APScheduler wrapper: register, cancel, list active jobs |
 | `services/trade_log.py` | SQLite writes: evaluations, trades, positions |
 | `services/allocation_service.py` | Local allocation accounting for live strategies |
+
+**Architectural note:** there is no `strategy_evaluator.py` module. Strategy evaluation (signal firing, position sizing, risk gates, cooldowns, volatility adjustments) is entirely the responsibility of `mangroveai.execution.evaluate()`. The agent calls the SDK and executes whatever `OrderIntent[]` comes back. Reimplementing any of that logic locally would duplicate upstream work and inevitably drift out of sync.
 
 ---
 


### PR DESCRIPTION
## Summary

System architecture for defi-agent. Stacked on top of PR #16 (spec) — this branch contains the architecture doc plus the round of spec refinements that came out of architecture review.

## What's in it

- **`docs/architecture.md`** — full system architecture
  - 1 system diagram + 2 data flow diagrams + 4 sequence diagrams + 1 component diagram
  - Folder/file hierarchy with annotations
  - Module retention table (what to keep, add, remove from the template)
  - Technology choices, deployment, roadmap

- **`docs/specification.md`** updates from architecture review:
  - Killed Cloud Run / Cloud SQL / Terraform everywhere (v1 is local-only)
  - Strategy evaluation goes through `mangroveai.execution.evaluate()` — no local `strategy_evaluator.py`. SDK applies all risk gates, position sizing, cooldowns.
  - Use the template's existing config system (`configuration-keys.json` + per-env JSON + `secret:name:property`). No `.env` files.
  - EVM-only for live execution; XRPL stubbed (returns 501); Solana skipped
  - Service principle: only services that ADD orchestration exist. 8 services total: `wallet_manager`, `strategy_service`, `candidate_generator`, `backtest_service`, `order_executor`, `scheduler_service`, `trade_log`, `allocation_service`. Routes call SDK clients directly for everything else.
  - `order_executor` is the SINGLE swap path — both cron-driven and user-initiated `POST /dex/swap`
  - x402 stays wired up (middleware + `hello_mangrove.py` demo route, renamed from `easter_egg.py`) for future endpoints
  - All "Hank" references dropped from the service — Hank is the chat-facing persona; the service is "the agent" / "defi-agent"

## Test plan

- [ ] Confirm 8 services is the right service surface
- [ ] Confirm `order_executor` consolidation (cron + user paths share code)
- [ ] Confirm x402 stays wired up + `hello_mangrove` rename is fine

🤖 Generated with [Claude Code](https://claude.com/claude-code)