### PR TITLE
Phase 3: strategy pipeline (4 tasks)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ docker-compose.override.yml
 TEMPLATE-REVIEW.md
 ROADMAP.md
 docs/plans/
+agent.db

--- a/server/scripts/test_x402_mainnet.py
+++ b/server/scripts/test_x402_mainnet.py
@@ -40,8 +40,8 @@ async def main():
     from src.shared.x402.config import (
         get_cdp_api_key_id,
         get_cdp_api_key_secret,
-        get_hello_mangrove_price,
         get_facilitator_url,
+        get_hello_mangrove_price,
         get_network,
         get_pay_to,
     )

--- a/server/src/services/backtest_service.py
+++ b/server/src/services/backtest_service.py
@@ -1,0 +1,251 @@
+"""backtest_service — quick + full backtest orchestration + IRR ranking.
+
+Phase 3 Task 3.2. Thin orchestrator over mangroveai.backtesting.run().
+The SDK exposes a single run() today; Tim is adding a dedicated quick
+mode on the server. Until that ships, "quick" and "full" here both hit
+run() — the distinction is in how we summarize results (quick = metrics
+only; full = metrics + trade_history).
+
+Filter + rank:
+- Drop candidates with win_rate <= BACKTEST_MIN_WIN_RATE  (default 0.51)
+- Drop candidates with total_trades < BACKTEST_MIN_TRADES (default 10)
+- Sort survivors by irr_annualized DESC
+
+Metric key lookup is defensive: the SDK's metrics dict field names may
+vary. We look up several common spellings and return 0.0 if none present.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from mangroveai.models import BacktestRequest
+from pydantic import BaseModel
+
+from src.config import app_config
+from src.services.candidate_generator import StrategyCandidate
+from src.shared.clients.mangrove import mangroveai_client
+from src.shared.errors import SdkError
+from src.shared.logging import get_logger
+
+_log = get_logger(__name__)
+
+
+# Reasonable defaults for an autonomous backtest. These match the defaults
+# the strategy spec uses; advanced users can override via the manual path.
+_DEFAULT_EXECUTION_CONFIG = {
+    "initial_balance": 10_000.0,
+    "min_balance_threshold": 0.1,
+    "min_trade_amount": 25.0,
+    "max_open_positions": 3,
+    "max_trades_per_day": 10,
+    "max_risk_per_trade": 0.02,
+    "max_units_per_trade": 1_000_000.0,
+    "max_trade_amount": 10_000_000.0,
+    "volatility_window": 24,
+    "target_volatility": 0.1,
+}
+
+
+class CandidateBacktestResult(BaseModel):
+    """Per-candidate outcome of quick_backtest_all."""
+
+    candidate: StrategyCandidate
+    success: bool
+    irr_annualized: float
+    win_rate: float
+    total_trades: int
+    sharpe_ratio: float
+    max_drawdown: float
+    net_pnl: float
+    reject_reason: str | None = None  # filled after filter step
+    raw_metrics: dict[str, Any] = {}
+    error: str | None = None
+
+
+def _metric(metrics: dict[str, Any] | None, *keys: str, default: float = 0.0) -> float:
+    """Defensive metric lookup: try each key in order."""
+    if not metrics:
+        return default
+    for k in keys:
+        if k in metrics and metrics[k] is not None:
+            try:
+                return float(metrics[k])
+            except (TypeError, ValueError):
+                continue
+    return default
+
+
+def _int_metric(metrics: dict[str, Any] | None, *keys: str, default: int = 0) -> int:
+    if not metrics:
+        return default
+    for k in keys:
+        if k in metrics and metrics[k] is not None:
+            try:
+                return int(metrics[k])
+            except (TypeError, ValueError):
+                continue
+    return default
+
+
+def _build_request(
+    candidate: StrategyCandidate,
+    lookback_months: int,
+    start_date: str | None = None,
+    end_date: str | None = None,
+) -> BacktestRequest:
+    """Build a BacktestRequest from a candidate + sensible defaults."""
+    strategy_json = json.dumps({
+        "name": candidate.name,
+        "asset": candidate.asset,
+        "entry": candidate.entry,
+        "exit": candidate.exit or [],
+    })
+    return BacktestRequest(
+        asset=candidate.asset,
+        interval=candidate.timeframe,
+        strategy_json=strategy_json,
+        **_DEFAULT_EXECUTION_CONFIG,
+        lookback_months=lookback_months if not start_date else None,
+        start_date=start_date,
+        end_date=end_date,
+    )
+
+
+def _summarize(
+    candidate: StrategyCandidate,
+    raw_result: Any,
+) -> CandidateBacktestResult:
+    """Translate an SDK BacktestResult into CandidateBacktestResult."""
+    metrics: dict[str, Any] = getattr(raw_result, "metrics", None) or {}
+    success = bool(getattr(raw_result, "success", False))
+    return CandidateBacktestResult(
+        candidate=candidate,
+        success=success,
+        irr_annualized=_metric(metrics, "irr_annualized", "irr", "annualized_return"),
+        win_rate=_metric(metrics, "win_rate", "winrate"),
+        total_trades=_int_metric(
+            metrics,
+            "total_trades",
+            "trade_count",
+            default=int(getattr(raw_result, "trade_count", None) or 0),
+        ),
+        sharpe_ratio=_metric(metrics, "sharpe_ratio", "sharpe"),
+        max_drawdown=_metric(metrics, "max_drawdown", "maxdd"),
+        net_pnl=_metric(metrics, "net_pnl", "total_pnl", "return"),
+        raw_metrics=metrics,
+        error=getattr(raw_result, "error", None),
+    )
+
+
+def quick_backtest_all(
+    candidates: list[StrategyCandidate],
+    lookback_months: int | None = None,
+) -> list[CandidateBacktestResult]:
+    """Run a backtest for every candidate. Per-candidate failures do not
+    abort the batch — the result's .success and .error fields carry the
+    outcome."""
+    if lookback_months is None:
+        lookback_months = int(app_config.BACKTEST_DEFAULT_LOOKBACK_MONTHS)
+
+    client = mangroveai_client()
+    results: list[CandidateBacktestResult] = []
+    for c in candidates:
+        try:
+            raw = client.backtesting.run(
+                _build_request(c, lookback_months=lookback_months),
+            )
+            results.append(_summarize(c, raw))
+        except Exception as e:  # noqa: BLE001 — SDK may raise arbitrary subclasses
+            results.append(CandidateBacktestResult(
+                candidate=c,
+                success=False,
+                irr_annualized=0.0,
+                win_rate=0.0,
+                total_trades=0,
+                sharpe_ratio=0.0,
+                max_drawdown=0.0,
+                net_pnl=0.0,
+                error=str(e),
+            ))
+
+    _log.info(
+        "backtest.quick_batch_completed",
+        n=len(candidates),
+        succeeded=sum(1 for r in results if r.success),
+    )
+    return results
+
+
+def filter_and_rank(
+    results: list[CandidateBacktestResult],
+    min_win_rate: float | None = None,
+    min_trades: int | None = None,
+) -> tuple[list[CandidateBacktestResult], list[CandidateBacktestResult]]:
+    """Split results into (survivors, rejected), with rejected carrying a
+    reject_reason. Survivors are sorted by irr_annualized DESC."""
+    if min_win_rate is None:
+        min_win_rate = float(app_config.BACKTEST_MIN_WIN_RATE)
+    if min_trades is None:
+        min_trades = int(app_config.BACKTEST_MIN_TRADES)
+
+    survivors: list[CandidateBacktestResult] = []
+    rejected: list[CandidateBacktestResult] = []
+
+    for r in results:
+        if not r.success:
+            rejected.append(r.model_copy(update={"reject_reason": f"backtest failed: {r.error or 'unknown error'}"}))
+            continue
+        if r.total_trades < min_trades:
+            rejected.append(r.model_copy(update={
+                "reject_reason": f"total_trades {r.total_trades} < {min_trades}"
+            }))
+            continue
+        if r.win_rate <= min_win_rate:
+            rejected.append(r.model_copy(update={
+                "reject_reason": f"win_rate {r.win_rate:.3f} <= {min_win_rate}"
+            }))
+            continue
+        survivors.append(r)
+
+    survivors.sort(key=lambda r: r.irr_annualized, reverse=True)
+    return survivors, rejected
+
+
+def full_backtest(
+    candidate: StrategyCandidate,
+    lookback_months: int | None = None,
+    start_date: str | None = None,
+    end_date: str | None = None,
+) -> CandidateBacktestResult:
+    """Run a full backtest — same SDK call as quick, but we also return
+    the trade_history attached to raw_metrics for downstream display."""
+    if lookback_months is None:
+        lookback_months = int(app_config.BACKTEST_DEFAULT_LOOKBACK_MONTHS)
+
+    client = mangroveai_client()
+    try:
+        raw = client.backtesting.run(
+            _build_request(candidate, lookback_months, start_date, end_date),
+        )
+    except Exception as e:  # noqa: BLE001
+        raise SdkError(
+            f"Full backtest failed: {e}",
+            suggestion="Check the strategy JSON is well-formed and the asset/interval are supported by mangroveai.",
+        ) from e
+
+    summary = _summarize(candidate, raw)
+    # Attach trade history (if present) so the /strategies/autonomous response
+    # can include it in full_backtest_metrics.
+    trade_history = getattr(raw, "trade_history", None)
+    if trade_history is not None:
+        summary.raw_metrics = {**summary.raw_metrics, "trade_history": trade_history}
+
+    _log.info(
+        "backtest.full_completed",
+        candidate_name=candidate.name,
+        irr=summary.irr_annualized,
+        win_rate=summary.win_rate,
+        total_trades=summary.total_trades,
+    )
+    return summary

--- a/server/src/services/candidate_generator.py
+++ b/server/src/services/candidate_generator.py
@@ -1,0 +1,239 @@
+"""candidate_generator — goal → 5-10 strategy candidates.
+
+Deterministic heuristic: parse keywords from the user's goal to pick
+signal categories, then randomly sample within those buckets. The result
+is a list of StrategyCandidate dicts that are ready to pass to
+mangroveai.backtesting.run() and eventually mangroveai.strategies.create().
+
+Not an LLM; not Oracle; not anything clever. Just a mapping table plus
+random sampling with a user-supplied seed. The "intelligence" lives in
+(a) the mapping and (b) the user's choice of goal language.
+
+Composition constraints (enforced):
+- entry = exactly 1 TRIGGER + 0–2 FILTERs
+- exit  = 0–1 TRIGGER + 0–2 FILTERs (can be empty — strategy may exit only via SL/TP)
+"""
+from __future__ import annotations
+
+import random
+from typing import Any
+
+from pydantic import BaseModel
+
+from src.shared.clients.mangrove import mangroveai_client
+from src.shared.errors import StrategyNoViableCandidates
+from src.shared.logging import get_logger
+
+_log = get_logger(__name__)
+
+
+# Keyword -> {"trigger": [categories], "filter": [categories]}
+# Lowercase keys; multiple keywords can match, we union them.
+GOAL_TO_CATEGORIES: dict[str, dict[str, list[str]]] = {
+    "momentum": {
+        "trigger": ["momentum", "trend"],
+        "filter": ["volume", "trend"],
+    },
+    "mean_reversion": {
+        "trigger": ["overbought_oversold", "oscillator"],
+        "filter": ["volatility", "trend"],
+    },
+    "breakout": {
+        "trigger": ["breakout"],
+        "filter": ["volume", "volatility"],
+    },
+    "trend": {
+        "trigger": ["trend"],
+        "filter": ["momentum", "volume"],
+    },
+    "oversold": {
+        "trigger": ["overbought_oversold"],
+        "filter": ["volatility"],
+    },
+    "overbought": {
+        "trigger": ["overbought_oversold"],
+        "filter": ["volatility"],
+    },
+    "volume": {
+        "trigger": ["volume"],
+        "filter": ["momentum"],
+    },
+}
+
+# Aliases that collapse to a canonical keyword.
+_KEYWORD_ALIASES: dict[str, str] = {
+    "mean-reversion": "mean_reversion",
+    "meanreversion": "mean_reversion",
+    "revert": "mean_reversion",
+    "reversion": "mean_reversion",
+    "break out": "breakout",
+    "break-out": "breakout",
+    "trending": "trend",
+    "trends": "trend",
+    "momentum-based": "momentum",
+}
+
+
+class StrategyCandidate(BaseModel):
+    """A proposed strategy — ready to backtest or submit to mangroveai."""
+
+    name: str
+    asset: str
+    timeframe: str
+    entry: list[dict[str, Any]]
+    exit: list[dict[str, Any]]
+
+
+def parse_goal(goal: str) -> dict[str, list[str]]:
+    """Detect goal keywords and return the unioned category buckets.
+
+    Defaults to "momentum" when nothing matches so we always produce
+    candidates; the user can try different phrasing if they don't like
+    what comes back.
+    """
+    text = goal.lower()
+    for alias, canonical in _KEYWORD_ALIASES.items():
+        text = text.replace(alias, canonical)
+
+    matched = [k for k in GOAL_TO_CATEGORIES if k in text]
+    if not matched:
+        matched = ["momentum"]
+
+    triggers: set[str] = set()
+    filters: set[str] = set()
+    for kw in matched:
+        triggers.update(GOAL_TO_CATEGORIES[kw]["trigger"])
+        filters.update(GOAL_TO_CATEGORIES[kw]["filter"])
+
+    return {
+        "keywords_matched": matched,
+        "trigger_categories": sorted(triggers),
+        "filter_categories": sorted(filters),
+    }
+
+
+def _default_params(signal: Any) -> dict[str, Any]:
+    """Extract sensible default parameter values from a signal's metadata.
+
+    mangroveai's Signal.metadata.params is a dict describing each param
+    (type, default, min, max). We want {param_name: default_value}.
+    If a default isn't present we skip the param and let the SDK apply
+    its own defaults.
+    """
+    meta = getattr(signal, "metadata", None)
+    params_spec = getattr(meta, "params", None) if meta else None
+    if not params_spec:
+        return {}
+    out: dict[str, Any] = {}
+    for pname, pspec in params_spec.items():
+        if isinstance(pspec, dict) and "default" in pspec:
+            out[pname] = pspec["default"]
+        elif not isinstance(pspec, dict):
+            # Some specs might just be the default value itself.
+            out[pname] = pspec
+    return out
+
+
+def _signal_rule(signal: Any, timeframe: str) -> dict[str, Any]:
+    return {
+        "name": signal.name,
+        "signal_type": signal.signal_type or "TRIGGER",
+        "timeframe": timeframe,
+        "params": _default_params(signal),
+    }
+
+
+def _bucket_signals(
+    signals: list[Any],
+    categories: list[str],
+    signal_type: str,
+) -> list[Any]:
+    """Return signals whose category is in the bucket AND type matches."""
+    cat_set = {c.lower() for c in categories}
+    return [
+        s for s in signals
+        if (s.category or "").lower() in cat_set
+        and (s.signal_type or "").upper() == signal_type.upper()
+    ]
+
+
+def _fetch_catalog() -> list[Any]:
+    """Pull the full signal catalog via the SDK (paginated)."""
+    client = mangroveai_client()
+    return list(client.signals.list_iter(limit_per_page=100))
+
+
+def generate(
+    goal: str,
+    asset: str,
+    timeframe: str,
+    n: int = 7,
+    seed: int | None = None,
+) -> list[StrategyCandidate]:
+    """Produce `n` candidate strategies matching the goal.
+
+    Args:
+        goal: Natural-language goal (e.g. "momentum on ETH").
+        asset: Asset symbol (e.g. "ETH").
+        timeframe: Bar timeframe (e.g. "1h").
+        n: Number of candidates (clamped to [5, 10]).
+        seed: Optional deterministic seed for reproducibility.
+
+    Raises StrategyNoViableCandidates if the SDK returns no signals in
+    the matched categories.
+    """
+    n = max(5, min(10, n))
+    rng = random.Random(seed)
+
+    parsed = parse_goal(goal)
+    catalog = _fetch_catalog()
+
+    trigger_pool = _bucket_signals(catalog, parsed["trigger_categories"], "TRIGGER")
+    filter_pool = _bucket_signals(catalog, parsed["filter_categories"], "FILTER")
+
+    if not trigger_pool:
+        raise StrategyNoViableCandidates(
+            f"No TRIGGER signals available in categories {parsed['trigger_categories']} for goal '{goal}'.",
+            suggestion="Try a different goal keyword (momentum, mean_reversion, breakout, trend) or broaden the timeframe.",
+        )
+
+    candidates: list[StrategyCandidate] = []
+    for i in range(n):
+        entry_trigger = rng.choice(trigger_pool)
+        n_entry_filters = rng.randint(0, min(2, len(filter_pool)))
+        entry_filter_picks = rng.sample(filter_pool, n_entry_filters) if n_entry_filters else []
+
+        entry = [_signal_rule(entry_trigger, timeframe)]
+        entry += [_signal_rule(s, timeframe) for s in entry_filter_picks]
+
+        # Exit is shorter — 50% chance of an exit trigger, 0-2 filters.
+        exit_rules: list[dict[str, Any]] = []
+        if rng.random() < 0.5 and trigger_pool:
+            exit_trigger = rng.choice(trigger_pool)
+            # Avoid picking the exact same signal we used for entry.
+            if exit_trigger.name == entry_trigger.name and len(trigger_pool) > 1:
+                candidates_t = [s for s in trigger_pool if s.name != entry_trigger.name]
+                exit_trigger = rng.choice(candidates_t)
+            exit_rules.append(_signal_rule(exit_trigger, timeframe))
+        n_exit_filters = rng.randint(0, min(2, len(filter_pool)))
+        exit_rules += [_signal_rule(s, timeframe) for s in rng.sample(filter_pool, n_exit_filters)] if n_exit_filters else []
+
+        candidates.append(StrategyCandidate(
+            name=f"auto-{goal[:20].replace(' ', '-')}-{i+1}",
+            asset=asset,
+            timeframe=timeframe,
+            entry=entry,
+            exit=exit_rules,
+        ))
+
+    _log.info(
+        "candidate_generator.generated",
+        goal=goal,
+        asset=asset,
+        timeframe=timeframe,
+        keywords_matched=parsed["keywords_matched"],
+        trigger_pool_size=len(trigger_pool),
+        filter_pool_size=len(filter_pool),
+        n_candidates=len(candidates),
+    )
+    return candidates

--- a/server/src/services/order_executor.py
+++ b/server/src/services/order_executor.py
@@ -1,0 +1,329 @@
+"""order_executor — SINGLE swap path for cron-driven + user-initiated trades.
+
+Takes an OrderIntent and executes it:
+- Paper mode: fetch current market price via mangroveai.crypto_assets,
+  build a simulated Trade row with mode=paper, status=simulated,
+  tx_hash=None.
+- Live mode: full 6-step DEX swap via mangrovemarkets:
+    1. dex.get_quote
+    2. dex.approve_token (may return None if allowance already set)
+    3. If approval returned: wallet_manager.sign → dex.broadcast → poll tx_status
+    4. dex.prepare_swap
+    5. wallet_manager.sign → dex.broadcast
+    6. poll dex.tx_status until confirmed
+  Build a Trade row with mode=live, tx_hash, fill price from quote.
+
+Both paths end with trade_log.log_trade + optionally update_position.
+
+Callers:
+- strategy_service.tick (cron-driven): passes order_intents from
+  mangroveai.execution.evaluate() + the strategy's mode + wallet_address
+  from the allocation.
+- POST /dex/swap route (user-initiated): builds an OrderIntent from the
+  request body + hands to execute_one(mode='live').
+"""
+from __future__ import annotations
+
+import time
+import uuid
+from typing import Any, Literal
+
+from src.config import app_config
+from src.models.domain import OrderIntent, Trade
+from src.services import trade_log
+from src.services.wallet_manager import sign as wallet_sign
+from src.shared.clients.mangrove import mangroveai_client, mangrovemarkets_client
+from src.shared.errors import SdkError, SigningError
+from src.shared.logging import get_logger
+
+_log = get_logger(__name__)
+
+# How long to wait for a tx to move past "pending" when broadcasting a live swap.
+_TX_POLL_TIMEOUT_S = 60.0
+_TX_POLL_INTERVAL_S = 2.0
+
+
+def _fetch_mark_price(symbol: str) -> float:
+    """Pull a current mark price via crypto_assets.get_market_data()."""
+    resp = mangroveai_client().crypto_assets.get_market_data(symbol)
+    data = getattr(resp, "data", None) or {}
+    for key in ("current_price", "price", "usd_price"):
+        if key in data and data[key] is not None:
+            try:
+                return float(data[key])
+            except (TypeError, ValueError):
+                continue
+    raise SdkError(
+        f"No current price found in market data for {symbol}.",
+        suggestion="Check the symbol is recognized by mangroveai.crypto_assets.get_market_data().",
+    )
+
+
+def _paper_fill(intent: OrderIntent, strategy_id: str, evaluation_id: str | None) -> Trade:
+    """Simulate a paper fill at the current mark price."""
+    mark = _fetch_mark_price(intent.symbol)
+    # Convention: "buy" spends USDC for the asset; "sell" does the reverse.
+    # For paper we're not actually moving funds; we just record what the fill
+    # would have looked like.
+    if intent.side == "buy":
+        input_token, output_token = "USDC", intent.symbol
+        input_amount = intent.amount * mark
+        output_amount = intent.amount
+    else:
+        input_token, output_token = intent.symbol, "USDC"
+        input_amount = intent.amount
+        output_amount = intent.amount * mark
+
+    trade = Trade(
+        id=str(uuid.uuid4()),
+        strategy_id=strategy_id,
+        evaluation_id=evaluation_id,
+        order_intent=intent,
+        mode="paper",
+        tx_hash=None,
+        input_token=input_token,
+        input_amount=input_amount,
+        output_token=output_token,
+        output_amount=output_amount,
+        fill_price=mark,
+        fees={},
+        status="simulated",
+        executed_at=trade_log.now_utc(),
+    )
+    trade_log.log_trade(trade)
+    _log.info(
+        "order.paper.simulated",
+        trade_id=trade.id,
+        strategy_id=strategy_id,
+        symbol=intent.symbol,
+        side=intent.side,
+        amount=intent.amount,
+        fill_price=mark,
+    )
+    return trade
+
+
+def _poll_tx(tx_hash: str, chain_id: int, venue_id: str | None = None) -> dict[str, Any]:
+    """Poll dex.tx_status until it's out of 'pending' or timeout."""
+    client = mangrovemarkets_client()
+    deadline = time.monotonic() + _TX_POLL_TIMEOUT_S
+    last_status: Any = None
+    while time.monotonic() < deadline:
+        status = client.dex.tx_status(tx_hash=tx_hash, chain_id=chain_id, venue_id=venue_id)
+        last_status = status
+        s = (getattr(status, "status", "") or "").lower()
+        if s and s != "pending":
+            return {
+                "tx_hash": tx_hash,
+                "status": s,
+                "block_number": getattr(status, "block_number", None),
+                "error": getattr(status, "error_message", None),
+            }
+        time.sleep(_TX_POLL_INTERVAL_S)
+    return {
+        "tx_hash": tx_hash,
+        "status": (getattr(last_status, "status", "timeout") or "timeout"),
+        "block_number": None,
+        "error": "poll timeout",
+    }
+
+
+def _live_swap(
+    intent: OrderIntent,
+    strategy_id: str,
+    evaluation_id: str | None,
+    wallet_address: str,
+    chain_id: int | None = None,
+    venue_id: str | None = None,
+) -> Trade:
+    """Execute the full 6-step live swap flow.
+
+    The SDK never receives the private key — signing happens locally via
+    wallet_manager.sign(). The SDK sees unsigned tx payloads + signed tx
+    hex strings.
+    """
+    if chain_id is None:
+        raise SigningError(
+            "chain_id is required for live swaps.",
+            suggestion="Pass chain_id in the OrderIntent metadata or strategy config.",
+        )
+
+    client = mangrovemarkets_client()
+    if intent.side == "buy":
+        input_token, output_token = "USDC", intent.symbol
+        input_amount = intent.amount  # treat as USDC notional for now
+    else:
+        input_token, output_token = intent.symbol, "USDC"
+        input_amount = intent.amount
+
+    # 1. Quote
+    try:
+        quote = client.dex.get_quote(
+            input_token=input_token,
+            output_token=output_token,
+            amount=input_amount,
+            chain_id=chain_id,
+            venue_id=venue_id,
+        )
+    except Exception as e:  # noqa: BLE001
+        raise SdkError(f"dex.get_quote failed: {e}") from e
+
+    _log.info("order.executing", trade_symbol=intent.symbol, side=intent.side,
+              input_token=input_token, output_token=output_token,
+              input_amount=input_amount, quote_id=getattr(quote, "quote_id", None))
+
+    fees: dict[str, Any] = {
+        "venue_fee": getattr(quote, "venue_fee", 0.0),
+        "mangrove_fee": getattr(quote, "mangrove_fee", 0.0),
+        "price_impact_percent": getattr(quote, "price_impact_percent", 0.0),
+    }
+
+    # 2. Conditional token approval
+    approval_tx_hash: str | None = None
+    try:
+        approval_tx = client.dex.approve_token(
+            token_address=input_token,
+            chain_id=chain_id,
+            wallet_address=wallet_address,
+        )
+    except Exception as e:  # noqa: BLE001
+        raise SdkError(f"dex.approve_token failed: {e}") from e
+
+    if approval_tx is not None:
+        # 3. Sign + broadcast the approval
+        signed_approval = wallet_sign(getattr(approval_tx, "payload", {}), wallet_address)
+        _log.info("order.live.signed", kind="approval", wallet=wallet_address)
+        try:
+            broadcast_result = client.dex.broadcast(signed_tx=signed_approval, chain_id=chain_id, venue_id=venue_id)
+        except Exception as e:  # noqa: BLE001
+            raise SdkError(f"dex.broadcast(approval) failed: {e}") from e
+        approval_tx_hash = getattr(broadcast_result, "tx_hash", None)
+        _log.info("order.live.broadcast", kind="approval", tx_hash=approval_tx_hash)
+        if approval_tx_hash:
+            poll_result = _poll_tx(approval_tx_hash, chain_id, venue_id)
+            if poll_result["status"] not in ("confirmed", "success"):
+                raise SdkError(
+                    f"Approval tx did not confirm: {poll_result['status']} ({poll_result.get('error')})",
+                )
+
+    # 4. Prepare swap
+    try:
+        swap_tx = client.dex.prepare_swap(
+            quote_id=quote.quote_id,
+            wallet_address=wallet_address,
+        )
+    except Exception as e:  # noqa: BLE001
+        raise SdkError(f"dex.prepare_swap failed: {e}") from e
+
+    # 5. Sign + broadcast the swap
+    signed_swap = wallet_sign(getattr(swap_tx, "payload", {}), wallet_address)
+    _log.info("order.live.signed", kind="swap", wallet=wallet_address)
+    try:
+        broadcast_result = client.dex.broadcast(signed_tx=signed_swap, chain_id=chain_id, venue_id=venue_id)
+    except Exception as e:  # noqa: BLE001
+        raise SdkError(f"dex.broadcast(swap) failed: {e}") from e
+    tx_hash = getattr(broadcast_result, "tx_hash", None)
+    _log.info("order.live.broadcast", kind="swap", tx_hash=tx_hash)
+
+    # 6. Poll
+    final = _poll_tx(tx_hash, chain_id, venue_id) if tx_hash else {"status": "failed", "error": "no tx_hash"}
+    status_str = final["status"]
+    confirmed_at = trade_log.now_utc() if status_str in ("confirmed", "success") else None
+    trade_status = "confirmed" if status_str in ("confirmed", "success") else ("failed" if status_str == "failed" else "pending")
+    _log.info("order.live.confirmed", tx_hash=tx_hash, status=status_str,
+              block_number=final.get("block_number"))
+
+    trade = Trade(
+        id=str(uuid.uuid4()),
+        strategy_id=strategy_id,
+        evaluation_id=evaluation_id,
+        order_intent=intent,
+        mode="live",
+        tx_hash=tx_hash,
+        input_token=input_token,
+        input_amount=input_amount,
+        output_token=output_token,
+        output_amount=float(getattr(quote, "output_amount", 0.0)),
+        fill_price=float(getattr(quote, "exchange_rate", 0.0)),
+        fees={**fees, "approval_tx_hash": approval_tx_hash},
+        status=trade_status,
+        executed_at=trade_log.now_utc(),
+        confirmed_at=confirmed_at,
+    )
+    trade_log.log_trade(trade)
+    return trade
+
+
+def execute_one(
+    intent: OrderIntent,
+    mode: Literal["paper", "live"],
+    strategy_id: str = "user-initiated",
+    evaluation_id: str | None = None,
+    wallet_address: str | None = None,
+    chain_id: int | None = None,
+    venue_id: str | None = None,
+) -> Trade:
+    """Execute a single OrderIntent.
+
+    strategy_id defaults to "user-initiated" for /dex/swap-style callers;
+    cron-driven callers pass the real strategy UUID.
+    """
+    if mode == "paper":
+        return _paper_fill(intent, strategy_id=strategy_id, evaluation_id=evaluation_id)
+    if mode == "live":
+        if not wallet_address:
+            raise SigningError(
+                "wallet_address is required for live execution.",
+                suggestion="Pass a wallet_address from the strategy's active allocation, or from the /dex/swap request body.",
+            )
+        return _live_swap(
+            intent,
+            strategy_id=strategy_id,
+            evaluation_id=evaluation_id,
+            wallet_address=wallet_address,
+            chain_id=chain_id,
+            venue_id=venue_id,
+        )
+    raise SigningError(f"Unknown mode: {mode}")
+
+
+def execute_many(
+    intents: list[OrderIntent],
+    mode: Literal["paper", "live"],
+    strategy_id: str,
+    evaluation_id: str | None = None,
+    wallet_address: str | None = None,
+    chain_id: int | None = None,
+    venue_id: str | None = None,
+) -> list[Trade]:
+    """Execute N intents in order. Failures on one do not abort the batch.
+
+    Exceptions during a single intent's execution are logged as
+    order.errored and the batch continues; the returned list only contains
+    trades that were successfully logged to SQLite.
+    """
+    results: list[Trade] = []
+    _ = app_config  # config access forces validation at import time in some tests
+    for intent in intents:
+        try:
+            t = execute_one(
+                intent,
+                mode=mode,
+                strategy_id=strategy_id,
+                evaluation_id=evaluation_id,
+                wallet_address=wallet_address,
+                chain_id=chain_id,
+                venue_id=venue_id,
+            )
+            results.append(t)
+        except Exception as e:  # noqa: BLE001
+            _log.error(
+                "order.errored",
+                strategy_id=strategy_id,
+                symbol=intent.symbol,
+                side=intent.side,
+                exception=str(e),
+            )
+            # Intentional: don't re-raise. The caller (strategy_service.tick)
+            # logs the evaluation and moves on.
+    return results

--- a/server/src/services/strategy_service.py
+++ b/server/src/services/strategy_service.py
@@ -1,0 +1,524 @@
+"""strategy_service — CRUD, lifecycle, cron tick.
+
+Responsibilities:
+- Autonomous creation (goal → candidates → backtest → filter → rank → full → persist)
+- Manual creation (validate composition → persist)
+- List + get + status transitions (single source of truth for lifecycle)
+- Cron tick: call mangroveai.execution.evaluate(strategy_id), dispatch
+  returned OrderIntents to order_executor.
+
+Mangrove's SDK owns all evaluation logic — signal firing, risk gates,
+position sizing, cooldowns, volatility adjustment. The agent just
+orchestrates: fetch strategy from local cache → call SDK evaluate →
+hand orders to executor → log.
+"""
+from __future__ import annotations
+
+import json
+import time
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Literal
+
+from mangroveai.models import CreateStrategyRequest
+from pydantic import BaseModel, Field
+
+from src.models.domain import Evaluation, OrderIntent
+from src.services import (
+    allocation_service,
+    backtest_service,
+    candidate_generator,
+    order_executor,
+    scheduler_service,
+    trade_log,
+)
+from src.shared.clients.mangrove import mangroveai_client
+from src.shared.db.sqlite import get_connection
+from src.shared.errors import (
+    SdkError,
+    StrategyInvalidComposition,
+    StrategyInvalidStatusTransition,
+    StrategyNotFound,
+    StrategyNoViableCandidates,
+)
+from src.shared.logging import get_logger, with_correlation_id
+
+_log = get_logger(__name__)
+
+
+# Valid status transitions: {from: {allowed to}}
+_TRANSITIONS: dict[str, set[str]] = {
+    "draft": {"inactive", "archived"},
+    "inactive": {"paper", "live", "archived"},
+    "paper": {"live", "inactive", "archived"},
+    "live": {"inactive", "archived"},
+    "archived": set(),
+}
+
+_VALID_STATUSES = {"draft", "inactive", "paper", "live", "archived"}
+
+
+# -- Pydantic request/response models ---------------------------------------
+
+
+class StrategyAutonomousRequest(BaseModel):
+    goal: str
+    asset: str
+    timeframe: str
+    candidate_count: int = Field(7, ge=5, le=10)
+    backtest_lookback_months: int = 3
+    seed: int | None = None  # reproducibility
+
+
+class StrategyManualRequest(BaseModel):
+    name: str
+    asset: str
+    timeframe: str
+    entry: list[dict[str, Any]]
+    exit: list[dict[str, Any]] = Field(default_factory=list)
+    execution_config: dict[str, Any] | None = None
+
+
+class StrategyAllocationInput(BaseModel):
+    wallet_address: str
+    token: str  # symbol like "USDC"
+    token_address: str
+    amount: float
+
+
+class StrategyStatusUpdate(BaseModel):
+    status: Literal["draft", "inactive", "paper", "live", "archived"]
+    confirm: bool = False
+    allocation: StrategyAllocationInput | None = None
+
+
+class StrategyDetailResponse(BaseModel):
+    id: str
+    mangrove_id: str
+    name: str
+    asset: str
+    timeframe: str
+    status: str
+    entry: list[dict[str, Any]]
+    exit: list[dict[str, Any]]
+    execution_config: dict[str, Any]
+    generation_report: dict[str, Any] | None = None
+    created_at: datetime
+    updated_at: datetime
+
+
+# -- Composition validation --------------------------------------------------
+
+
+def _validate_composition(entry: list[dict], exit_rules: list[dict]) -> None:
+    """Entry must be exactly 1 TRIGGER + 0+ FILTERs; exit 0-1 TRIGGERs + 0+ FILTERs."""
+    entry_triggers = [r for r in entry if (r.get("signal_type") or "").upper() == "TRIGGER"]
+    if len(entry_triggers) != 1:
+        raise StrategyInvalidComposition(
+            f"Entry must have exactly 1 TRIGGER; got {len(entry_triggers)}.",
+            suggestion="Compose entry as: [one TRIGGER, zero or more FILTERs].",
+        )
+    exit_triggers = [r for r in exit_rules if (r.get("signal_type") or "").upper() == "TRIGGER"]
+    if len(exit_triggers) > 1:
+        raise StrategyInvalidComposition(
+            f"Exit may have at most 1 TRIGGER; got {len(exit_triggers)}.",
+            suggestion="Compose exit as: [zero or one TRIGGER, zero or more FILTERs].",
+        )
+
+
+# -- Local cache helpers -----------------------------------------------------
+
+
+def _insert_cache(
+    mangrove_detail: Any,
+    entry: list[dict],
+    exit_rules: list[dict],
+    execution_config: dict[str, Any],
+    generation_report: dict[str, Any] | None,
+) -> str:
+    """Insert a row into local strategies cache. Returns our local UUID."""
+    local_id = str(uuid.uuid4())
+    now = datetime.now(timezone.utc).isoformat()
+    mangrove_id = str(getattr(mangrove_detail, "id", None) or getattr(mangrove_detail, "strategy_id", local_id))
+    get_connection().execute(
+        """INSERT INTO strategies
+           (id, mangrove_id, name, asset, timeframe, status,
+            entry_json, exit_json, execution_config_json,
+            generation_report_json, created_at, updated_at)
+           VALUES (?,?,?,?,?,?,?,?,?,?,?,?)""",
+        (
+            local_id, mangrove_id,
+            getattr(mangrove_detail, "name", "unnamed"),
+            getattr(mangrove_detail, "asset", ""),
+            _extract_timeframe(entry),
+            getattr(mangrove_detail, "status", "draft"),
+            json.dumps(entry),
+            json.dumps(exit_rules),
+            json.dumps(execution_config or {}),
+            json.dumps(generation_report) if generation_report else None,
+            now, now,
+        ),
+    )
+    get_connection().commit()
+    return local_id
+
+
+def _extract_timeframe(entry: list[dict]) -> str:
+    if not entry:
+        return "1h"
+    return entry[0].get("timeframe") or "1h"
+
+
+def _row_to_response(row: Any) -> StrategyDetailResponse:
+    return StrategyDetailResponse(
+        id=row["id"],
+        mangrove_id=row["mangrove_id"],
+        name=row["name"],
+        asset=row["asset"],
+        timeframe=row["timeframe"],
+        status=row["status"],
+        entry=json.loads(row["entry_json"] or "[]"),
+        exit=json.loads(row["exit_json"] or "[]"),
+        execution_config=json.loads(row["execution_config_json"] or "{}"),
+        generation_report=json.loads(row["generation_report_json"]) if row["generation_report_json"] else None,
+        created_at=datetime.fromisoformat(row["created_at"]),
+        updated_at=datetime.fromisoformat(row["updated_at"]),
+    )
+
+
+def _get_row(strategy_id: str) -> Any:
+    row = get_connection().execute(
+        "SELECT * FROM strategies WHERE id = ?", (strategy_id,),
+    ).fetchone()
+    if not row:
+        raise StrategyNotFound(
+            f"Strategy {strategy_id} not found.",
+            suggestion="Use GET /api/v1/agent/strategies to list available strategies.",
+        )
+    return row
+
+
+def _set_status(strategy_id: str, new_status: str) -> None:
+    now = datetime.now(timezone.utc).isoformat()
+    get_connection().execute(
+        "UPDATE strategies SET status = ?, updated_at = ? WHERE id = ?",
+        (new_status, now, strategy_id),
+    )
+    get_connection().commit()
+
+
+# -- Public API --------------------------------------------------------------
+
+
+def create_autonomous(req: StrategyAutonomousRequest) -> tuple[StrategyDetailResponse, dict[str, Any]]:
+    """Generate candidates, backtest, filter, rank, create winner.
+
+    Returns (strategy_detail_response, generation_report). The report is
+    also persisted in the local strategies cache for audit.
+    """
+    candidates = candidate_generator.generate(
+        goal=req.goal, asset=req.asset, timeframe=req.timeframe,
+        n=req.candidate_count, seed=req.seed,
+    )
+
+    results = backtest_service.quick_backtest_all(
+        candidates, lookback_months=req.backtest_lookback_months,
+    )
+    survivors, rejected = backtest_service.filter_and_rank(results)
+
+    if not survivors:
+        raise StrategyNoViableCandidates(
+            f"No candidate passed filters (n_tried={len(candidates)}, n_rejected={len(rejected)}).",
+            suggestion="Try a different goal, longer timeframe, or longer backtest lookback.",
+        )
+
+    winner = survivors[0]
+    full = backtest_service.full_backtest(
+        winner.candidate, lookback_months=req.backtest_lookback_months,
+    )
+
+    # Build the SDK request from the winning candidate.
+    try:
+        detail = mangroveai_client().strategies.create(
+            CreateStrategyRequest(
+                name=winner.candidate.name,
+                asset=winner.candidate.asset,
+                entry=winner.candidate.entry,
+                exit=winner.candidate.exit,
+                status="inactive",
+            ),
+        )
+    except Exception as e:  # noqa: BLE001
+        raise SdkError(f"strategies.create failed: {e}") from e
+
+    generation_report = {
+        "candidates_tried": len(candidates),
+        "candidates_passed_filter": len(survivors),
+        "winner_rank": 1,
+        "full_backtest_metrics": {
+            "irr_annualized": full.irr_annualized,
+            "win_rate": full.win_rate,
+            "total_trades": full.total_trades,
+            "sharpe_ratio": full.sharpe_ratio,
+            "max_drawdown": full.max_drawdown,
+            "net_pnl": full.net_pnl,
+        },
+        "rejected_reasons": [
+            {"candidate": r.candidate.name, "reason": r.reject_reason}
+            for r in rejected
+        ],
+    }
+
+    local_id = _insert_cache(
+        detail,
+        entry=winner.candidate.entry,
+        exit_rules=winner.candidate.exit,
+        execution_config=backtest_service._DEFAULT_EXECUTION_CONFIG.copy(),
+        generation_report=generation_report,
+    )
+    row = _get_row(local_id)
+    resp = _row_to_response(row)
+    _log.info("strategy.created",
+              strategy_id=local_id, mangrove_id=resp.mangrove_id, mode="autonomous",
+              asset=req.asset, timeframe=req.timeframe,
+              winner_irr=full.irr_annualized, winner_trades=full.total_trades)
+    return resp, generation_report
+
+
+def create_manual(req: StrategyManualRequest) -> StrategyDetailResponse:
+    """Manual creation — caller supplies explicit entry/exit rules."""
+    _validate_composition(req.entry, req.exit)
+
+    try:
+        detail = mangroveai_client().strategies.create(
+            CreateStrategyRequest(
+                name=req.name, asset=req.asset,
+                entry=req.entry, exit=req.exit,
+                status="inactive",
+                execution_config=req.execution_config,
+            ),
+        )
+    except Exception as e:  # noqa: BLE001
+        raise SdkError(f"strategies.create failed: {e}") from e
+
+    local_id = _insert_cache(
+        detail,
+        entry=req.entry,
+        exit_rules=req.exit,
+        execution_config=req.execution_config or backtest_service._DEFAULT_EXECUTION_CONFIG.copy(),
+        generation_report=None,
+    )
+    row = _get_row(local_id)
+    resp = _row_to_response(row)
+    _log.info("strategy.created", strategy_id=local_id, mangrove_id=resp.mangrove_id, mode="manual")
+    return resp
+
+
+def list_strategies(
+    status: str | None = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> list[StrategyDetailResponse]:
+    """List strategies from local cache."""
+    sql = "SELECT * FROM strategies"
+    params: list = []
+    if status:
+        sql += " WHERE status = ?"
+        params.append(status)
+    sql += " ORDER BY created_at DESC LIMIT ? OFFSET ?"
+    params.extend([limit, offset])
+    rows = get_connection().execute(sql, params).fetchall()
+    return [_row_to_response(r) for r in rows]
+
+
+def get_strategy(strategy_id: str) -> StrategyDetailResponse:
+    return _row_to_response(_get_row(strategy_id))
+
+
+def update_status(strategy_id: str, update: StrategyStatusUpdate) -> StrategyDetailResponse:
+    """Single source of truth for strategy lifecycle transitions."""
+    row = _get_row(strategy_id)
+    current = row["status"]
+    target = update.status
+
+    if target not in _VALID_STATUSES:
+        raise StrategyInvalidStatusTransition(f"Unknown status '{target}'.")
+    if target == current:
+        return _row_to_response(row)  # no-op
+    if target not in _TRANSITIONS.get(current, set()):
+        raise StrategyInvalidStatusTransition(
+            f"Cannot transition from {current} to {target}.",
+            suggestion=f"Valid transitions from {current}: {sorted(_TRANSITIONS.get(current, set()))}",
+        )
+
+    # Gate transitions that move real money or stop live execution.
+    needs_confirm = (
+        target == "live"
+        or (current == "live" and target in {"inactive", "archived"})
+    )
+    if needs_confirm and not update.confirm:
+        from src.shared.errors import ConfirmationRequired
+        raise ConfirmationRequired(
+            f"Transition {current} → {target} requires confirm=true.",
+            suggestion="This transition affects real funds or stops live execution. Re-submit with confirm=true.",
+        )
+
+    if target == "live":
+        if not update.allocation:
+            raise StrategyInvalidStatusTransition(
+                "Transition to live requires an allocation block.",
+                suggestion="Include allocation: {wallet_address, token, token_address, amount} in the request.",
+            )
+        allocation_service.record_allocation(
+            strategy_id=strategy_id,
+            wallet_address=update.allocation.wallet_address,
+            token_address=update.allocation.token_address,
+            token_symbol=update.allocation.token,
+            amount=update.allocation.amount,
+        )
+
+    # Sync status upstream.
+    try:
+        mangroveai_client().strategies.update_status(row["mangrove_id"], target)
+    except Exception as e:  # noqa: BLE001
+        # If we already recorded an allocation, roll it back.
+        if target == "live":
+            allocation_service.release_allocation(strategy_id)
+        raise SdkError(f"strategies.update_status failed: {e}") from e
+
+    # Side effects by target.
+    if target in {"paper", "live"}:
+        scheduler_service.register_job(
+            strategy_id, row["timeframe"],
+            "src.services.strategy_service:tick",
+        )
+    else:  # inactive, archived
+        scheduler_service.cancel_job(strategy_id)
+        if current == "live":
+            allocation_service.release_allocation(strategy_id)
+
+    _set_status(strategy_id, target)
+    new_row = _get_row(strategy_id)
+    _log.info("strategy.status_changed",
+              strategy_id=strategy_id, from_status=current, to_status=target,
+              allocation=bool(update.allocation))
+    return _row_to_response(new_row)
+
+
+# -- Cron tick ---------------------------------------------------------------
+
+
+def tick(strategy_id: str) -> None:
+    """The scheduler callback. Runs in a threadpool — must never propagate
+    exceptions, and must never block the request path.
+
+    Semantics (from the architecture doc):
+    1. Load strategy from local cache.
+    2. Call mangroveai.execution.evaluate(mangrove_id,
+       persist=(mode=='live')). SDK fetches market data, applies all
+       risk gates, returns OrderIntent[].
+    3. If empty: log evaluation status=ok, no trades.
+    4. If present: dispatch to order_executor.execute_many(...).
+    5. On any exception: log evaluation status=error with error_msg.
+       Never let the exception escape.
+    """
+    tick_id = str(uuid.uuid4())
+    start_ns = time.monotonic()
+    with with_correlation_id(tick_id):
+        try:
+            row = _get_row(strategy_id)
+        except StrategyNotFound:
+            _log.error("strategy.tick.errored",
+                       strategy_id=strategy_id, tick_id=tick_id,
+                       exception="StrategyNotFound")
+            return
+        mode = row["status"]
+        _log.info("strategy.tick.started",
+                  strategy_id=strategy_id, tick_id=tick_id,
+                  timeframe=row["timeframe"], mode=mode)
+
+        # Only run the tick for paper or live strategies (defensive).
+        if mode not in {"paper", "live"}:
+            _log.info("strategy.tick.completed",
+                      strategy_id=strategy_id, tick_id=tick_id,
+                      order_count=0, duration_ms=0, reason="not active")
+            return
+
+        try:
+            persist = mode == "live"
+            sdk_resp = mangroveai_client().execution.evaluate(
+                row["mangrove_id"], persist=persist,
+            )
+        except Exception as e:  # noqa: BLE001
+            duration_ms = int((time.monotonic() - start_ns) * 1000)
+            trade_log.log_evaluation(Evaluation(
+                id=str(uuid.uuid4()),
+                strategy_id=strategy_id,
+                timestamp=trade_log.now_utc(),
+                duration_ms=duration_ms,
+                status="error",
+                error_msg=f"SDK evaluate failed: {e}",
+            ))
+            _log.error("strategy.tick.errored",
+                       strategy_id=strategy_id, tick_id=tick_id,
+                       exception=str(e), duration_ms=duration_ms)
+            return
+
+        # Extract OrderIntents from SDK response. The shape varies: modern
+        # SDKs return EvaluateResult.orders or .actions; be defensive.
+        raw_orders = (
+            getattr(sdk_resp, "order_intents", None)
+            or getattr(sdk_resp, "orders", None)
+            or (sdk_resp.model_dump().get("order_intents") if hasattr(sdk_resp, "model_dump") else None)
+            or []
+        )
+        order_intents: list[OrderIntent] = []
+        for o in raw_orders:
+            if isinstance(o, OrderIntent):
+                order_intents.append(o)
+            elif isinstance(o, dict):
+                try:
+                    order_intents.append(OrderIntent.model_validate(o))
+                except Exception:  # noqa: BLE001
+                    continue
+
+        # Find the wallet + chain_id for live execution (allocation provides it).
+        wallet_address = None
+        chain_id = None
+        if mode == "live":
+            active_alloc = allocation_service.get_active_allocation(strategy_id)
+            if active_alloc:
+                wallet_address = active_alloc.wallet_address
+                # We don't track chain_id on allocation; pull from wallet row.
+                wrow = get_connection().execute(
+                    "SELECT chain_id FROM wallets WHERE address = ?",
+                    (wallet_address,),
+                ).fetchone()
+                chain_id = wrow["chain_id"] if wrow else None
+
+        # Log the evaluation FIRST so trades can FK-reference it. The
+        # evaluation describes the SDK call outcome, not the downstream
+        # execution outcomes; those get their own rows in `trades`.
+        evaluation_id = str(uuid.uuid4())
+        duration_ms = int((time.monotonic() - start_ns) * 1000)
+        sdk_dump = sdk_resp.model_dump() if hasattr(sdk_resp, "model_dump") else {}
+        trade_log.log_evaluation(Evaluation(
+            id=evaluation_id,
+            strategy_id=strategy_id,
+            timestamp=trade_log.now_utc(),
+            sdk_response=sdk_dump,
+            order_intents=order_intents,
+            duration_ms=duration_ms,
+            status="ok",
+        ))
+
+        if order_intents:
+            order_executor.execute_many(
+                order_intents, mode=mode, strategy_id=strategy_id,
+                evaluation_id=evaluation_id,
+                wallet_address=wallet_address, chain_id=chain_id,
+            )
+
+        _log.info("strategy.tick.completed",
+                  strategy_id=strategy_id, tick_id=tick_id,
+                  order_count=len(order_intents), duration_ms=duration_ms)

--- a/server/tests/integration/test_strategy_service.py
+++ b/server/tests/integration/test_strategy_service.py
@@ -1,0 +1,382 @@
+"""Integration tests for strategy_service — CRUD + lifecycle + tick.
+
+These exercise the full stack against the real SQLite, with mocked
+Mangrove + DEX SDKs. The autonomous path and tick path touch enough
+collaborators (candidate_generator, backtest_service, order_executor,
+allocation_service, scheduler_service) that this lives in integration
+rather than unit.
+"""
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock
+
+os.environ.setdefault("ENVIRONMENT", "test")
+
+import pytest  # noqa: E402
+
+
+@pytest.fixture
+def temp_db(tmp_path, monkeypatch):
+    db_file = tmp_path / "ss.db"
+    from src.config import app_config
+    from src.services import scheduler_service as ss
+    from src.shared.db import sqlite as db_mod
+
+    monkeypatch.setattr(app_config, "DB_PATH", str(db_file))
+    db_mod.reset_connection()
+    ss.reset_scheduler_cache()
+
+    from src.shared.db.sqlite import get_connection, init_db
+    init_db()
+    ss.start()  # so register_job works
+
+    # Seed a wallet for allocations.
+    get_connection().execute(
+        """INSERT INTO wallets
+           (id, address, chain, network, chain_id, encrypted_secret,
+            encryption_method, label, created_at, metadata_json)
+           VALUES (?,?,?,?,?,?,?,?,?,?)""",
+        ("w1", "0xabc", "evm", "testnet", 84532, b"ciphertext",
+         "fernet-v1", "test", "2026-04-20T00:00:00+00:00", None),
+    )
+    get_connection().commit()
+
+    yield db_file
+    ss.reset_scheduler_cache()
+    db_mod.reset_connection()
+
+
+@pytest.fixture
+def mock_ai_sdk(monkeypatch):
+    """Stub mangroveai_client used by strategy_service + candidate_generator + backtest_service."""
+    from tests.unit.test_candidate_generator import _catalog
+
+    client = MagicMock()
+    client.signals.list_iter.side_effect = lambda **kw: iter(_catalog())
+
+    # Backtests always succeed with the same metrics.
+    bt_result = MagicMock()
+    bt_result.success = True
+    bt_result.metrics = {
+        "irr_annualized": 0.4,
+        "win_rate": 0.6,
+        "total_trades": 25,
+        "sharpe_ratio": 1.5,
+        "max_drawdown": 0.1,
+        "net_pnl": 2500.0,
+    }
+    bt_result.trade_count = 25
+    bt_result.trade_history = []
+    bt_result.error = None
+    client.backtesting.run.return_value = bt_result
+
+    # strategies.create: return a fresh mock with a unique id per call,
+    # so the DB's UNIQUE(mangrove_id) constraint is respected.
+    _counter = {"n": 0}
+
+    def _fresh_create(_request):
+        _counter["n"] += 1
+        m = MagicMock()
+        m.id = f"mg-new-{_counter['n']}"
+        m.name = getattr(_request, "name", "auto")
+        m.asset = getattr(_request, "asset", "ETH")
+        m.status = "inactive"
+        return m
+
+    client.strategies.create.side_effect = _fresh_create
+
+    # update_status returns SuccessResponse
+    success = MagicMock()
+    success.success = True
+    client.strategies.update_status.return_value = success
+
+    # execute.evaluate — empty by default
+    eval_resp = MagicMock()
+    eval_resp.order_intents = []
+    eval_resp.orders = None
+    eval_resp.model_dump.return_value = {"orders": []}
+    client.execution.evaluate.return_value = eval_resp
+
+    for path in (
+        "src.services.candidate_generator.mangroveai_client",
+        "src.services.backtest_service.mangroveai_client",
+        "src.services.strategy_service.mangroveai_client",
+    ):
+        monkeypatch.setattr(path, lambda c=client: c)
+    return client
+
+
+def test_create_autonomous_happy_path(temp_db, mock_ai_sdk):
+    from src.services.strategy_service import StrategyAutonomousRequest, create_autonomous
+
+    detail, report = create_autonomous(StrategyAutonomousRequest(
+        goal="momentum on ETH", asset="ETH", timeframe="1h",
+        candidate_count=5, backtest_lookback_months=3, seed=42,
+    ))
+    assert detail.mangrove_id.startswith("mg-new-")
+    assert detail.asset == "ETH"
+    assert report["candidates_tried"] == 5
+    assert report["candidates_passed_filter"] >= 1
+    assert report["winner_rank"] == 1
+    assert "irr_annualized" in report["full_backtest_metrics"]
+
+
+def test_create_autonomous_no_viable_candidates(temp_db, mock_ai_sdk):
+    """If every backtest fails the filter, raise StrategyNoViableCandidates."""
+    from src.services.strategy_service import StrategyAutonomousRequest, create_autonomous
+    from src.shared.errors import StrategyNoViableCandidates
+
+    # Drop win_rate under the threshold.
+    mock_ai_sdk.backtesting.run.return_value.metrics["win_rate"] = 0.3
+
+    with pytest.raises(StrategyNoViableCandidates):
+        create_autonomous(StrategyAutonomousRequest(
+            goal="momentum on ETH", asset="ETH", timeframe="1h",
+            candidate_count=5, seed=1,
+        ))
+
+
+def test_create_manual_happy_path(temp_db, mock_ai_sdk):
+    from src.services.strategy_service import StrategyManualRequest, create_manual
+
+    detail = create_manual(StrategyManualRequest(
+        name="my strategy",
+        asset="ETH",
+        timeframe="1h",
+        entry=[{"name": "rsi_oversold", "signal_type": "TRIGGER", "timeframe": "1h", "params": {}}],
+        exit=[],
+    ))
+    assert detail.mangrove_id.startswith("mg-new-")
+
+
+def test_create_manual_invalid_composition_raises(temp_db, mock_ai_sdk):
+    from src.services.strategy_service import StrategyManualRequest, create_manual
+    from src.shared.errors import StrategyInvalidComposition
+
+    with pytest.raises(StrategyInvalidComposition):
+        create_manual(StrategyManualRequest(
+            name="bad", asset="ETH", timeframe="1h",
+            entry=[  # two triggers — not allowed
+                {"name": "rsi_oversold", "signal_type": "TRIGGER"},
+                {"name": "macd_cross_up", "signal_type": "TRIGGER"},
+            ],
+        ))
+
+
+def test_list_and_get_strategy(temp_db, mock_ai_sdk):
+    from src.services.strategy_service import StrategyManualRequest, create_manual, get_strategy, list_strategies
+
+    a = create_manual(StrategyManualRequest(
+        name="a", asset="ETH", timeframe="1h",
+        entry=[{"name": "rsi_oversold", "signal_type": "TRIGGER", "timeframe": "1h"}],
+    ))
+    b = create_manual(StrategyManualRequest(
+        name="b", asset="BTC", timeframe="4h",
+        entry=[{"name": "macd_cross_up", "signal_type": "TRIGGER", "timeframe": "4h"}],
+    ))
+    items = list_strategies()
+    ids = {s.id for s in items}
+    assert a.id in ids
+    assert b.id in ids
+
+    fetched = get_strategy(a.id)
+    assert fetched.asset == "ETH"
+
+
+def test_status_paper_to_live_requires_confirm(temp_db, mock_ai_sdk):
+    from src.services.strategy_service import (
+        StrategyAllocationInput,
+        StrategyManualRequest,
+        StrategyStatusUpdate,
+        create_manual,
+        update_status,
+    )
+    from src.shared.errors import ConfirmationRequired
+
+    s = create_manual(StrategyManualRequest(
+        name="s", asset="ETH", timeframe="1h",
+        entry=[{"name": "rsi_oversold", "signal_type": "TRIGGER", "timeframe": "1h"}],
+    ))
+    # draft -> inactive -> paper first
+    update_status(s.id, StrategyStatusUpdate(status="inactive"))
+    update_status(s.id, StrategyStatusUpdate(status="paper"))
+    # paper -> live requires confirm
+    with pytest.raises(ConfirmationRequired):
+        update_status(
+            s.id,
+            StrategyStatusUpdate(
+                status="live",
+                allocation=StrategyAllocationInput(
+                    wallet_address="0xabc", token="USDC",
+                    token_address="0xusdc", amount=100,
+                ),
+            ),
+        )
+
+
+def test_status_to_live_registers_cron_and_allocation(temp_db, mock_ai_sdk):
+    from src.services.allocation_service import get_active_allocation
+    from src.services.scheduler_service import active_job_count
+    from src.services.strategy_service import (
+        StrategyAllocationInput,
+        StrategyManualRequest,
+        StrategyStatusUpdate,
+        create_manual,
+        update_status,
+    )
+
+    s = create_manual(StrategyManualRequest(
+        name="s", asset="ETH", timeframe="1h",
+        entry=[{"name": "rsi_oversold", "signal_type": "TRIGGER", "timeframe": "1h"}],
+    ))
+    update_status(s.id, StrategyStatusUpdate(status="inactive"))
+    result = update_status(
+        s.id,
+        StrategyStatusUpdate(
+            status="live",
+            confirm=True,
+            allocation=StrategyAllocationInput(
+                wallet_address="0xabc", token="USDC",
+                token_address="0xusdc", amount=100,
+            ),
+        ),
+    )
+    assert result.status == "live"
+    alloc = get_active_allocation(s.id)
+    assert alloc is not None
+    assert alloc.amount == 100
+    assert active_job_count() == 1
+
+
+def test_deactivating_live_releases_allocation_and_cancels_cron(temp_db, mock_ai_sdk):
+    from src.services.allocation_service import get_active_allocation
+    from src.services.scheduler_service import active_job_count
+    from src.services.strategy_service import (
+        StrategyAllocationInput,
+        StrategyManualRequest,
+        StrategyStatusUpdate,
+        create_manual,
+        update_status,
+    )
+
+    s = create_manual(StrategyManualRequest(
+        name="s", asset="ETH", timeframe="1h",
+        entry=[{"name": "rsi_oversold", "signal_type": "TRIGGER", "timeframe": "1h"}],
+    ))
+    update_status(s.id, StrategyStatusUpdate(status="inactive"))
+    update_status(
+        s.id,
+        StrategyStatusUpdate(
+            status="live",
+            confirm=True,
+            allocation=StrategyAllocationInput(
+                wallet_address="0xabc", token="USDC",
+                token_address="0xusdc", amount=100,
+            ),
+        ),
+    )
+    update_status(s.id, StrategyStatusUpdate(status="inactive", confirm=True))
+
+    assert get_active_allocation(s.id) is None
+    assert active_job_count() == 0
+
+
+def test_tick_paper_mode_logs_simulated_trade(temp_db, mock_ai_sdk, monkeypatch):
+    """tick fires evaluate, dispatches returned orders, logs everything."""
+    from src.services.strategy_service import (
+        StrategyManualRequest,
+        StrategyStatusUpdate,
+        create_manual,
+        tick,
+        update_status,
+    )
+    from src.services.trade_log import list_evaluations, list_trades
+
+    # SDK returns one order intent.
+    eval_resp = MagicMock()
+    eval_resp.order_intents = [
+        {"action": "enter", "side": "buy", "symbol": "ETH",
+         "amount": 0.1, "reason": "rsi_oversold fired"},
+    ]
+    eval_resp.orders = None
+    eval_resp.model_dump.return_value = {"orders": ["something"]}
+    mock_ai_sdk.execution.evaluate.return_value = eval_resp
+
+    # Stub crypto_assets.get_market_data for paper-mode mark price.
+    md = MagicMock()
+    md.data = {"current_price": 2500.0}
+    mock_ai_sdk.crypto_assets.get_market_data.return_value = md
+    monkeypatch.setattr("src.services.order_executor.mangroveai_client",
+                        lambda: mock_ai_sdk)
+
+    s = create_manual(StrategyManualRequest(
+        name="tickee", asset="ETH", timeframe="1h",
+        entry=[{"name": "rsi_oversold", "signal_type": "TRIGGER", "timeframe": "1h"}],
+    ))
+    update_status(s.id, StrategyStatusUpdate(status="inactive"))
+    update_status(s.id, StrategyStatusUpdate(status="paper"))
+
+    tick(s.id)
+
+    evals = list_evaluations(s.id)
+    assert len(evals) == 1
+    assert evals[0].status == "ok"
+    trades = list_trades(s.id)
+    assert len(trades) == 1
+    assert trades[0].mode == "paper"
+    assert trades[0].status == "simulated"
+
+
+def test_tick_catches_sdk_errors(temp_db, mock_ai_sdk):
+    """SDK failure during tick logs evaluation with status=error, does NOT raise."""
+    from src.services.strategy_service import (
+        StrategyManualRequest,
+        StrategyStatusUpdate,
+        create_manual,
+        tick,
+        update_status,
+    )
+    from src.services.trade_log import list_evaluations
+
+    mock_ai_sdk.execution.evaluate.side_effect = RuntimeError("upstream 500")
+
+    s = create_manual(StrategyManualRequest(
+        name="err", asset="ETH", timeframe="1h",
+        entry=[{"name": "rsi_oversold", "signal_type": "TRIGGER", "timeframe": "1h"}],
+    ))
+    update_status(s.id, StrategyStatusUpdate(status="inactive"))
+    update_status(s.id, StrategyStatusUpdate(status="paper"))
+
+    tick(s.id)  # must not raise
+
+    evals = list_evaluations(s.id)
+    assert len(evals) == 1
+    assert evals[0].status == "error"
+    assert "upstream 500" in (evals[0].error_msg or "")
+
+
+def test_invalid_transition_raises(temp_db, mock_ai_sdk):
+    from src.services.strategy_service import (
+        StrategyManualRequest,
+        StrategyStatusUpdate,
+        create_manual,
+        update_status,
+    )
+    from src.shared.errors import StrategyInvalidStatusTransition
+
+    s = create_manual(StrategyManualRequest(
+        name="s", asset="ETH", timeframe="1h",
+        entry=[{"name": "rsi_oversold", "signal_type": "TRIGGER", "timeframe": "1h"}],
+    ))
+    # draft -> live is illegal (must go through inactive then paper)
+    with pytest.raises(StrategyInvalidStatusTransition):
+        update_status(s.id, StrategyStatusUpdate(status="live", confirm=True))
+
+
+def test_get_missing_strategy_raises(temp_db, mock_ai_sdk):
+    from src.services.strategy_service import get_strategy
+    from src.shared.errors import StrategyNotFound
+
+    with pytest.raises(StrategyNotFound):
+        get_strategy("does-not-exist")

--- a/server/tests/unit/test_backtest_service.py
+++ b/server/tests/unit/test_backtest_service.py
@@ -1,0 +1,169 @@
+"""Unit tests for backtest_service — orchestration + filter/rank logic.
+
+Integration against the dev Mangrove env lives in Task 5.2 E2E; this
+module mocks the SDK so we can test the composition in isolation.
+"""
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock
+
+os.environ.setdefault("ENVIRONMENT", "test")
+
+import pytest  # noqa: E402
+
+from src.services.candidate_generator import StrategyCandidate  # noqa: E402
+
+
+def _candidate(name: str = "c1") -> StrategyCandidate:
+    return StrategyCandidate(
+        name=name,
+        asset="ETH",
+        timeframe="1h",
+        entry=[{"name": "macd_cross_up", "signal_type": "TRIGGER", "timeframe": "1h", "params": {}}],
+        exit=[],
+    )
+
+
+def _fake_result(
+    success: bool = True,
+    irr: float = 0.5,
+    win_rate: float = 0.6,
+    total_trades: int = 20,
+    sharpe: float = 1.2,
+    max_dd: float = 0.1,
+    net_pnl: float = 1500.0,
+    trade_history: list | None = None,
+    error: str | None = None,
+) -> MagicMock:
+    r = MagicMock()
+    r.success = success
+    r.metrics = {
+        "irr_annualized": irr,
+        "win_rate": win_rate,
+        "total_trades": total_trades,
+        "sharpe_ratio": sharpe,
+        "max_drawdown": max_dd,
+        "net_pnl": net_pnl,
+    }
+    r.trade_count = total_trades
+    r.trade_history = trade_history
+    r.error = error
+    return r
+
+
+@pytest.fixture
+def mock_sdk(monkeypatch):
+    sdk = MagicMock()
+    monkeypatch.setattr(
+        "src.services.backtest_service.mangroveai_client",
+        lambda: sdk,
+    )
+    return sdk
+
+
+def test_quick_backtest_returns_metrics(mock_sdk):
+    from src.services.backtest_service import quick_backtest_all
+
+    mock_sdk.backtesting.run.return_value = _fake_result()
+    results = quick_backtest_all([_candidate("c1"), _candidate("c2")])
+    assert len(results) == 2
+    for r in results:
+        assert r.success is True
+        assert r.irr_annualized == 0.5
+        assert r.win_rate == 0.6
+        assert r.total_trades == 20
+        assert r.sharpe_ratio == 1.2
+
+
+def test_quick_backtest_catches_per_candidate_failures(mock_sdk):
+    """One bad candidate does not abort the batch."""
+    from src.services.backtest_service import quick_backtest_all
+
+    good = _fake_result()
+    mock_sdk.backtesting.run.side_effect = [good, RuntimeError("boom"), good]
+    results = quick_backtest_all([_candidate("a"), _candidate("b"), _candidate("c")])
+    assert len(results) == 3
+    assert results[0].success is True
+    assert results[1].success is False
+    assert "boom" in (results[1].error or "")
+    assert results[2].success is True
+
+
+def test_filter_drops_low_win_rate(mock_sdk):
+    from src.services.backtest_service import _summarize, filter_and_rank
+
+    r_low = _summarize(_candidate("low"), _fake_result(win_rate=0.40))
+    r_ok = _summarize(_candidate("ok"), _fake_result(win_rate=0.55))
+    survivors, rejected = filter_and_rank([r_low, r_ok], min_win_rate=0.51, min_trades=10)
+    assert len(survivors) == 1
+    assert survivors[0].candidate.name == "ok"
+    assert len(rejected) == 1
+    assert "win_rate" in (rejected[0].reject_reason or "")
+
+
+def test_filter_drops_low_trade_count(mock_sdk):
+    from src.services.backtest_service import _summarize, filter_and_rank
+
+    r_few = _summarize(_candidate("few"), _fake_result(total_trades=5))
+    r_ok = _summarize(_candidate("ok"), _fake_result(total_trades=20))
+    survivors, rejected = filter_and_rank([r_few, r_ok], min_win_rate=0.51, min_trades=10)
+    assert [s.candidate.name for s in survivors] == ["ok"]
+    assert "total_trades" in (rejected[0].reject_reason or "")
+
+
+def test_filter_drops_failed_runs(mock_sdk):
+    from src.services.backtest_service import _summarize, filter_and_rank
+
+    r_bad = _summarize(_candidate("bad"), _fake_result(success=False, error="sdk 500"))
+    r_ok = _summarize(_candidate("ok"), _fake_result())
+    survivors, rejected = filter_and_rank([r_bad, r_ok])
+    assert [s.candidate.name for s in survivors] == ["ok"]
+    assert any("backtest failed" in (r.reject_reason or "") for r in rejected)
+
+
+def test_rank_by_irr_descending(mock_sdk):
+    from src.services.backtest_service import _summarize, filter_and_rank
+
+    irr_values = [(0.2, "low"), (0.8, "high"), (0.5, "mid")]
+    results = [
+        _summarize(_candidate(name), _fake_result(irr=irr))
+        for irr, name in irr_values
+    ]
+    survivors, _ = filter_and_rank(results, min_win_rate=0.0, min_trades=0)
+    assert [s.candidate.name for s in survivors] == ["high", "mid", "low"]
+
+
+def test_full_backtest_includes_trade_history(mock_sdk):
+    from src.services.backtest_service import full_backtest
+
+    trades = [{"entry_time": "2026-01-01", "pnl": 12.3}]
+    mock_sdk.backtesting.run.return_value = _fake_result(trade_history=trades)
+    result = full_backtest(_candidate("winner"))
+    assert result.success is True
+    assert "trade_history" in result.raw_metrics
+    assert result.raw_metrics["trade_history"] == trades
+
+
+def test_full_backtest_wraps_sdk_error(mock_sdk):
+    from src.services.backtest_service import full_backtest
+    from src.shared.errors import SdkError
+
+    mock_sdk.backtesting.run.side_effect = RuntimeError("upstream 503")
+    with pytest.raises(SdkError):
+        full_backtest(_candidate("winner"))
+
+
+def test_irr_ranking_uses_config_defaults_when_thresholds_not_passed(mock_sdk, monkeypatch):
+    """filter_and_rank picks up thresholds from app_config when args omitted."""
+    from src.config import app_config
+    from src.services.backtest_service import _summarize, filter_and_rank
+
+    monkeypatch.setattr(app_config, "BACKTEST_MIN_WIN_RATE", 0.60)
+    monkeypatch.setattr(app_config, "BACKTEST_MIN_TRADES", 5)
+
+    r_borderline = _summarize(_candidate("borderline"), _fake_result(win_rate=0.55))
+    r_ok = _summarize(_candidate("ok"), _fake_result(win_rate=0.65))
+    survivors, rejected = filter_and_rank([r_borderline, r_ok])
+    assert [s.candidate.name for s in survivors] == ["ok"]
+    assert len(rejected) == 1

--- a/server/tests/unit/test_candidate_generator.py
+++ b/server/tests/unit/test_candidate_generator.py
@@ -1,0 +1,179 @@
+"""Unit tests for candidate_generator — deterministic goal→candidate mapping."""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import MagicMock
+
+os.environ.setdefault("ENVIRONMENT", "test")
+
+import pytest  # noqa: E402
+
+
+@dataclass
+class _FakeSignalMetadata:
+    params: dict[str, Any] | None = None
+
+
+@dataclass
+class _FakeSignal:
+    name: str
+    category: str
+    signal_type: str
+    metadata: _FakeSignalMetadata | None = None
+
+
+def _catalog() -> list[_FakeSignal]:
+    """A small catalog covering the goal keywords the generator supports."""
+    return [
+        _FakeSignal("rsi_oversold", "overbought_oversold", "TRIGGER",
+                    _FakeSignalMetadata({"window": {"default": 14}, "threshold": {"default": 30}})),
+        _FakeSignal("rsi_overbought", "overbought_oversold", "TRIGGER",
+                    _FakeSignalMetadata({"window": {"default": 14}, "threshold": {"default": 70}})),
+        _FakeSignal("macd_cross_up", "momentum", "TRIGGER", _FakeSignalMetadata({})),
+        _FakeSignal("price_breakout", "breakout", "TRIGGER", _FakeSignalMetadata({})),
+        _FakeSignal("ema_trend", "trend", "TRIGGER", _FakeSignalMetadata({})),
+        _FakeSignal("volume_spike", "volume", "FILTER", _FakeSignalMetadata({})),
+        _FakeSignal("atr_volatility", "volatility", "FILTER", _FakeSignalMetadata({})),
+        _FakeSignal("ema_above_ma", "trend", "FILTER", _FakeSignalMetadata({})),
+        _FakeSignal("rsi_momentum", "momentum", "FILTER", _FakeSignalMetadata({})),
+    ]
+
+
+@pytest.fixture
+def mock_sdk_catalog(monkeypatch):
+    """Stub mangroveai_client().signals.list_iter() with our fake catalog."""
+    client = MagicMock()
+    client.signals.list_iter.return_value = iter(_catalog())
+
+    # list_iter is consumed by list(...), so it must be re-creatable per call.
+    def _fresh_iter(**_kwargs):
+        return iter(_catalog())
+    client.signals.list_iter.side_effect = _fresh_iter
+
+    monkeypatch.setattr(
+        "src.services.candidate_generator.mangroveai_client",
+        lambda: client,
+    )
+    return client
+
+
+# -- parse_goal --------------------------------------------------------------
+
+
+def test_parse_goal_momentum():
+    from src.services.candidate_generator import parse_goal
+
+    parsed = parse_goal("Trade ETH on momentum breakouts with tight stops")
+    assert "momentum" in parsed["keywords_matched"]
+    assert "breakout" in parsed["keywords_matched"]
+    # trigger categories union: momentum+trend (from momentum) + breakout (from breakout)
+    assert "momentum" in parsed["trigger_categories"]
+    assert "breakout" in parsed["trigger_categories"]
+
+
+def test_parse_goal_mean_reversion_alias():
+    from src.services.candidate_generator import parse_goal
+
+    parsed = parse_goal("classic mean-reversion setup on BTC")
+    assert "mean_reversion" in parsed["keywords_matched"]
+    assert "overbought_oversold" in parsed["trigger_categories"]
+
+
+def test_parse_goal_defaults_to_momentum():
+    from src.services.candidate_generator import parse_goal
+
+    parsed = parse_goal("something totally unrecognized")
+    assert parsed["keywords_matched"] == ["momentum"]
+
+
+def test_parse_goal_case_insensitive():
+    from src.services.candidate_generator import parse_goal
+
+    parsed = parse_goal("BREAKOUT on the daily")
+    assert "breakout" in parsed["keywords_matched"]
+
+
+# -- generate ----------------------------------------------------------------
+
+
+def test_generate_returns_requested_count(mock_sdk_catalog):
+    from src.services.candidate_generator import generate
+
+    candidates = generate("momentum on ETH", "ETH", "1h", n=7, seed=42)
+    assert len(candidates) == 7
+
+
+def test_generate_clamps_n_to_5_10(mock_sdk_catalog):
+    from src.services.candidate_generator import generate
+
+    assert len(generate("momentum", "ETH", "1h", n=1, seed=1)) == 5
+    assert len(generate("momentum", "ETH", "1h", n=50, seed=1)) == 10
+
+
+def test_generate_is_deterministic_with_seed(mock_sdk_catalog):
+    from src.services.candidate_generator import generate
+
+    a = generate("momentum on ETH", "ETH", "1h", n=5, seed=42)
+    b = generate("momentum on ETH", "ETH", "1h", n=5, seed=42)
+    assert [c.model_dump() for c in a] == [c.model_dump() for c in b]
+
+
+def test_generate_respects_composition_rules(mock_sdk_catalog):
+    from src.services.candidate_generator import generate
+
+    candidates = generate("momentum on ETH", "ETH", "1h", n=10, seed=7)
+    for c in candidates:
+        # entry: exactly 1 TRIGGER
+        triggers = [r for r in c.entry if r["signal_type"] == "TRIGGER"]
+        filters = [r for r in c.entry if r["signal_type"] == "FILTER"]
+        assert len(triggers) == 1, f"entry must have exactly 1 TRIGGER, got {len(triggers)}"
+        assert 0 <= len(filters) <= 2
+
+        # exit: 0 or 1 TRIGGER, 0+ FILTERs
+        exit_triggers = [r for r in c.exit if r["signal_type"] == "TRIGGER"]
+        assert 0 <= len(exit_triggers) <= 1
+
+
+def test_generate_uses_signal_defaults(mock_sdk_catalog):
+    """Picked signals carry their default params pulled from metadata."""
+    from src.services.candidate_generator import generate
+
+    candidates = generate("oversold on BTC", "BTC", "1h", n=5, seed=0)
+    # rsi_oversold is one of the TRIGGER signals in our fake catalog.
+    has_rsi_with_defaults = False
+    for c in candidates:
+        for rule in c.entry:
+            if rule["name"] == "rsi_oversold":
+                assert rule["params"].get("window") == 14
+                assert rule["params"].get("threshold") == 30
+                has_rsi_with_defaults = True
+    assert has_rsi_with_defaults, "expected at least one rsi_oversold entry with defaults"
+
+
+def test_generate_raises_when_no_trigger_signals(monkeypatch):
+    """Empty trigger pool → StrategyNoViableCandidates."""
+    from src.services.candidate_generator import generate
+    from src.shared.errors import StrategyNoViableCandidates
+
+    empty_client = MagicMock()
+    empty_client.signals.list_iter.side_effect = lambda **kw: iter([])
+    monkeypatch.setattr(
+        "src.services.candidate_generator.mangroveai_client",
+        lambda: empty_client,
+    )
+
+    with pytest.raises(StrategyNoViableCandidates):
+        generate("momentum", "ETH", "1h")
+
+
+def test_generate_carries_asset_and_timeframe(mock_sdk_catalog):
+    from src.services.candidate_generator import generate
+
+    candidates = generate("momentum", "SOL", "4h", n=5, seed=3)
+    for c in candidates:
+        assert c.asset == "SOL"
+        assert c.timeframe == "4h"
+        for rule in c.entry + c.exit:
+            assert rule["timeframe"] == "4h"

--- a/server/tests/unit/test_order_executor.py
+++ b/server/tests/unit/test_order_executor.py
@@ -1,0 +1,251 @@
+"""Unit tests for order_executor with mocked SDKs.
+
+Live-testnet integration (Task 5.3) lives in tests/e2e. Here we verify
+the paper/live branching + SDK call sequence + trade_log wiring with
+mocks so we can assert exactly which calls are made in which order.
+"""
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock
+
+os.environ.setdefault("ENVIRONMENT", "test")
+
+import pytest  # noqa: E402
+
+from src.models.domain import OrderIntent  # noqa: E402
+
+
+def _intent(side: str = "buy", symbol: str = "ETH", amount: float = 0.1) -> OrderIntent:
+    return OrderIntent(action="enter", side=side, symbol=symbol, amount=amount, reason="unit-test")
+
+
+@pytest.fixture
+def temp_db(tmp_path, monkeypatch):
+    db_file = tmp_path / "oe.db"
+    from src.config import app_config
+    from src.shared.db import sqlite as db_mod
+
+    monkeypatch.setattr(app_config, "DB_PATH", str(db_file))
+    db_mod.reset_connection()
+    from src.shared.db.sqlite import get_connection, init_db
+    init_db()
+
+    # Seed a strategy row; FKs from trades/evaluations/positions.
+    get_connection().execute(
+        """INSERT INTO strategies
+           (id, mangrove_id, name, asset, timeframe, status,
+            entry_json, exit_json, execution_config_json,
+            generation_report_json, created_at, updated_at)
+           VALUES (?,?,?,?,?,?,?,?,?,?,?,?)""",
+        ("s1", "mg-s1", "t", "ETH", "1h", "paper",
+         "[]", "[]", "{}", None,
+         "2026-04-20T00:00:00+00:00", "2026-04-20T00:00:00+00:00"),
+    )
+    get_connection().execute(
+        """INSERT INTO strategies
+           (id, mangrove_id, name, asset, timeframe, status,
+            entry_json, exit_json, execution_config_json,
+            generation_report_json, created_at, updated_at)
+           VALUES (?,?,?,?,?,?,?,?,?,?,?,?)""",
+        ("user-initiated", "mg-user", "user", "ETH", "1h", "paper",
+         "[]", "[]", "{}", None,
+         "2026-04-20T00:00:00+00:00", "2026-04-20T00:00:00+00:00"),
+    )
+    get_connection().commit()
+    yield db_file
+    db_mod.reset_connection()
+
+
+@pytest.fixture
+def mock_mangroveai(monkeypatch):
+    """Stub mangroveai_client (used by _fetch_mark_price in paper mode)."""
+    client = MagicMock()
+    market_resp = MagicMock()
+    market_resp.data = {"current_price": 2500.0}
+    client.crypto_assets.get_market_data.return_value = market_resp
+    monkeypatch.setattr("src.services.order_executor.mangroveai_client", lambda: client)
+    return client
+
+
+@pytest.fixture
+def mock_markets(monkeypatch):
+    """Stub mangrovemarkets_client (used in live mode)."""
+    client = MagicMock()
+
+    quote = MagicMock()
+    quote.quote_id = "q-123"
+    quote.output_amount = 0.04
+    quote.exchange_rate = 2500.0
+    quote.venue_fee = 1.0
+    quote.mangrove_fee = 0.5
+    quote.price_impact_percent = 0.05
+    client.dex.get_quote.return_value = quote
+
+    # Default: approval already in place (None returned).
+    client.dex.approve_token.return_value = None
+
+    swap_tx = MagicMock()
+    swap_tx.payload = {"chainId": 84532, "to": "0x" + "a" * 40, "nonce": 0, "data": "0x"}
+    client.dex.prepare_swap.return_value = swap_tx
+
+    broadcast = MagicMock()
+    broadcast.tx_hash = "0xdeadbeef"
+    client.dex.broadcast.return_value = broadcast
+
+    status = MagicMock()
+    status.status = "confirmed"
+    status.block_number = 12345
+    status.error_message = None
+    client.dex.tx_status.return_value = status
+
+    monkeypatch.setattr("src.services.order_executor.mangrovemarkets_client", lambda: client)
+    return client
+
+
+@pytest.fixture
+def stub_sign(monkeypatch):
+    """Stub wallet_manager.sign so live tests don't need a real wallet."""
+    monkeypatch.setattr("src.services.order_executor.wallet_sign",
+                        lambda payload, wallet_address: "0xSIGNED")
+
+
+# -- Paper -----------------------------------------------------------------
+
+
+def test_paper_simulates_at_mark_price(temp_db, mock_mangroveai, mock_markets):
+    from src.services.order_executor import execute_one
+    from src.services.trade_log import list_trades
+
+    trade = execute_one(_intent("buy"), mode="paper", strategy_id="s1")
+    assert trade.mode == "paper"
+    assert trade.status == "simulated"
+    assert trade.tx_hash is None
+    assert trade.fill_price == 2500.0
+    # No DEX calls whatsoever.
+    assert not mock_markets.dex.get_quote.called
+    assert not mock_markets.dex.prepare_swap.called
+    assert not mock_markets.dex.broadcast.called
+
+    fetched = list_trades("s1")
+    assert len(fetched) == 1
+    assert fetched[0].mode == "paper"
+
+
+def test_paper_sell_swaps_tokens(temp_db, mock_mangroveai, mock_markets):
+    from src.services.order_executor import execute_one
+
+    trade = execute_one(_intent("sell"), mode="paper", strategy_id="s1")
+    # Sell: input is the asset, output is USDC
+    assert trade.input_token == "ETH"
+    assert trade.output_token == "USDC"
+
+
+# -- Live ------------------------------------------------------------------
+
+
+def test_live_skips_approval_when_none(temp_db, mock_mangroveai, mock_markets, stub_sign):
+    from src.services.order_executor import execute_one
+
+    # approve_token returns None → no approval sign/broadcast
+    mock_markets.dex.approve_token.return_value = None
+
+    trade = execute_one(
+        _intent("buy"),
+        mode="live",
+        strategy_id="s1",
+        wallet_address="0xabc",
+        chain_id=84532,
+    )
+    assert trade.mode == "live"
+    assert trade.status == "confirmed"
+    assert trade.tx_hash == "0xdeadbeef"
+    # get_quote called once; prepare_swap called once; broadcast called ONCE (only swap, not approval)
+    assert mock_markets.dex.get_quote.call_count == 1
+    assert mock_markets.dex.prepare_swap.call_count == 1
+    assert mock_markets.dex.broadcast.call_count == 1
+
+
+def test_live_full_flow_with_approval(temp_db, mock_mangroveai, mock_markets, stub_sign):
+    from src.services.order_executor import execute_one
+
+    # First call: returns an approval; both broadcasts confirm.
+    approval_tx = MagicMock()
+    approval_tx.payload = {"chainId": 84532, "to": "0x" + "b" * 40, "data": "0x"}
+    mock_markets.dex.approve_token.return_value = approval_tx
+
+    trade = execute_one(
+        _intent("buy"),
+        mode="live",
+        strategy_id="s1",
+        wallet_address="0xabc",
+        chain_id=84532,
+    )
+    assert trade.status == "confirmed"
+    # broadcast called twice (approval + swap)
+    assert mock_markets.dex.broadcast.call_count == 2
+    assert trade.fees["approval_tx_hash"] == "0xdeadbeef"
+
+
+def test_live_requires_wallet_address(temp_db, mock_mangroveai, mock_markets, stub_sign):
+    from src.services.order_executor import execute_one
+    from src.shared.errors import SigningError
+
+    with pytest.raises(SigningError):
+        execute_one(_intent("buy"), mode="live", strategy_id="s1", chain_id=84532)
+
+
+def test_live_requires_chain_id(temp_db, mock_mangroveai, mock_markets, stub_sign):
+    from src.services.order_executor import execute_one
+    from src.shared.errors import SigningError
+
+    with pytest.raises(SigningError):
+        execute_one(_intent("buy"), mode="live", strategy_id="s1", wallet_address="0xabc")
+
+
+def test_live_wraps_sdk_failures(temp_db, mock_mangroveai, mock_markets, stub_sign):
+    from src.services.order_executor import execute_one
+    from src.shared.errors import SdkError
+
+    mock_markets.dex.get_quote.side_effect = RuntimeError("upstream 503")
+    with pytest.raises(SdkError):
+        execute_one(_intent("buy"), mode="live", strategy_id="s1",
+                    wallet_address="0xabc", chain_id=84532)
+
+
+# -- Batching --------------------------------------------------------------
+
+
+def test_execute_many_failure_does_not_block_others(temp_db, mock_mangroveai, mock_markets):
+    from src.services.order_executor import execute_many
+
+    # Second call to get_market_data raises; first + third succeed.
+    bad = MagicMock()
+    bad.data = {}  # triggers SdkError in _fetch_mark_price
+    good = MagicMock()
+    good.data = {"current_price": 3000.0}
+    mock_mangroveai.crypto_assets.get_market_data.side_effect = [good, bad, good]
+
+    intents = [_intent("buy", "ETH", 0.1), _intent("buy", "BTC", 0.01), _intent("sell", "ETH", 0.05)]
+    trades = execute_many(intents, mode="paper", strategy_id="s1")
+    # Two succeeded (first + third); middle failed.
+    assert len(trades) == 2
+    assert trades[0].order_intent.symbol == "ETH"
+    assert trades[1].order_intent.symbol == "ETH"
+
+
+def test_execute_many_empty_list(temp_db, mock_mangroveai, mock_markets):
+    from src.services.order_executor import execute_many
+
+    assert execute_many([], mode="paper", strategy_id="s1") == []
+
+
+# -- Unknown mode ----------------------------------------------------------
+
+
+def test_unknown_mode_raises(temp_db, mock_mangroveai, mock_markets):
+    from src.services.order_executor import execute_one
+    from src.shared.errors import SigningError
+
+    with pytest.raises(SigningError):
+        execute_one(_intent(), mode="backtest", strategy_id="s1")  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

Implements Phase 3 (4 tasks) of \`docs/implementation-plan.md\`. Assembles the full "autonomous strategy creation + cron-driven execution" pipeline end-to-end against mocked Mangrove SDKs. All evaluation logic stays in \`mangroveai.execution.evaluate()\` — the agent is a thin orchestrator.

## Tasks

| # | Task | What it adds |
|---|------|--------------|
| 3.1 | candidate_generator | \`services/candidate_generator.py\` — deterministic goal→candidates mapping via keyword + signal category table. Seeded random sampling within category buckets. 11 unit tests. |
| 3.2 | backtest_service | \`services/backtest_service.py\` — quick batch, filter (WR>0.51, trades≥10), rank by IRR, full backtest on winner. 9 unit tests. |
| 3.3 | order_executor | \`services/order_executor.py\` — SINGLE swap path for both cron-driven AND user-initiated trades. Paper: mark-price simulation. Live: full 6-step DEX flow with client-side signing. 10 unit tests. |
| 3.4 | strategy_service | \`services/strategy_service.py\` — autonomous + manual creation, lifecycle transitions (confirm gates + allocation + cron registration), and the \`tick\` callback that calls \`mangroveai.execution.evaluate()\` and dispatches orders. 12 integration tests. |

## Test results

\`\`\`
docker run ... pytest tests/
======================== 157 passed, 1 warning in 4.94s ========================
\`\`\`

- **42 new tests** across the four modules
- **115 Phase 1+2 tests** still passing

## Architectural discipline held

- **Agent does no signal evaluation, no risk gates, no position sizing, no cooldown enforcement** — all of that lives in \`mangroveai.execution.evaluate()\`. The agent calls the SDK and executes whatever \`OrderIntent[]\` comes back.
- **One swap path**: user-initiated \`/dex/swap\` and cron-driven trades both go through \`order_executor.execute_one\` (this is enforced because \`strategy_service.tick\` and the future \`/dex/swap\` route are the only callers of \`execute_one\` / \`execute_many\`).
- **Signing stays local**: \`order_executor._live_swap\` never hands a private key to the SDK; it calls \`wallet_manager.sign()\` on the unsigned payload and passes the signed hex string to \`dex.broadcast()\`.
- **Tick never crashes the scheduler**: the entire body of \`tick()\` is wrapped in try/except. SDK failures log an error evaluation and return; the scheduler worker stays alive.
- **Log events emitted**: \`candidate_generator.generated\`, \`backtest.quick_batch_completed\`, \`backtest.full_completed\`, \`strategy.created\`, \`strategy.status_changed\`, \`strategy.tick.started\`, \`strategy.tick.completed\`, \`strategy.tick.errored\`, \`order.executing\`, \`order.live.signed\`, \`order.live.broadcast\`, \`order.live.confirmed\`, \`order.paper.simulated\`, \`order.errored\`. All tagged with tick_id as correlation_id when emitted from inside \`tick()\`.
- **Evaluation logged BEFORE trades** so trades' \`evaluation_id\` FK resolves (bug fix during dev).

## Smoke tested

- \`docker compose up --build\`: container starts clean
- \`curl /health\`: 200 + correlation_id header
- Logs show \`db.migrated\` + \`scheduler.started\` + \`app.startup\` on startup

## Out of scope (intentionally)

- No REST routes or MCP tools yet (Phase 4)
- No E2E live swap on testnet yet (Phase 5.3)

## Test plan (reviewer)

- [x] \`pytest tests/\` shows 157 passed
- [x] \`ruff check server/\` clean
- [x] \`docker compose up --build\` boots cleanly
- [x] Spot-check that the \`tick\` callback does NOT re-implement any signal/risk logic — it only calls \`mangroveai.execution.evaluate()\` and dispatches to \`order_executor\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)