### PR TITLE
Phase 4: API layer (7 tasks, 22 MCP tools)

### DIFF
--- a/server/src/api/router.py
+++ b/server/src/api/router.py
@@ -1,14 +1,22 @@
 """REST API routers.
 
-/api/v1/*   -- Free and auth-gated endpoints
-/api/x402/* -- x402 payment-gated endpoints
+/api/v1/*       -- Free and auth-gated endpoints
+/api/v1/agent/* -- defi-agent endpoints (free discovery + auth-gated actions)
+/api/x402/*     -- x402 payment-gated endpoints
 """
 from fastapi import APIRouter
 
+from src.api.routes.discovery import router as discovery_router
 from src.api.routes.hello_mangrove import router as hello_mangrove_router
 
-# Free + auth-gated (placeholder for defi-agent routes added in Phase 4)
+# Free + auth-gated
 api_router = APIRouter(prefix="/api/v1")
+
+# defi-agent namespace
+agent_router = APIRouter(prefix="/agent")
+agent_router.include_router(discovery_router, tags=["discovery"])
+
+api_router.include_router(agent_router)
 
 # x402 payment-gated (hello_mangrove is the smoke test for the payment path)
 x402_router = APIRouter(prefix="/api/x402")

--- a/server/src/api/router.py
+++ b/server/src/api/router.py
@@ -6,6 +6,7 @@
 """
 from fastapi import APIRouter
 
+from src.api.routes.dex import router as dex_router
 from src.api.routes.discovery import router as discovery_router
 from src.api.routes.hello_mangrove import router as hello_mangrove_router
 from src.api.routes.wallet import router as wallet_router
@@ -17,6 +18,7 @@ api_router = APIRouter(prefix="/api/v1")
 agent_router = APIRouter(prefix="/agent")
 agent_router.include_router(discovery_router, tags=["discovery"])
 agent_router.include_router(wallet_router)
+agent_router.include_router(dex_router)
 
 api_router.include_router(agent_router)
 

--- a/server/src/api/router.py
+++ b/server/src/api/router.py
@@ -9,6 +9,10 @@ from fastapi import APIRouter
 from src.api.routes.dex import router as dex_router
 from src.api.routes.discovery import router as discovery_router
 from src.api.routes.hello_mangrove import router as hello_mangrove_router
+from src.api.routes.kb import router as kb_router
+from src.api.routes.market import router as market_router
+from src.api.routes.on_chain import router as on_chain_router
+from src.api.routes.signals import router as signals_router
 from src.api.routes.wallet import router as wallet_router
 
 # Free + auth-gated
@@ -19,6 +23,10 @@ agent_router = APIRouter(prefix="/agent")
 agent_router.include_router(discovery_router, tags=["discovery"])
 agent_router.include_router(wallet_router)
 agent_router.include_router(dex_router)
+agent_router.include_router(market_router)
+agent_router.include_router(on_chain_router)
+agent_router.include_router(signals_router)
+agent_router.include_router(kb_router)
 
 api_router.include_router(agent_router)
 

--- a/server/src/api/router.py
+++ b/server/src/api/router.py
@@ -13,6 +13,7 @@ from src.api.routes.kb import router as kb_router
 from src.api.routes.market import router as market_router
 from src.api.routes.on_chain import router as on_chain_router
 from src.api.routes.signals import router as signals_router
+from src.api.routes.strategies import router as strategies_router
 from src.api.routes.wallet import router as wallet_router
 
 # Free + auth-gated
@@ -26,6 +27,7 @@ agent_router.include_router(dex_router)
 agent_router.include_router(market_router)
 agent_router.include_router(on_chain_router)
 agent_router.include_router(signals_router)
+agent_router.include_router(strategies_router)
 agent_router.include_router(kb_router)
 
 api_router.include_router(agent_router)

--- a/server/src/api/router.py
+++ b/server/src/api/router.py
@@ -10,6 +10,7 @@ from src.api.routes.dex import router as dex_router
 from src.api.routes.discovery import router as discovery_router
 from src.api.routes.hello_mangrove import router as hello_mangrove_router
 from src.api.routes.kb import router as kb_router
+from src.api.routes.logs import router as logs_router
 from src.api.routes.market import router as market_router
 from src.api.routes.on_chain import router as on_chain_router
 from src.api.routes.signals import router as signals_router
@@ -28,6 +29,7 @@ agent_router.include_router(market_router)
 agent_router.include_router(on_chain_router)
 agent_router.include_router(signals_router)
 agent_router.include_router(strategies_router)
+agent_router.include_router(logs_router)
 agent_router.include_router(kb_router)
 
 api_router.include_router(agent_router)

--- a/server/src/api/router.py
+++ b/server/src/api/router.py
@@ -8,6 +8,7 @@ from fastapi import APIRouter
 
 from src.api.routes.discovery import router as discovery_router
 from src.api.routes.hello_mangrove import router as hello_mangrove_router
+from src.api.routes.wallet import router as wallet_router
 
 # Free + auth-gated
 api_router = APIRouter(prefix="/api/v1")
@@ -15,6 +16,7 @@ api_router = APIRouter(prefix="/api/v1")
 # defi-agent namespace
 agent_router = APIRouter(prefix="/agent")
 agent_router.include_router(discovery_router, tags=["discovery"])
+agent_router.include_router(wallet_router)
 
 api_router.include_router(agent_router)
 

--- a/server/src/api/routes/dex.py
+++ b/server/src/api/routes/dex.py
@@ -1,0 +1,140 @@
+"""DEX routes — auth-gated.
+
+- GET  /api/v1/agent/dex/venues
+- GET  /api/v1/agent/dex/pairs?venue_id
+- POST /api/v1/agent/dex/quote
+- POST /api/v1/agent/dex/swap (requires confirm=true)
+
+venues/pairs/quote pass through to mangrovemarkets.dex directly. swap
+builds an OrderIntent and hands it to order_executor — the SINGLE swap
+path used for both user-initiated and cron-driven trades.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel, Field
+
+from src.models.domain import OrderIntent
+from src.services.order_executor import execute_one
+from src.shared.auth.dependency import require_api_key
+from src.shared.clients.mangrove import mangrovemarkets_client
+from src.shared.errors import ConfirmationRequired, SdkError
+
+router = APIRouter(
+    prefix="/dex",
+    dependencies=[Depends(require_api_key)],
+    tags=["dex"],
+)
+
+
+@router.get("/venues", summary="List DEX venues")
+async def dex_venues() -> list[Any]:
+    try:
+        venues = mangrovemarkets_client().dex.supported_venues()
+    except Exception as e:  # noqa: BLE001
+        raise SdkError(f"dex.supported_venues failed: {e}") from e
+    return [v.model_dump() if hasattr(v, "model_dump") else v for v in venues]
+
+
+@router.get("/pairs", summary="List trading pairs for a venue")
+async def dex_pairs(venue_id: str) -> list[Any]:
+    try:
+        pairs = mangrovemarkets_client().dex.supported_pairs(venue_id=venue_id)
+    except Exception as e:  # noqa: BLE001
+        raise SdkError(f"dex.supported_pairs failed: {e}") from e
+    return [p.model_dump() if hasattr(p, "model_dump") else p for p in pairs]
+
+
+class QuoteRequest(BaseModel):
+    input_token: str
+    output_token: str
+    amount: float
+    chain_id: int
+    venue_id: str | None = None
+
+
+@router.post("/quote", summary="Get a swap quote")
+async def dex_quote(req: QuoteRequest) -> dict:
+    try:
+        quote = mangrovemarkets_client().dex.get_quote(
+            input_token=req.input_token,
+            output_token=req.output_token,
+            amount=req.amount,
+            chain_id=req.chain_id,
+            venue_id=req.venue_id,
+        )
+    except Exception as e:  # noqa: BLE001
+        raise SdkError(f"dex.get_quote failed: {e}") from e
+    return quote.model_dump() if hasattr(quote, "model_dump") else quote
+
+
+class SwapRequest(BaseModel):
+    input_token: str
+    output_token: str
+    amount: float
+    chain_id: int
+    wallet_address: str
+    slippage: float = 1.0
+    mev_protection: bool = False
+    venue_id: str | None = None
+    confirm: bool = Field(
+        False,
+        description="Must be true. Protects against agent-initiated swaps without user approval.",
+    )
+
+
+@router.post(
+    "/swap",
+    summary="Execute a DEX swap",
+    description=(
+        "Full 6-step flow: quote → conditional approve → sign → broadcast → poll → "
+        "prepare → sign → broadcast → poll. Signing is client-side; SDK never sees keys. "
+        "Requires confirm=true."
+    ),
+)
+async def dex_swap(req: SwapRequest) -> dict:
+    if not req.confirm:
+        raise ConfirmationRequired(
+            "DEX swaps require confirm=true.",
+            suggestion="Re-submit with confirm=true. This is intentional — protects against agent-initiated swaps without user approval.",
+        )
+
+    # Build an OrderIntent from the user's request. side=buy means "spend
+    # input_token to get output_token"; from the intent's perspective the
+    # symbol is the non-USDC leg.
+    if req.output_token.upper() == "USDC":
+        side = "sell"
+        symbol = req.input_token
+    else:
+        side = "buy"
+        symbol = req.output_token
+
+    intent = OrderIntent(
+        action="enter",
+        side=side,
+        symbol=symbol,
+        amount=req.amount,
+        reason="user-initiated",
+    )
+
+    trade = execute_one(
+        intent,
+        mode="live",
+        wallet_address=req.wallet_address,
+        chain_id=req.chain_id,
+        venue_id=req.venue_id,
+    )
+    return {
+        "tx_hash": trade.tx_hash,
+        "status": trade.status,
+        "input_token": trade.input_token,
+        "input_amount": trade.input_amount,
+        "output_token": trade.output_token,
+        "output_amount": trade.output_amount,
+        "fill_price": trade.fill_price,
+        "fees": trade.fees,
+        "approval_tx_hash": trade.fees.get("approval_tx_hash"),
+        "trade_log_id": trade.id,
+    }

--- a/server/src/api/routes/discovery.py
+++ b/server/src/api/routes/discovery.py
@@ -1,0 +1,61 @@
+"""Discovery endpoints — free, no auth.
+
+- GET /api/v1/agent/status: version, wallet count, strategies grouped
+  by status, active cron jobs, db path, uptime.
+- GET /api/v1/agent/tools: MCP tool catalog (auto-populated by
+  src/mcp/tools.py at registration time).
+
+/health lives in src/app.py (template-provided).
+"""
+from __future__ import annotations
+
+import time
+from collections import Counter
+
+from fastapi import APIRouter
+
+from src.config import app_config
+from src.mcp.registry import list_tools as list_registered_tools
+from src.services.scheduler_service import active_job_count
+from src.shared.db.sqlite import get_connection
+
+router = APIRouter()
+
+_STARTUP_MONOTONIC = time.monotonic()
+
+
+@router.get(
+    "/status",
+    summary="Agent status",
+    description="Version, wallet count, strategies by status, active cron jobs, db path, uptime. Free, no auth.",
+    tags=["discovery"],
+)
+async def status() -> dict:
+    conn = get_connection()
+    wallets_count = conn.execute("SELECT COUNT(*) AS c FROM wallets").fetchone()["c"]
+    strategy_rows = conn.execute("SELECT status FROM strategies").fetchall()
+    counts = Counter(r["status"] for r in strategy_rows)
+    return {
+        "version": "0.1.0",
+        "wallets_count": wallets_count,
+        "strategies": {
+            "draft": counts.get("draft", 0),
+            "inactive": counts.get("inactive", 0),
+            "paper": counts.get("paper", 0),
+            "live": counts.get("live", 0),
+            "archived": counts.get("archived", 0),
+        },
+        "active_cron_jobs": active_job_count(),
+        "db_path": str(app_config.DB_PATH),
+        "uptime_seconds": int(time.monotonic() - _STARTUP_MONOTONIC),
+    }
+
+
+@router.get(
+    "/tools",
+    summary="MCP tool catalog",
+    description="Full catalog of registered MCP tools: name, description, parameters, access tier, pricing. Free, no auth.",
+    tags=["discovery"],
+)
+async def tools() -> dict:
+    return {"tools": list_registered_tools()}

--- a/server/src/api/routes/kb.py
+++ b/server/src/api/routes/kb.py
@@ -1,0 +1,36 @@
+"""Knowledge Base routes — pass-through to mangroveai.kb."""
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends
+
+from src.shared.auth.dependency import require_api_key
+from src.shared.clients.mangrove import mangroveai_client
+from src.shared.errors import SdkError
+
+router = APIRouter(
+    prefix="/kb",
+    dependencies=[Depends(require_api_key)],
+    tags=["kb"],
+)
+
+
+def _dump(obj: Any) -> Any:
+    return obj.model_dump() if hasattr(obj, "model_dump") else obj
+
+
+@router.get("/search", summary="Full-text search the knowledge base")
+async def search(q: str, limit: int = 20) -> Any:
+    try:
+        return _dump(mangroveai_client().kb.search.query(q=q, limit=limit))
+    except Exception as e:  # noqa: BLE001
+        raise SdkError(f"kb.search.query failed: {e}") from e
+
+
+@router.get("/glossary/{term}", summary="Glossary term lookup with backlinks")
+async def glossary(term: str) -> Any:
+    try:
+        return _dump(mangroveai_client().kb.glossary.get(term))
+    except Exception as e:  # noqa: BLE001
+        raise SdkError(f"kb.glossary.get failed: {e}") from e

--- a/server/src/api/routes/logs.py
+++ b/server/src/api/routes/logs.py
@@ -1,0 +1,48 @@
+"""Log query routes — auth-gated. Reads from local SQLite via trade_log."""
+from __future__ import annotations
+
+from typing import Literal
+
+from fastapi import APIRouter, Depends
+
+from src.models.domain import Evaluation, Trade
+from src.services import trade_log
+from src.shared.auth.dependency import require_api_key
+
+router = APIRouter(
+    dependencies=[Depends(require_api_key)],
+    tags=["logs"],
+)
+
+
+@router.get(
+    "/strategies/{strategy_id}/evaluations",
+    response_model=list[Evaluation],
+    summary="Evaluation log for a strategy (newest first)",
+)
+async def list_evaluations(strategy_id: str, limit: int = 50, offset: int = 0) -> list[Evaluation]:
+    return trade_log.list_evaluations(strategy_id, limit=limit, offset=offset)
+
+
+@router.get(
+    "/strategies/{strategy_id}/trades",
+    response_model=list[Trade],
+    summary="Trades for a strategy (newest first)",
+)
+async def list_trades_for_strategy(
+    strategy_id: str, limit: int = 50, offset: int = 0,
+) -> list[Trade]:
+    return trade_log.list_trades(strategy_id, limit=limit, offset=offset)
+
+
+@router.get(
+    "/trades",
+    response_model=list[Trade],
+    summary="All trades across strategies (optional filters)",
+)
+async def list_all_trades(
+    limit: int = 50,
+    strategy_id: str | None = None,
+    mode: Literal["live", "paper"] | None = None,
+) -> list[Trade]:
+    return trade_log.list_all_trades(limit=limit, strategy_id=strategy_id, mode=mode)

--- a/server/src/api/routes/market.py
+++ b/server/src/api/routes/market.py
@@ -1,0 +1,60 @@
+"""Market data routes — auth-gated; pure pass-through to mangroveai.crypto_assets."""
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends
+
+from src.shared.auth.dependency import require_api_key
+from src.shared.clients.mangrove import mangroveai_client
+from src.shared.errors import SdkError
+
+router = APIRouter(
+    prefix="/market",
+    dependencies=[Depends(require_api_key)],
+    tags=["market"],
+)
+
+
+def _dump(obj: Any) -> Any:
+    return obj.model_dump() if hasattr(obj, "model_dump") else obj
+
+
+@router.get("/ohlcv", summary="OHLCV bars for an asset")
+async def ohlcv(symbol: str, timeframe: str = "1h", lookback_days: int = 30) -> Any:
+    try:
+        return _dump(mangroveai_client().crypto_assets.get_ohlcv(
+            symbol=symbol, timeframe=timeframe, days=lookback_days,
+        ))
+    except TypeError:
+        # Older SDK may use different kwarg names; fall back.
+        try:
+            return _dump(mangroveai_client().crypto_assets.get_ohlcv(symbol))
+        except Exception as e:  # noqa: BLE001
+            raise SdkError(f"crypto_assets.get_ohlcv failed: {e}") from e
+    except Exception as e:  # noqa: BLE001
+        raise SdkError(f"crypto_assets.get_ohlcv failed: {e}") from e
+
+
+@router.get("/data", summary="Current market data (price, market cap, volume)")
+async def market_data(symbol: str) -> Any:
+    try:
+        return _dump(mangroveai_client().crypto_assets.get_market_data(symbol))
+    except Exception as e:  # noqa: BLE001
+        raise SdkError(f"crypto_assets.get_market_data failed: {e}") from e
+
+
+@router.get("/trending", summary="Trending assets")
+async def trending() -> Any:
+    try:
+        return _dump(mangroveai_client().crypto_assets.get_trending())
+    except Exception as e:  # noqa: BLE001
+        raise SdkError(f"crypto_assets.get_trending failed: {e}") from e
+
+
+@router.get("/global", summary="Global market data (BTC dominance, total cap, 24h change)")
+async def global_market() -> Any:
+    try:
+        return _dump(mangroveai_client().crypto_assets.get_global_market())
+    except Exception as e:  # noqa: BLE001
+        raise SdkError(f"crypto_assets.get_global_market failed: {e}") from e

--- a/server/src/api/routes/on_chain.py
+++ b/server/src/api/routes/on_chain.py
@@ -1,0 +1,44 @@
+"""On-chain analytics routes — pass-through to mangroveai.on_chain."""
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends
+
+from src.shared.auth.dependency import require_api_key
+from src.shared.clients.mangrove import mangroveai_client
+from src.shared.errors import SdkError
+
+router = APIRouter(
+    prefix="/on-chain",
+    dependencies=[Depends(require_api_key)],
+    tags=["on-chain"],
+)
+
+
+def _dump(obj: Any) -> Any:
+    return obj.model_dump() if hasattr(obj, "model_dump") else obj
+
+
+@router.get("/smart-money", summary="Smart money sentiment for a token")
+async def smart_money(symbol: str, chain: str | None = None) -> Any:
+    try:
+        return _dump(mangroveai_client().on_chain.get_smart_money_sentiment(symbol, chain=chain))
+    except Exception as e:  # noqa: BLE001
+        raise SdkError(f"on_chain.get_smart_money_sentiment failed: {e}") from e
+
+
+@router.get("/whale-activity", summary="Whale activity summary for a token")
+async def whale_activity(symbol: str, hours_back: int = 24) -> Any:
+    try:
+        return _dump(mangroveai_client().on_chain.get_whale_activity(symbol, hours_back=hours_back))
+    except Exception as e:  # noqa: BLE001
+        raise SdkError(f"on_chain.get_whale_activity failed: {e}") from e
+
+
+@router.get("/token-holders/{symbol}", summary="Holder distribution + concentration")
+async def token_holders(symbol: str) -> Any:
+    try:
+        return _dump(mangroveai_client().on_chain.get_token_holders(symbol))
+    except Exception as e:  # noqa: BLE001
+        raise SdkError(f"on_chain.get_token_holders failed: {e}") from e

--- a/server/src/api/routes/signals.py
+++ b/server/src/api/routes/signals.py
@@ -1,0 +1,58 @@
+"""Signal routes — pass-through to mangroveai.signals."""
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends
+
+from src.shared.auth.dependency import require_api_key
+from src.shared.clients.mangrove import mangroveai_client
+from src.shared.errors import SdkError
+
+router = APIRouter(
+    prefix="/signals",
+    dependencies=[Depends(require_api_key)],
+    tags=["signals"],
+)
+
+
+def _dump(obj: Any) -> Any:
+    return obj.model_dump() if hasattr(obj, "model_dump") else obj
+
+
+@router.get("", summary="List available signals (optionally filtered)")
+async def list_signals(
+    category: str | None = None,
+    search: str | None = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> dict:
+    client = mangroveai_client()
+    try:
+        if search:
+            from mangroveai.models import SearchSignalsRequest
+            page = client.signals.search(SearchSignalsRequest(query=search, limit=limit, offset=offset))
+        else:
+            page = client.signals.list(limit=limit, offset=offset)
+    except Exception as e:  # noqa: BLE001
+        raise SdkError(f"signals list/search failed: {e}") from e
+
+    items = [_dump(s) for s in getattr(page, "items", [])]
+    if category:
+        cat_lower = category.lower()
+        items = [s for s in items if (s.get("category") or "").lower() == cat_lower]
+
+    return {
+        "items": items,
+        "total": getattr(page, "total", len(items)),
+        "limit": limit,
+        "offset": offset,
+    }
+
+
+@router.get("/{name}", summary="Signal detail with parameter spec")
+async def get_signal(name: str) -> Any:
+    try:
+        return _dump(mangroveai_client().signals.get(name))
+    except Exception as e:  # noqa: BLE001
+        raise SdkError(f"signals.get failed: {e}") from e

--- a/server/src/api/routes/strategies.py
+++ b/server/src/api/routes/strategies.py
@@ -1,0 +1,163 @@
+"""Strategy routes — auth-gated. All thin wrappers over strategy_service."""
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+
+from src.services import backtest_service, strategy_service
+from src.services.strategy_service import (
+    StrategyAutonomousRequest,
+    StrategyDetailResponse,
+    StrategyManualRequest,
+    StrategyStatusUpdate,
+)
+from src.shared.auth.dependency import require_api_key
+
+router = APIRouter(
+    prefix="/strategies",
+    dependencies=[Depends(require_api_key)],
+    tags=["strategies"],
+)
+
+
+class AutonomousResponse(BaseModel):
+    strategy: StrategyDetailResponse
+    generation_report: dict[str, Any]
+
+
+@router.post(
+    "/autonomous",
+    response_model=AutonomousResponse,
+    status_code=201,
+    summary="Autonomous strategy creation from a natural-language goal",
+)
+async def create_autonomous(req: StrategyAutonomousRequest) -> AutonomousResponse:
+    detail, report = strategy_service.create_autonomous(req)
+    return AutonomousResponse(strategy=detail, generation_report=report)
+
+
+@router.post(
+    "/manual",
+    response_model=StrategyDetailResponse,
+    status_code=201,
+    summary="Manual strategy creation with explicit entry/exit rules",
+)
+async def create_manual(req: StrategyManualRequest) -> StrategyDetailResponse:
+    return strategy_service.create_manual(req)
+
+
+@router.get(
+    "",
+    response_model=list[StrategyDetailResponse],
+    summary="List strategies",
+)
+async def list_strategies(
+    status: str | None = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> list[StrategyDetailResponse]:
+    return strategy_service.list_strategies(status=status, limit=limit, offset=offset)
+
+
+@router.get(
+    "/{strategy_id}",
+    response_model=StrategyDetailResponse,
+    summary="Get a strategy by ID",
+)
+async def get_strategy(strategy_id: str) -> StrategyDetailResponse:
+    return strategy_service.get_strategy(strategy_id)
+
+
+@router.patch(
+    "/{strategy_id}/status",
+    response_model=StrategyDetailResponse,
+    summary="Update strategy status (single source of truth for lifecycle)",
+    description=(
+        "Transitions: draft→inactive, inactive→{paper,live,archived}, "
+        "paper→{live,inactive,archived}, live→{inactive,archived}. "
+        "Target=live requires confirm=true AND an allocation block. "
+        "Transition off live requires confirm=true."
+    ),
+)
+async def update_status(strategy_id: str, req: StrategyStatusUpdate) -> StrategyDetailResponse:
+    return strategy_service.update_status(strategy_id, req)
+
+
+class BacktestInput(BaseModel):
+    mode: str = "full"  # quick | full
+    lookback_months: int = 3
+    start_date: str | None = None
+    end_date: str | None = None
+
+
+@router.post(
+    "/{strategy_id}/backtest",
+    summary="Run a backtest on an existing strategy",
+)
+async def backtest(strategy_id: str, req: BacktestInput) -> dict:
+    detail = strategy_service.get_strategy(strategy_id)
+    # Build a StrategyCandidate shape from the stored strategy.
+    from src.services.candidate_generator import StrategyCandidate
+    candidate = StrategyCandidate(
+        name=detail.name,
+        asset=detail.asset,
+        timeframe=detail.timeframe,
+        entry=detail.entry,
+        exit=detail.exit,
+    )
+    if req.mode == "quick":
+        results = backtest_service.quick_backtest_all(
+            [candidate], lookback_months=req.lookback_months,
+        )
+        result = results[0]
+    else:
+        result = backtest_service.full_backtest(
+            candidate,
+            lookback_months=req.lookback_months,
+            start_date=req.start_date,
+            end_date=req.end_date,
+        )
+
+    return {
+        "strategy_id": strategy_id,
+        "mode": req.mode,
+        "metrics": {
+            "irr_annualized": result.irr_annualized,
+            "win_rate": result.win_rate,
+            "total_trades": result.total_trades,
+            "sharpe_ratio": result.sharpe_ratio,
+            "max_drawdown": result.max_drawdown,
+            "net_pnl": result.net_pnl,
+        },
+        "trade_history": result.raw_metrics.get("trade_history") if req.mode == "full" else None,
+        "success": result.success,
+        "error": result.error,
+    }
+
+
+@router.post(
+    "/{strategy_id}/evaluate",
+    summary="Manually trigger a single evaluation tick",
+    description="Same code path the cron job runs. Useful for debugging or power-user workflows.",
+)
+async def evaluate(strategy_id: str) -> dict:
+    # Make sure the strategy exists; strategy_service.get_strategy raises
+    # StrategyNotFound otherwise.
+    strategy_service.get_strategy(strategy_id)
+    strategy_service.tick(strategy_id)
+    # Return the latest evaluation row for this strategy.
+    from src.services.trade_log import list_evaluations
+    evs = list_evaluations(strategy_id, limit=1)
+    if not evs:
+        return {"strategy_id": strategy_id, "status": "no_evaluation_recorded"}
+    e = evs[0]
+    return {
+        "strategy_id": strategy_id,
+        "evaluation_id": e.id,
+        "status": e.status,
+        "order_count": len(e.order_intents),
+        "duration_ms": e.duration_ms,
+        "error_msg": e.error_msg,
+    }

--- a/server/src/api/routes/wallet.py
+++ b/server/src/api/routes/wallet.py
@@ -1,0 +1,119 @@
+"""Wallet routes — auth-gated.
+
+- POST /api/v1/agent/wallet/create: create + store an encrypted wallet
+- GET  /api/v1/agent/wallet/list: list stored wallets (no secrets)
+- GET  /api/v1/agent/wallet/{address}/balances: token balances via SDK
+- GET  /api/v1/agent/wallet/{address}/portfolio: aggregate portfolio
+- GET  /api/v1/agent/wallet/{address}/history: transaction history
+
+wallet_manager handles create + list (local encryption). The three
+read endpoints pass through to mangrovemarkets_client directly — no
+wrapper service by design (see architecture doc).
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel, Field
+
+from src.services.wallet_manager import (
+    WalletCreateResponse,
+    WalletListItem,
+    create_wallet,
+    list_wallets,
+)
+from src.shared.auth.dependency import require_api_key
+from src.shared.clients.mangrove import mangrovemarkets_client
+from src.shared.errors import SdkError
+
+router = APIRouter(
+    prefix="/wallet",
+    dependencies=[Depends(require_api_key)],
+    tags=["wallet"],
+)
+
+
+class WalletCreateRequest(BaseModel):
+    chain: str = Field(..., description="evm | xrpl (xrpl stubbed 501 in v1)")
+    network: str = Field("testnet", description="mainnet | testnet")
+    chain_id: int | None = Field(None, description="Required for evm")
+    label: str | None = None
+
+
+@router.post(
+    "/create",
+    response_model=WalletCreateResponse,
+    summary="Create a new wallet",
+    description=(
+        "Creates + encrypts a wallet locally. The seed phrase is returned "
+        "ONCE here and never retrievable via the API afterwards. EVM only "
+        "in v1; XRPL returns 501."
+    ),
+    status_code=201,
+)
+async def wallet_create(req: WalletCreateRequest) -> WalletCreateResponse:
+    return create_wallet(
+        chain=req.chain,
+        network=req.network,
+        chain_id=req.chain_id,
+        label=req.label,
+    )
+
+
+@router.get(
+    "/list",
+    response_model=list[WalletListItem],
+    summary="List stored wallets",
+    description="Returns addresses + metadata only. Never includes secrets.",
+)
+async def wallet_list() -> list[WalletListItem]:
+    return list_wallets()
+
+
+@router.get(
+    "/{address}/balances",
+    summary="Token balances",
+    description="Pass-through to mangrovemarkets.dex.balances(chain_id, wallet).",
+)
+async def wallet_balances(address: str, chain_id: int) -> Any:
+    try:
+        result = mangrovemarkets_client().dex.balances(chain_id=chain_id, wallet=address)
+    except Exception as e:  # noqa: BLE001
+        raise SdkError(f"dex.balances failed: {e}") from e
+    return result.model_dump() if hasattr(result, "model_dump") else result
+
+
+@router.get(
+    "/{address}/portfolio",
+    summary="Portfolio aggregate",
+    description="Combined value + P&L + tokens + DeFi via mangrovemarkets.portfolio.*.",
+)
+async def wallet_portfolio(address: str, chain_id: int | None = None) -> dict:
+    client = mangrovemarkets_client()
+    try:
+        value = client.portfolio.value(addresses=address, chain_id=chain_id)
+        pnl = client.portfolio.pnl(addresses=address, chain_id=chain_id)
+        tokens = client.portfolio.tokens(addresses=address, chain_id=chain_id)
+        defi = client.portfolio.defi(addresses=address, chain_id=chain_id)
+    except Exception as e:  # noqa: BLE001
+        raise SdkError(f"portfolio query failed: {e}") from e
+    return {
+        "value": value.model_dump() if hasattr(value, "model_dump") else value,
+        "pnl": pnl.model_dump() if hasattr(pnl, "model_dump") else pnl,
+        "tokens": tokens.model_dump() if hasattr(tokens, "model_dump") else tokens,
+        "defi": defi.model_dump() if hasattr(defi, "model_dump") else defi,
+    }
+
+
+@router.get(
+    "/{address}/history",
+    summary="Transaction history",
+    description="Pass-through to mangrovemarkets.portfolio.history.",
+)
+async def wallet_history(address: str, limit: int = 50) -> list[Any]:
+    try:
+        items = mangrovemarkets_client().portfolio.history(address=address, limit=limit)
+    except Exception as e:  # noqa: BLE001
+        raise SdkError(f"portfolio.history failed: {e}") from e
+    return [i.model_dump() if hasattr(i, "model_dump") else i for i in items]

--- a/server/src/app.py
+++ b/server/src/app.py
@@ -54,67 +54,86 @@ def _setup_x402():
 x402_handler = _setup_x402()
 
 
-@asynccontextmanager
-async def lifespan(application: FastAPI):
-    from src.mcp.server import create_mcp_server
-    from src.services.scheduler_service import shutdown as scheduler_shutdown
-    from src.services.scheduler_service import start as scheduler_start
-    from src.shared.db.sqlite import init_db
+from src.mcp.server import create_mcp_server, reset_mcp_server  # noqa: E402
 
-    init_db()  # emits db.migrated log event; idempotent
-    scheduler_start()  # emits scheduler.started; non-blocking BackgroundScheduler
+
+def create_app() -> FastAPI:
+    """Build a FastAPI app with REST routes + a fresh MCP server mounted at /mcp.
+
+    Each call returns a NEW app + a NEW MCP server. This matters for tests:
+    multiple TestClient lifespans must not share the same MCP session manager
+    (its task group is closed after the first lifespan exit).
+    """
+    reset_mcp_server()
     mcp_server = create_mcp_server()
-    application.mount("/mcp", mcp_server.streamable_http_app())
-    _log.info("app.startup", version=application.version, environment=str(app_config.ENVIRONMENT))
-    yield
-    scheduler_shutdown()  # wait=False so we don't block on in-flight ticks
-    _log.info("app.shutdown")
+    mcp_app = mcp_server.streamable_http_app()
+
+    @asynccontextmanager
+    async def lifespan(application: FastAPI):
+        from src.services.scheduler_service import shutdown as scheduler_shutdown
+        from src.services.scheduler_service import start as scheduler_start
+        from src.shared.db.sqlite import init_db
+
+        init_db()  # emits db.migrated log event; idempotent
+        scheduler_start()  # emits scheduler.started; non-blocking BackgroundScheduler
+        # FastMCP's session manager must be running for the /mcp endpoint to
+        # handle requests. Without this, calls into /mcp raise
+        # "RuntimeError: Task group is not initialized."
+        async with mcp_server.session_manager.run():
+            _log.info("app.startup", version=application.version, environment=str(app_config.ENVIRONMENT))
+            yield
+            _log.info("app.shutdown")
+        scheduler_shutdown()  # wait=False so we don't block on in-flight ticks
+
+    application = FastAPI(
+        title="App-in-a-Box",
+        description=(
+            "FastAPI + MCP service template with three-tier access control.\n\n"
+            "## For Agents\n\n"
+            "- **REST discovery**: GET `/openapi.json` for the full OpenAPI 3.0 spec\n"
+            "- **MCP tool catalog**: GET `/api/v1/docs/tools` for tool names, parameters, access tiers, and pricing\n"
+            "- **MCP endpoint**: Connect to `/mcp` via Streamable HTTP transport\n\n"
+            "## Access Tiers\n\n"
+            "| Tier | How to access |\n"
+            "|------|---------------|\n"
+            "| Free | No credentials needed |\n"
+            "| Auth | `X-API-Key` header |\n"
+            "| x402 | Payment via x402 protocol (or API key for free access) |\n"
+        ),
+        version="0.1.0",
+        lifespan=lifespan,
+        openapi_tags=[
+            {"name": "discovery", "description": "API and tool discovery endpoints (free, no auth)"},
+            {"name": "x402", "description": "x402 payment-gated endpoints (e.g. hello_mangrove)"},
+        ],
+    )
+
+    @application.middleware("http")
+    async def x402_middleware(request: Request, call_next):
+        api_key = request.headers.get("x-api-key")
+        if api_key:
+            return await call_next(request)
+        return await x402_handler(request, call_next)
+
+    application.add_exception_handler(AgentError, agent_error_handler)
+    application.add_middleware(CorrelationIdMiddleware)
+
+    application.include_router(api_router)
+    application.include_router(x402_router)
+    application.mount("/mcp", mcp_app)
+
+    @application.get(
+        "/health",
+        summary="Health check",
+        description="Returns service health status and timestamp. Free, no auth required.",
+        tags=["discovery"],
+    )
+    async def health():
+        return health_payload()
+
+    return application
 
 
-app = FastAPI(
-    title="App-in-a-Box",
-    description=(
-        "FastAPI + MCP service template with three-tier access control.\n\n"
-        "## For Agents\n\n"
-        "- **REST discovery**: GET `/openapi.json` for the full OpenAPI 3.0 spec\n"
-        "- **MCP tool catalog**: GET `/api/v1/docs/tools` for tool names, parameters, access tiers, and pricing\n"
-        "- **MCP endpoint**: Connect to `/mcp` via Streamable HTTP transport\n\n"
-        "## Access Tiers\n\n"
-        "| Tier | How to access |\n"
-        "|------|---------------|\n"
-        "| Free | No credentials needed |\n"
-        "| Auth | `X-API-Key` header |\n"
-        "| x402 | Payment via x402 protocol (or API key for free access) |\n"
-    ),
-    version="0.1.0",
-    lifespan=lifespan,
-    openapi_tags=[
-        {"name": "discovery", "description": "API and tool discovery endpoints (free, no auth)"},
-        {"name": "x402", "description": "x402 payment-gated endpoints (e.g. hello_mangrove)"},
-    ],
-)
-
-
-@app.middleware("http")
-async def x402_middleware(request: Request, call_next):
-    api_key = request.headers.get("x-api-key")
-    if api_key:
-        return await call_next(request)
-    return await x402_handler(request, call_next)
-
-
-app.add_exception_handler(AgentError, agent_error_handler)
-app.add_middleware(CorrelationIdMiddleware)
-
-app.include_router(api_router)
-app.include_router(x402_router)
-
-
-@app.get(
-    "/health",
-    summary="Health check",
-    description="Returns service health status and timestamp. Free, no auth required.",
-    tags=["discovery"],
-)
-async def health():
-    return health_payload()
+# Module-level app instance for uvicorn (`uvicorn src.app:app`).
+# Tests should call create_app() to get a fresh instance per test.
+app = create_app()

--- a/server/src/mcp/server.py
+++ b/server/src/mcp/server.py
@@ -7,17 +7,32 @@ from mcp.server.fastmcp import FastMCP
 _mcp_server = None
 
 
+def reset_mcp_server() -> None:
+    """Drop the cached MCP server. Used between TestClient lifespans where
+    the prior session manager has been closed and can't be reused."""
+    global _mcp_server
+    _mcp_server = None
+
+
 def create_mcp_server() -> FastMCP:
     """Create and configure the MCP server with all tools registered.
 
     Idempotent -- returns the same server instance on repeated calls
-    to avoid duplicate tool registration warnings.
+    to avoid duplicate tool registration warnings. Call reset_mcp_server()
+    first if you need a fresh instance.
     """
     global _mcp_server
     if _mcp_server is not None:
         return _mcp_server
 
-    _mcp_server = FastMCP("app-in-a-box")
+    # streamable_http_path="/" so when mounted at /mcp on the parent app,
+    # the final endpoint is /mcp/ (instead of /mcp/mcp).
+    # stateless_http=True so each request stands alone — no per-session task
+    # group state means the session manager is safe to reuse across multiple
+    # TestClient lifespans (and matches our single-user, request-driven model).
+    _mcp_server = FastMCP(
+        "app-in-a-box", streamable_http_path="/", stateless_http=True, json_response=True
+    )
 
     from src.mcp.tools import register
     register(_mcp_server)

--- a/server/src/mcp/tools.py
+++ b/server/src/mcp/tools.py
@@ -1,57 +1,751 @@
-"""MCP tool definitions.
+"""MCP tool definitions for the defi-agent.
 
-For now this only registers the `hello_mangrove` x402 demo tool — the smoke
-test for the payment pipeline. The defi-agent tools (wallet, strategy, dex,
-etc.) are registered in Phase 4 Task 4.7.
+Every tool mirrors a REST route by calling the same service function.
+Zero duplicated business logic — the MCP layer is just a different
+interface over the same code.
 
-Both REST routes and MCP tools call the same service-layer functions,
-never duplicating business logic.
+Auth: tools accept an `api_key` parameter; `has_valid_api_key` validates
+against config. Returns the spec-shaped `AgentError` JSON on failure.
+Discovery tools (`status`, `list_tools`) bypass auth.
+
+Naming: plain verb_resource form (no project prefix). The MCP server
+namespace is enough. See docs/specification.md MCP Tools table.
 """
+from __future__ import annotations
+
 import json
+from typing import Any
 
 from mcp.server.fastmcp import FastMCP
 
 from src.mcp.registry import ToolEntry, ToolParam, clear_tools, register_tool
-from src.services.hello_mangrove import get_hello_mangrove
+from src.shared.auth.middleware import has_valid_api_key
+from src.shared.errors import AgentError
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _err(code: str, message: str, suggestion: str | None = None, status: int = 400) -> str:
+    return json.dumps({
+        "error": True,
+        "code": code,
+        "message": message,
+        "suggestion": suggestion,
+        "correlation_id": None,
+    })
+
+
+def _auth_error() -> str:
+    return _err(
+        "AUTH_INVALID_API_KEY",
+        "API key required or invalid.",
+        "Pass a valid api_key parameter matching the configured API_KEYS.",
+        status=401,
+    )
+
+
+def _handle_agent_error(e: AgentError) -> str:
+    return json.dumps(e.to_dict())
+
+
+def _dump(obj: Any) -> Any:
+    if hasattr(obj, "model_dump"):
+        return obj.model_dump()
+    if isinstance(obj, list):
+        return [_dump(x) for x in obj]
+    return obj
+
+
+def _require(api_key: str) -> bool:
+    """Return True if api_key is valid, False otherwise."""
+    return has_valid_api_key(api_key)
+
+
+# Shorthand for the "api_key required" parameter in the discovery catalog.
+_APIKEY = ToolParam(name="api_key", type="string", required=True, description="Valid API key")
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
 
 
 def register(server: FastMCP):
-    """Register all tools on the MCP server and discovery catalog."""
-    # Clear catalog to avoid duplicates on re-registration
+    """Register all agent MCP tools + the x402 demo tool."""
     clear_tools()
+    _register_discovery(server)
+    _register_wallet(server)
+    _register_dex(server)
+    _register_market(server)
+    _register_signals(server)
+    _register_strategy(server)
+    _register_logs(server)
+    _register_kb(server)
+    _register_hello_mangrove(server)
 
-    # -- x402-gated demo tool --
+
+# ---------------------------------------------------------------------------
+# Discovery (free)
+# ---------------------------------------------------------------------------
+
+
+def _register_discovery(server: FastMCP) -> None:
+    @server.tool()
+    async def status() -> str:
+        """Return agent status: version, wallets count, strategies by status,
+        active cron jobs, db path, uptime. Free, no auth required."""
+        from src.api.routes.discovery import status as route
+        return json.dumps(await route())
+
+    register_tool(ToolEntry(
+        name="status",
+        description="Agent status + counts + uptime. Free, no auth.",
+        access="free",
+        parameters=[],
+    ))
 
     @server.tool()
-    async def hello_mangrove(payment: str = "") -> str:
-        """Get the hello_mangrove message. Costs $0.05 USDC on Base.
+    async def list_tools() -> str:
+        """List all registered MCP tools with their access tier, parameters,
+        and pricing. Free, no auth."""
+        from src.api.routes.discovery import tools as route
+        return json.dumps(await route())
 
-        Call with no parameters to get payment requirements.
-        Sign the payment using the x402 client SDK, then call again
-        with the base64-encoded payment signature.
-        """
+    register_tool(ToolEntry(
+        name="list_tools",
+        description="MCP tool catalog (name, tier, params, pricing). Free, no auth.",
+        access="free",
+        parameters=[],
+    ))
+
+
+# ---------------------------------------------------------------------------
+# Wallet (auth)
+# ---------------------------------------------------------------------------
+
+
+def _register_wallet(server: FastMCP) -> None:
+    @server.tool()
+    async def create_wallet(
+        chain: str, network: str = "testnet",
+        chain_id: int | None = None, label: str | None = None,
+        api_key: str = "",
+    ) -> str:
+        """Create + encrypt a wallet locally. Seed phrase returned ONCE.
+        EVM only in v1."""
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            from src.services.wallet_manager import create_wallet as svc
+            result = svc(chain=chain, network=network, chain_id=chain_id, label=label)
+            return json.dumps(result.model_dump(mode="json"))
+        except AgentError as e:
+            return _handle_agent_error(e)
+
+    register_tool(ToolEntry(
+        name="create_wallet",
+        description="Create + encrypt a wallet. EVM only in v1.",
+        access="auth",
+        parameters=[
+            ToolParam(name="chain", type="string", required=True, description="evm | xrpl (xrpl stubbed 501)"),
+            ToolParam(name="network", type="string", required=False, description="mainnet | testnet"),
+            ToolParam(name="chain_id", type="integer", required=False, description="Required for evm"),
+            ToolParam(name="label", type="string", required=False, description="Human-friendly name"),
+            _APIKEY,
+        ],
+    ))
+
+    @server.tool()
+    async def list_wallets(api_key: str = "") -> str:
+        """List stored wallets (addresses + metadata only)."""
+        if not _require(api_key):
+            return _auth_error()
+        from src.services.wallet_manager import list_wallets as svc
+        return json.dumps([w.model_dump(mode="json") for w in svc()])
+
+    register_tool(ToolEntry(
+        name="list_wallets",
+        description="List stored wallets (secrets never returned).",
+        access="auth",
+        parameters=[_APIKEY],
+    ))
+
+    @server.tool()
+    async def get_balances(address: str, chain_id: int, api_key: str = "") -> str:
+        """Token balances for a wallet via mangrovemarkets.dex.balances."""
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            from src.shared.clients.mangrove import mangrovemarkets_client
+            result = mangrovemarkets_client().dex.balances(chain_id=chain_id, wallet=address)
+            return json.dumps(_dump(result))
+        except AgentError as e:
+            return _handle_agent_error(e)
+
+    register_tool(ToolEntry(
+        name="get_balances",
+        description="Token balances for a wallet.",
+        access="auth",
+        parameters=[
+            ToolParam(name="address", type="string", required=True, description="Wallet address"),
+            ToolParam(name="chain_id", type="integer", required=True, description="EVM chain id"),
+            _APIKEY,
+        ],
+    ))
+
+
+# ---------------------------------------------------------------------------
+# DEX (auth)
+# ---------------------------------------------------------------------------
+
+
+def _register_dex(server: FastMCP) -> None:
+    @server.tool()
+    async def list_dex_venues(api_key: str = "") -> str:
+        """List supported DEX venues."""
+        if not _require(api_key):
+            return _auth_error()
+        from src.shared.clients.mangrove import mangrovemarkets_client
+        venues = mangrovemarkets_client().dex.supported_venues()
+        return json.dumps([_dump(v) for v in venues])
+
+    register_tool(ToolEntry(
+        name="list_dex_venues",
+        description="List supported DEX venues.",
+        access="auth",
+        parameters=[_APIKEY],
+    ))
+
+    @server.tool()
+    async def get_swap_quote(
+        input_token: str, output_token: str, amount: float,
+        chain_id: int, venue_id: str | None = None,
+        api_key: str = "",
+    ) -> str:
+        """Get a swap quote."""
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            from src.shared.clients.mangrove import mangrovemarkets_client
+            q = mangrovemarkets_client().dex.get_quote(
+                input_token=input_token, output_token=output_token,
+                amount=amount, chain_id=chain_id, venue_id=venue_id,
+            )
+            return json.dumps(_dump(q))
+        except AgentError as e:
+            return _handle_agent_error(e)
+
+    register_tool(ToolEntry(
+        name="get_swap_quote",
+        description="Get a DEX swap quote.",
+        access="auth",
+        parameters=[
+            ToolParam(name="input_token", type="string", required=True, description="Input token"),
+            ToolParam(name="output_token", type="string", required=True, description="Output token"),
+            ToolParam(name="amount", type="number", required=True, description="Input amount"),
+            ToolParam(name="chain_id", type="integer", required=True, description="EVM chain id"),
+            ToolParam(name="venue_id", type="string", required=False, description="Optional specific venue"),
+            _APIKEY,
+        ],
+    ))
+
+    @server.tool()
+    async def execute_swap(
+        input_token: str, output_token: str, amount: float,
+        chain_id: int, wallet_address: str,
+        slippage: float = 1.0, venue_id: str | None = None,
+        confirm: bool = False,
+        api_key: str = "",
+    ) -> str:
+        """Execute a swap. Requires confirm=true. Full 6-step flow with
+        client-side signing; SDK never sees keys."""
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            from src.models.domain import OrderIntent
+            from src.services.order_executor import execute_one
+            from src.shared.errors import ConfirmationRequired
+            if not confirm:
+                raise ConfirmationRequired(
+                    "DEX swaps require confirm=true.",
+                    suggestion="Re-invoke with confirm=true.",
+                )
+            side = "sell" if output_token.upper() == "USDC" else "buy"
+            symbol = input_token if side == "sell" else output_token
+            intent = OrderIntent(action="enter", side=side, symbol=symbol,
+                                 amount=amount, reason="user-initiated")
+            trade = execute_one(intent, mode="live",
+                                wallet_address=wallet_address,
+                                chain_id=chain_id, venue_id=venue_id)
+            return json.dumps({
+                "tx_hash": trade.tx_hash, "status": trade.status,
+                "input_token": trade.input_token, "input_amount": trade.input_amount,
+                "output_token": trade.output_token, "output_amount": trade.output_amount,
+                "fill_price": trade.fill_price, "fees": trade.fees,
+                "trade_log_id": trade.id,
+            })
+        except AgentError as e:
+            return _handle_agent_error(e)
+
+    register_tool(ToolEntry(
+        name="execute_swap",
+        description="Execute a DEX swap (requires confirm=true). Single code path shared with cron-driven trades.",
+        access="auth",
+        parameters=[
+            ToolParam(name="input_token", type="string", required=True, description="Input token"),
+            ToolParam(name="output_token", type="string", required=True, description="Output token"),
+            ToolParam(name="amount", type="number", required=True, description="Input amount"),
+            ToolParam(name="chain_id", type="integer", required=True, description="EVM chain id"),
+            ToolParam(name="wallet_address", type="string", required=True, description="Wallet from local store"),
+            ToolParam(name="slippage", type="number", required=False, description="Slippage % (default 1.0)"),
+            ToolParam(name="venue_id", type="string", required=False, description="Optional specific venue"),
+            ToolParam(name="confirm", type="boolean", required=True, description="Must be true"),
+            _APIKEY,
+        ],
+    ))
+
+
+# ---------------------------------------------------------------------------
+# Market data (auth)
+# ---------------------------------------------------------------------------
+
+
+def _register_market(server: FastMCP) -> None:
+    @server.tool()
+    async def get_ohlcv(symbol: str, timeframe: str = "1h",
+                        lookback_days: int = 30, api_key: str = "") -> str:
+        """OHLCV bars for an asset."""
+        if not _require(api_key):
+            return _auth_error()
+        from src.shared.clients.mangrove import mangroveai_client
+        try:
+            result = mangroveai_client().crypto_assets.get_ohlcv(
+                symbol=symbol, timeframe=timeframe, days=lookback_days,
+            )
+        except TypeError:
+            result = mangroveai_client().crypto_assets.get_ohlcv(symbol)
+        return json.dumps(_dump(result))
+
+    register_tool(ToolEntry(
+        name="get_ohlcv",
+        description="OHLCV bars for an asset.",
+        access="auth",
+        parameters=[
+            ToolParam(name="symbol", type="string", required=True, description="Asset symbol"),
+            ToolParam(name="timeframe", type="string", required=False, description="1m | 5m | 15m | 1h | 4h | 1d"),
+            ToolParam(name="lookback_days", type="integer", required=False, description="History window in days"),
+            _APIKEY,
+        ],
+    ))
+
+    @server.tool()
+    async def get_market_data(symbol: str, api_key: str = "") -> str:
+        """Current market data for an asset."""
+        if not _require(api_key):
+            return _auth_error()
+        from src.shared.clients.mangrove import mangroveai_client
+        return json.dumps(_dump(mangroveai_client().crypto_assets.get_market_data(symbol)))
+
+    register_tool(ToolEntry(
+        name="get_market_data",
+        description="Current price, market cap, volume, 24h/7d change.",
+        access="auth",
+        parameters=[
+            ToolParam(name="symbol", type="string", required=True, description="Asset symbol"),
+            _APIKEY,
+        ],
+    ))
+
+
+# ---------------------------------------------------------------------------
+# Signals (auth)
+# ---------------------------------------------------------------------------
+
+
+def _register_signals(server: FastMCP) -> None:
+    @server.tool()
+    async def list_signals(category: str | None = None, search: str | None = None,
+                           limit: int = 50, api_key: str = "") -> str:
+        """List available signals (optionally filtered by category or search)."""
+        if not _require(api_key):
+            return _auth_error()
+        from src.shared.clients.mangrove import mangroveai_client
+        client = mangroveai_client()
+        if search:
+            from mangroveai.models import SearchSignalsRequest
+            page = client.signals.search(SearchSignalsRequest(query=search, limit=limit))
+        else:
+            page = client.signals.list(limit=limit)
+        items = [_dump(s) for s in getattr(page, "items", [])]
+        if category:
+            items = [s for s in items if (s.get("category") or "").lower() == category.lower()]
+        return json.dumps({"items": items, "total": getattr(page, "total", len(items))})
+
+    register_tool(ToolEntry(
+        name="list_signals",
+        description="List / search available signals.",
+        access="auth",
+        parameters=[
+            ToolParam(name="category", type="string", required=False, description="Filter by category"),
+            ToolParam(name="search", type="string", required=False, description="Search query"),
+            ToolParam(name="limit", type="integer", required=False, description="Max results"),
+            _APIKEY,
+        ],
+    ))
+
+
+# ---------------------------------------------------------------------------
+# Strategy (auth)
+# ---------------------------------------------------------------------------
+
+
+def _register_strategy(server: FastMCP) -> None:
+    @server.tool()
+    async def create_strategy_autonomous(
+        goal: str, asset: str, timeframe: str,
+        candidate_count: int = 7, backtest_lookback_months: int = 3,
+        seed: int | None = None, api_key: str = "",
+    ) -> str:
+        """Autonomous strategy creation: goal → candidates → backtest → rank → winner."""
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            from src.services.strategy_service import (
+                StrategyAutonomousRequest,
+                create_autonomous,
+            )
+            detail, report = create_autonomous(StrategyAutonomousRequest(
+                goal=goal, asset=asset, timeframe=timeframe,
+                candidate_count=candidate_count,
+                backtest_lookback_months=backtest_lookback_months,
+                seed=seed,
+            ))
+            return json.dumps({"strategy": detail.model_dump(mode="json"),
+                               "generation_report": report})
+        except AgentError as e:
+            return _handle_agent_error(e)
+
+    register_tool(ToolEntry(
+        name="create_strategy_autonomous",
+        description="Create a strategy from a natural-language goal.",
+        access="auth",
+        parameters=[
+            ToolParam(name="goal", type="string", required=True, description="Natural-language goal"),
+            ToolParam(name="asset", type="string", required=True, description="Asset symbol"),
+            ToolParam(name="timeframe", type="string", required=True, description="1m | 5m | 15m | 1h | 4h | 1d"),
+            ToolParam(name="candidate_count", type="integer", required=False, description="5-10"),
+            ToolParam(name="backtest_lookback_months", type="integer", required=False, description="Default 3"),
+            ToolParam(name="seed", type="integer", required=False, description="Reproducibility seed"),
+            _APIKEY,
+        ],
+    ))
+
+    @server.tool()
+    async def create_strategy_manual(
+        name: str, asset: str, timeframe: str,
+        entry: list[dict], exit: list[dict] | None = None,
+        execution_config: dict | None = None, api_key: str = "",
+    ) -> str:
+        """Manual strategy creation with explicit rules."""
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            from src.services.strategy_service import (
+                StrategyManualRequest,
+                create_manual,
+            )
+            detail = create_manual(StrategyManualRequest(
+                name=name, asset=asset, timeframe=timeframe,
+                entry=entry, exit=exit or [],
+                execution_config=execution_config,
+            ))
+            return json.dumps(detail.model_dump(mode="json"))
+        except AgentError as e:
+            return _handle_agent_error(e)
+
+    register_tool(ToolEntry(
+        name="create_strategy_manual",
+        description="Create a strategy with explicit entry/exit rules.",
+        access="auth",
+        parameters=[
+            ToolParam(name="name", type="string", required=True, description="Strategy name"),
+            ToolParam(name="asset", type="string", required=True, description="Asset symbol"),
+            ToolParam(name="timeframe", type="string", required=True, description="Timeframe"),
+            ToolParam(name="entry", type="array", required=True, description="Entry rules"),
+            ToolParam(name="exit", type="array", required=False, description="Exit rules"),
+            ToolParam(name="execution_config", type="object", required=False, description="Override exec params"),
+            _APIKEY,
+        ],
+    ))
+
+    @server.tool()
+    async def list_strategies(status: str | None = None, limit: int = 50,
+                              offset: int = 0, api_key: str = "") -> str:
+        """List strategies, optionally filtered by status."""
+        if not _require(api_key):
+            return _auth_error()
+        from src.services.strategy_service import list_strategies as svc
+        items = svc(status=status, limit=limit, offset=offset)
+        return json.dumps([s.model_dump(mode="json") for s in items])
+
+    register_tool(ToolEntry(
+        name="list_strategies",
+        description="List strategies.",
+        access="auth",
+        parameters=[
+            ToolParam(name="status", type="string", required=False, description="Filter: draft|inactive|paper|live|archived"),
+            ToolParam(name="limit", type="integer", required=False, description="Page size"),
+            ToolParam(name="offset", type="integer", required=False, description="Page offset"),
+            _APIKEY,
+        ],
+    ))
+
+    @server.tool()
+    async def get_strategy(strategy_id: str, api_key: str = "") -> str:
+        """Get a strategy by ID."""
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            from src.services.strategy_service import get_strategy as svc
+            return json.dumps(svc(strategy_id).model_dump(mode="json"))
+        except AgentError as e:
+            return _handle_agent_error(e)
+
+    register_tool(ToolEntry(
+        name="get_strategy",
+        description="Get a strategy by ID.",
+        access="auth",
+        parameters=[
+            ToolParam(name="strategy_id", type="string", required=True, description="Agent strategy UUID"),
+            _APIKEY,
+        ],
+    ))
+
+    @server.tool()
+    async def update_strategy_status(
+        strategy_id: str, status: str, confirm: bool = False,
+        allocation: dict | None = None, api_key: str = "",
+    ) -> str:
+        """Transition strategy status. live + live→inactive require confirm=true;
+        live requires an allocation block."""
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            from src.services.strategy_service import (
+                StrategyAllocationInput,
+                StrategyStatusUpdate,
+                update_status,
+            )
+            alloc = StrategyAllocationInput(**allocation) if allocation else None
+            detail = update_status(strategy_id, StrategyStatusUpdate(
+                status=status, confirm=confirm, allocation=alloc,
+            ))
+            return json.dumps(detail.model_dump(mode="json"))
+        except AgentError as e:
+            return _handle_agent_error(e)
+
+    register_tool(ToolEntry(
+        name="update_strategy_status",
+        description="Transition strategy lifecycle status.",
+        access="auth",
+        parameters=[
+            ToolParam(name="strategy_id", type="string", required=True, description="Agent strategy UUID"),
+            ToolParam(name="status", type="string", required=True, description="Target status"),
+            ToolParam(name="confirm", type="boolean", required=False, description="Required for live + live→inactive"),
+            ToolParam(name="allocation", type="object", required=False, description="Required for live"),
+            _APIKEY,
+        ],
+    ))
+
+    @server.tool()
+    async def backtest_strategy(
+        strategy_id: str, mode: str = "full",
+        lookback_months: int = 3,
+        start_date: str | None = None, end_date: str | None = None,
+        api_key: str = "",
+    ) -> str:
+        """Run a backtest against an existing strategy (mode=quick|full)."""
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            from src.api.routes.strategies import BacktestInput, backtest
+            return json.dumps(await backtest(strategy_id, BacktestInput(
+                mode=mode, lookback_months=lookback_months,
+                start_date=start_date, end_date=end_date,
+            )))
+        except AgentError as e:
+            return _handle_agent_error(e)
+
+    register_tool(ToolEntry(
+        name="backtest_strategy",
+        description="Backtest a strategy (quick or full).",
+        access="auth",
+        parameters=[
+            ToolParam(name="strategy_id", type="string", required=True, description="Agent strategy UUID"),
+            ToolParam(name="mode", type="string", required=False, description="quick | full"),
+            ToolParam(name="lookback_months", type="integer", required=False, description="Default 3"),
+            ToolParam(name="start_date", type="string", required=False, description="ISO 8601"),
+            ToolParam(name="end_date", type="string", required=False, description="ISO 8601"),
+            _APIKEY,
+        ],
+    ))
+
+    @server.tool()
+    async def evaluate_strategy(strategy_id: str, api_key: str = "") -> str:
+        """Manually trigger a single evaluation tick."""
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            from src.api.routes.strategies import evaluate
+            return json.dumps(await evaluate(strategy_id))
+        except AgentError as e:
+            return _handle_agent_error(e)
+
+    register_tool(ToolEntry(
+        name="evaluate_strategy",
+        description="Manually trigger one evaluation tick.",
+        access="auth",
+        parameters=[
+            ToolParam(name="strategy_id", type="string", required=True, description="Agent strategy UUID"),
+            _APIKEY,
+        ],
+    ))
+
+
+# ---------------------------------------------------------------------------
+# Logs (auth)
+# ---------------------------------------------------------------------------
+
+
+def _register_logs(server: FastMCP) -> None:
+    @server.tool()
+    async def list_evaluations(strategy_id: str, limit: int = 50,
+                                offset: int = 0, api_key: str = "") -> str:
+        """Evaluation log for a strategy."""
+        if not _require(api_key):
+            return _auth_error()
+        from src.services.trade_log import list_evaluations as svc
+        return json.dumps([e.model_dump(mode="json") for e in
+                           svc(strategy_id, limit=limit, offset=offset)])
+
+    register_tool(ToolEntry(
+        name="list_evaluations",
+        description="Evaluation log for a strategy.",
+        access="auth",
+        parameters=[
+            ToolParam(name="strategy_id", type="string", required=True, description="Strategy UUID"),
+            ToolParam(name="limit", type="integer", required=False, description="Page size"),
+            ToolParam(name="offset", type="integer", required=False, description="Page offset"),
+            _APIKEY,
+        ],
+    ))
+
+    @server.tool()
+    async def list_trades(strategy_id: str, limit: int = 50,
+                          offset: int = 0, api_key: str = "") -> str:
+        """Trades for a strategy."""
+        if not _require(api_key):
+            return _auth_error()
+        from src.services.trade_log import list_trades as svc
+        return json.dumps([t.model_dump(mode="json") for t in
+                           svc(strategy_id, limit=limit, offset=offset)])
+
+    register_tool(ToolEntry(
+        name="list_trades",
+        description="Trades for a strategy.",
+        access="auth",
+        parameters=[
+            ToolParam(name="strategy_id", type="string", required=True, description="Strategy UUID"),
+            ToolParam(name="limit", type="integer", required=False, description="Page size"),
+            ToolParam(name="offset", type="integer", required=False, description="Page offset"),
+            _APIKEY,
+        ],
+    ))
+
+    @server.tool()
+    async def list_all_trades(limit: int = 50,
+                               strategy_id: str | None = None,
+                               mode: str | None = None,
+                               api_key: str = "") -> str:
+        """All trades across strategies."""
+        if not _require(api_key):
+            return _auth_error()
+        from src.services.trade_log import list_all_trades as svc
+        return json.dumps([t.model_dump(mode="json") for t in
+                           svc(limit=limit, strategy_id=strategy_id, mode=mode)])  # type: ignore[arg-type]
+
+    register_tool(ToolEntry(
+        name="list_all_trades",
+        description="All trades across strategies (optional filters).",
+        access="auth",
+        parameters=[
+            ToolParam(name="limit", type="integer", required=False, description="Max results"),
+            ToolParam(name="strategy_id", type="string", required=False, description="Filter"),
+            ToolParam(name="mode", type="string", required=False, description="live | paper"),
+            _APIKEY,
+        ],
+    ))
+
+
+# ---------------------------------------------------------------------------
+# Knowledge Base (auth)
+# ---------------------------------------------------------------------------
+
+
+def _register_kb(server: FastMCP) -> None:
+    @server.tool()
+    async def kb_search(q: str, limit: int = 20, api_key: str = "") -> str:
+        """Full-text search the knowledge base."""
+        if not _require(api_key):
+            return _auth_error()
+        from src.shared.clients.mangrove import mangroveai_client
+        return json.dumps(_dump(mangroveai_client().kb.search.query(q=q, limit=limit)))
+
+    register_tool(ToolEntry(
+        name="kb_search",
+        description="Full-text KB search.",
+        access="auth",
+        parameters=[
+            ToolParam(name="q", type="string", required=True, description="Search query"),
+            ToolParam(name="limit", type="integer", required=False, description="Max results"),
+            _APIKEY,
+        ],
+    ))
+
+
+# ---------------------------------------------------------------------------
+# x402 demo (unchanged)
+# ---------------------------------------------------------------------------
+
+
+def _register_hello_mangrove(server: FastMCP) -> None:
+    @server.tool()
+    async def hello_mangrove(payment: str = "") -> str:
+        """x402 demo tool. $0.05 USDC on Base. Smoke test for the payment path."""
         if payment:
             from src.shared.x402.server import verify_and_settle_payment
             settlement = await verify_and_settle_payment(payment)
             if settlement.get("error"):
                 return json.dumps(settlement)
+            from src.services.hello_mangrove import get_hello_mangrove
             result = get_hello_mangrove()
             result["settlement"] = settlement
             return json.dumps(result)
-
         from src.shared.x402.server import build_hello_mangrove_requirements
         return json.dumps(build_hello_mangrove_requirements())
 
     register_tool(ToolEntry(
         name="hello_mangrove",
-        description="Get the hello_mangrove message. Costs $0.05 USDC on Base. Smoke test for the x402 payment path.",
+        description="x402 demo: $0.05 USDC on Base. Smoke test for the payment path.",
         access="x402",
         price="$0.05 USDC",
         network="base",
         parameters=[
             ToolParam(
                 name="payment", type="string", required=False,
-                description="Base64-encoded x402 payment signature. Call with no parameters first to get payment requirements.",
+                description="Base64-encoded x402 payment signature. Call with no parameters to get payment requirements.",
             ),
         ],
     ))

--- a/server/src/shared/auth/dependency.py
+++ b/server/src/shared/auth/dependency.py
@@ -1,0 +1,40 @@
+"""FastAPI dependency for auth-gated agent endpoints.
+
+Wraps the existing validate_api_key middleware function and translates
+its ValueError into our standard AgentError types so the central
+agent_error_handler returns the spec-shaped JSON.
+
+Usage:
+    from fastapi import Depends
+    from src.shared.auth.dependency import require_api_key
+
+    @router.get("/something", dependencies=[Depends(require_api_key)])
+    async def something(): ...
+"""
+from __future__ import annotations
+
+from fastapi import Header
+
+from src.shared.auth.middleware import validate_api_key
+from src.shared.errors import AuthInvalidApiKey, AuthMissingApiKey
+
+
+def require_api_key(x_api_key: str | None = Header(None, alias="X-API-Key")) -> str | None:
+    """FastAPI dependency: enforce X-API-Key or return the configured one.
+
+    Returns the validated key (useful for per-user logic; v1 doesn't need
+    it but routes may bind the value if they want).
+    """
+    try:
+        return validate_api_key(x_api_key)
+    except ValueError as e:
+        msg = str(e).lower()
+        if "missing" in msg:
+            raise AuthMissingApiKey(
+                "API key required.",
+                suggestion="Pass X-API-Key header with a valid key.",
+            ) from e
+        raise AuthInvalidApiKey(
+            "Invalid API key.",
+            suggestion="Check your X-API-Key header against the configured API_KEYS.",
+        ) from e

--- a/server/src/shared/errors.py
+++ b/server/src/shared/errors.py
@@ -48,7 +48,16 @@ class AgentError(Exception):
         super().__init__(message)
         self.message = message
         self.suggestion = suggestion
-        self.correlation_id = correlation_id or str(uuid.uuid4())
+        # Inherit the request-scoped correlation_id bound by
+        # CorrelationIdMiddleware, so the error body and the
+        # X-Correlation-Id response header always agree. Fall back to
+        # a fresh UUID when raised outside any request (e.g. scheduler
+        # tick started from APScheduler — has its own id bound via
+        # with_correlation_id()).
+        if correlation_id is None:
+            from src.shared.logging import _correlation_id_var
+            correlation_id = _correlation_id_var.get() or str(uuid.uuid4())
+        self.correlation_id = correlation_id
 
     def to_dict(self) -> dict:
         return {

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -6,10 +6,14 @@ os.environ["ENVIRONMENT"] = "test"
 import pytest
 from fastapi.testclient import TestClient
 
-from src.app import app
+from src.app import create_app
 
 
 @pytest.fixture
 def client():
+    # Each test gets a fresh app + fresh MCP session manager. Sharing a
+    # module-global app across tests breaks because FastMCP's session
+    # manager's task group is closed after the first lifespan exit.
+    app = create_app()
     with TestClient(app) as c:
         yield c

--- a/server/tests/integration/test_dex_routes.py
+++ b/server/tests/integration/test_dex_routes.py
@@ -81,7 +81,8 @@ def client(tmp_path, monkeypatch):
     monkeypatch.setattr("src.services.order_executor.wallet_sign",
                         lambda payload, wallet_address: "0xSIGNED")
 
-    from src.app import app
+    from src.app import create_app
+    app = create_app()
     with TestClient(app) as c:
         yield c
     ss.reset_scheduler_cache()

--- a/server/tests/integration/test_dex_routes.py
+++ b/server/tests/integration/test_dex_routes.py
@@ -1,0 +1,157 @@
+"""Integration tests for DEX routes."""
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock
+
+os.environ.setdefault("ENVIRONMENT", "test")
+
+import pytest  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+_API_KEY = "test-key-1"
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    db_file = tmp_path / "dex.db"
+    from src.config import app_config
+    from src.services import scheduler_service as ss
+    from src.shared.db import sqlite as db_mod
+
+    monkeypatch.setattr(app_config, "DB_PATH", str(db_file))
+    db_mod.reset_connection()
+    ss.reset_scheduler_cache()
+
+    from src.shared.db.sqlite import get_connection, init_db
+    init_db()
+
+    # Seed a placeholder strategy row for user-initiated trades (FK target).
+    get_connection().execute(
+        """INSERT INTO strategies (id, mangrove_id, name, asset, timeframe, status,
+           entry_json, exit_json, execution_config_json, created_at, updated_at)
+           VALUES (?,?,?,?,?,?,?,?,?,?,?)""",
+        ("user-initiated", "mg-user", "user", "ETH", "1h", "paper",
+         "[]", "[]", "{}", "2026-04-20T00:00:00+00:00", "2026-04-20T00:00:00+00:00"),
+    )
+    get_connection().commit()
+
+    # Stub the markets SDK (used by routes AND order_executor).
+    sdk = MagicMock()
+
+    venue = MagicMock()
+    venue.model_dump.return_value = {"id": "uniswap-v2", "name": "Uniswap V2", "chain": "base"}
+    sdk.dex.supported_venues.return_value = [venue]
+
+    pair = MagicMock()
+    pair.model_dump.return_value = {"from_token": "USDC", "to_token": "ETH"}
+    sdk.dex.supported_pairs.return_value = [pair]
+
+    quote = MagicMock()
+    quote.model_dump.return_value = {
+        "quote_id": "q-1", "input_amount": 100.0, "output_amount": 0.04,
+        "exchange_rate": 2500.0,
+    }
+    quote.quote_id = "q-1"
+    quote.output_amount = 0.04
+    quote.exchange_rate = 2500.0
+    quote.venue_fee = 0.0
+    quote.mangrove_fee = 0.0
+    quote.price_impact_percent = 0.0
+    sdk.dex.get_quote.return_value = quote
+
+    sdk.dex.approve_token.return_value = None  # already approved
+
+    prepare = MagicMock()
+    prepare.payload = {"chainId": 84532, "to": "0x" + "a" * 40, "data": "0x"}
+    sdk.dex.prepare_swap.return_value = prepare
+
+    bcast = MagicMock()
+    bcast.tx_hash = "0xdeadbeef"
+    sdk.dex.broadcast.return_value = bcast
+
+    tx_status = MagicMock()
+    tx_status.status = "confirmed"
+    tx_status.block_number = 42
+    tx_status.error_message = None
+    sdk.dex.tx_status.return_value = tx_status
+
+    monkeypatch.setattr("src.api.routes.dex.mangrovemarkets_client", lambda: sdk)
+    monkeypatch.setattr("src.services.order_executor.mangrovemarkets_client", lambda: sdk)
+    monkeypatch.setattr("src.services.order_executor.wallet_sign",
+                        lambda payload, wallet_address: "0xSIGNED")
+
+    from src.app import app
+    with TestClient(app) as c:
+        yield c
+    ss.reset_scheduler_cache()
+    db_mod.reset_connection()
+
+
+def _auth() -> dict:
+    return {"X-API-Key": _API_KEY}
+
+
+def test_venues(client):
+    r = client.get("/api/v1/agent/dex/venues", headers=_auth())
+    assert r.status_code == 200
+    body = r.json()
+    assert len(body) == 1
+    assert body[0]["id"] == "uniswap-v2"
+
+
+def test_pairs(client):
+    r = client.get("/api/v1/agent/dex/pairs", params={"venue_id": "uniswap-v2"}, headers=_auth())
+    assert r.status_code == 200
+    assert r.json()[0]["from_token"] == "USDC"
+
+
+def test_quote(client):
+    r = client.post(
+        "/api/v1/agent/dex/quote",
+        headers=_auth(),
+        json={"input_token": "USDC", "output_token": "ETH", "amount": 100.0, "chain_id": 84532},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["quote_id"] == "q-1"
+    assert body["output_amount"] == 0.04
+
+
+def test_swap_requires_confirm(client):
+    r = client.post(
+        "/api/v1/agent/dex/swap",
+        headers=_auth(),
+        json={
+            "input_token": "USDC", "output_token": "ETH", "amount": 100.0,
+            "chain_id": 84532, "wallet_address": "0xabc", "confirm": False,
+        },
+    )
+    assert r.status_code == 400
+    assert r.json()["code"] == "CONFIRMATION_REQUIRED"
+
+
+def test_swap_happy_path(client):
+    r = client.post(
+        "/api/v1/agent/dex/swap",
+        headers=_auth(),
+        json={
+            "input_token": "USDC", "output_token": "ETH", "amount": 100.0,
+            "chain_id": 84532, "wallet_address": "0xabc", "confirm": True,
+        },
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["tx_hash"] == "0xdeadbeef"
+    assert body["status"] == "confirmed"
+    assert body["input_token"] == "USDC"
+    assert body["output_token"] == "ETH"
+    assert "trade_log_id" in body
+
+
+def test_auth_required_on_dex_endpoints(client):
+    assert client.get("/api/v1/agent/dex/venues").status_code == 401
+    assert client.get("/api/v1/agent/dex/pairs?venue_id=x").status_code == 401
+    assert client.post("/api/v1/agent/dex/quote",
+                       json={"input_token": "USDC", "output_token": "ETH",
+                             "amount": 1, "chain_id": 84532}).status_code == 401

--- a/server/tests/integration/test_discovery_routes.py
+++ b/server/tests/integration/test_discovery_routes.py
@@ -20,7 +20,8 @@ def client(tmp_path, monkeypatch):
     db_mod.reset_connection()
     ss.reset_scheduler_cache()
 
-    from src.app import app
+    from src.app import create_app
+    app = create_app()
     with TestClient(app) as c:
         yield c
     ss.reset_scheduler_cache()

--- a/server/tests/integration/test_discovery_routes.py
+++ b/server/tests/integration/test_discovery_routes.py
@@ -1,0 +1,85 @@
+"""Integration tests for discovery routes — /status and /tools."""
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("ENVIRONMENT", "test")
+
+import pytest  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    db_file = tmp_path / "disc.db"
+    from src.config import app_config
+    from src.services import scheduler_service as ss
+    from src.shared.db import sqlite as db_mod
+
+    monkeypatch.setattr(app_config, "DB_PATH", str(db_file))
+    db_mod.reset_connection()
+    ss.reset_scheduler_cache()
+
+    from src.app import app
+    with TestClient(app) as c:
+        yield c
+    ss.reset_scheduler_cache()
+    db_mod.reset_connection()
+
+
+def test_status_returns_expected_shape(client):
+    r = client.get("/api/v1/agent/status")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["version"] == "0.1.0"
+    assert body["wallets_count"] == 0
+    assert set(body["strategies"].keys()) == {"draft", "inactive", "paper", "live", "archived"}
+    assert body["active_cron_jobs"] == 0
+    assert "db_path" in body
+    assert body["uptime_seconds"] >= 0
+
+
+def test_status_counts_wallets_and_strategies(client):
+    from src.shared.db.sqlite import get_connection
+
+    conn = get_connection()
+    conn.execute(
+        """INSERT INTO wallets (id, address, chain, network, chain_id,
+           encrypted_secret, encryption_method, created_at)
+           VALUES (?,?,?,?,?,?,?,?)""",
+        ("w1", "0xabc", "evm", "testnet", 84532, b"ct", "fernet-v1",
+         "2026-04-20T00:00:00+00:00"),
+    )
+    for sid, status in [("s1", "paper"), ("s2", "live"), ("s3", "paper"), ("s4", "archived")]:
+        conn.execute(
+            """INSERT INTO strategies (id, mangrove_id, name, asset, timeframe, status,
+               entry_json, exit_json, execution_config_json, created_at, updated_at)
+               VALUES (?,?,?,?,?,?,?,?,?,?,?)""",
+            (sid, f"mg-{sid}", sid, "ETH", "1h", status, "[]", "[]", "{}",
+             "2026-04-20T00:00:00+00:00", "2026-04-20T00:00:00+00:00"),
+        )
+    conn.commit()
+
+    body = client.get("/api/v1/agent/status").json()
+    assert body["wallets_count"] == 1
+    assert body["strategies"]["paper"] == 2
+    assert body["strategies"]["live"] == 1
+    assert body["strategies"]["archived"] == 1
+
+
+def test_tools_returns_registered_catalog(client):
+    r = client.get("/api/v1/agent/tools")
+    assert r.status_code == 200
+    body = r.json()
+    assert "tools" in body
+    assert isinstance(body["tools"], list)
+    # hello_mangrove is registered from Phase 1; should be here.
+    names = {t["name"] for t in body["tools"]}
+    assert "hello_mangrove" in names
+
+
+def test_discovery_endpoints_do_not_require_api_key(client):
+    # No X-API-Key header.
+    assert client.get("/api/v1/agent/status").status_code == 200
+    assert client.get("/api/v1/agent/tools").status_code == 200
+    assert client.get("/health").status_code == 200

--- a/server/tests/integration/test_logs_routes.py
+++ b/server/tests/integration/test_logs_routes.py
@@ -1,0 +1,117 @@
+"""Integration tests for log query routes."""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+os.environ.setdefault("ENVIRONMENT", "test")
+
+import pytest  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+from src.models.domain import Evaluation, OrderIntent, Trade  # noqa: E402
+
+_API_KEY = "test-key-1"
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    db_file = tmp_path / "logs.db"
+    from src.config import app_config
+    from src.services import scheduler_service as ss
+    from src.shared.db import sqlite as db_mod
+
+    monkeypatch.setattr(app_config, "DB_PATH", str(db_file))
+    db_mod.reset_connection()
+    ss.reset_scheduler_cache()
+
+    from src.shared.db.sqlite import get_connection, init_db
+    init_db()
+
+    # Seed one strategy + a handful of evaluations + trades.
+    conn = get_connection()
+    conn.execute(
+        """INSERT INTO strategies (id, mangrove_id, name, asset, timeframe, status,
+           entry_json, exit_json, execution_config_json, created_at, updated_at)
+           VALUES (?,?,?,?,?,?,?,?,?,?,?)""",
+        ("s1", "mg-s1", "t", "ETH", "1h", "paper", "[]", "[]", "{}",
+         "2026-04-20T00:00:00+00:00", "2026-04-20T00:00:00+00:00"),
+    )
+    conn.commit()
+
+    from src.services.trade_log import log_evaluation, log_trade
+
+    now = datetime.now(timezone.utc)
+    for i in range(3):
+        log_evaluation(Evaluation(
+            id=str(uuid.uuid4()), strategy_id="s1",
+            timestamp=now - timedelta(minutes=i),
+            duration_ms=42, status="ok",
+        ))
+    for i, mode in enumerate(["paper", "live", "paper"]):
+        log_trade(Trade(
+            id=str(uuid.uuid4()), strategy_id="s1",
+            order_intent=OrderIntent(action="enter", side="buy", symbol="ETH", amount=0.1),
+            mode=mode,
+            tx_hash="0x" + str(i) * 40 if mode == "live" else None,
+            input_token="USDC", input_amount=100.0,
+            output_token="ETH", output_amount=0.04,
+            fill_price=2500.0, fees={},
+            status="simulated" if mode == "paper" else "confirmed",
+            executed_at=now - timedelta(minutes=i),
+        ))
+
+    from src.app import app
+    with TestClient(app) as c:
+        yield c
+    ss.reset_scheduler_cache()
+    db_mod.reset_connection()
+
+
+def _auth() -> dict:
+    return {"X-API-Key": _API_KEY}
+
+
+def test_list_evaluations(client):
+    r = client.get("/api/v1/agent/strategies/s1/evaluations", headers=_auth())
+    assert r.status_code == 200
+    body = r.json()
+    assert len(body) == 3
+    # Newest first
+    ts = [item["timestamp"] for item in body]
+    assert ts == sorted(ts, reverse=True)
+
+
+def test_list_trades_for_strategy(client):
+    r = client.get("/api/v1/agent/strategies/s1/trades", headers=_auth())
+    assert r.status_code == 200
+    assert len(r.json()) == 3
+
+
+def test_list_all_trades(client):
+    r = client.get("/api/v1/agent/trades", headers=_auth())
+    assert r.status_code == 200
+    assert len(r.json()) == 3
+
+
+def test_list_all_trades_filter_by_mode(client):
+    r = client.get("/api/v1/agent/trades", params={"mode": "live"}, headers=_auth())
+    assert r.status_code == 200
+    body = r.json()
+    assert len(body) == 1
+    assert body[0]["mode"] == "live"
+    assert body[0]["tx_hash"]
+
+
+def test_list_all_trades_filter_by_strategy(client):
+    r = client.get("/api/v1/agent/trades",
+                   params={"strategy_id": "nonexistent"}, headers=_auth())
+    assert r.status_code == 200
+    assert r.json() == []
+
+
+def test_auth_required_on_log_routes(client):
+    assert client.get("/api/v1/agent/strategies/s1/evaluations").status_code == 401
+    assert client.get("/api/v1/agent/strategies/s1/trades").status_code == 401
+    assert client.get("/api/v1/agent/trades").status_code == 401

--- a/server/tests/integration/test_logs_routes.py
+++ b/server/tests/integration/test_logs_routes.py
@@ -62,7 +62,8 @@ def client(tmp_path, monkeypatch):
             executed_at=now - timedelta(minutes=i),
         ))
 
-    from src.app import app
+    from src.app import create_app
+    app = create_app()
     with TestClient(app) as c:
         yield c
     ss.reset_scheduler_cache()

--- a/server/tests/integration/test_mcp_tools.py
+++ b/server/tests/integration/test_mcp_tools.py
@@ -1,0 +1,113 @@
+"""Integration tests for MCP tool registration — wiring, not business logic.
+
+Exhaustive business-logic tests live per-service; here we verify:
+- Every expected tool name is registered
+- Free tools bypass auth
+- Auth-gated tools reject missing/invalid api_key
+- Valid api_key reaches the tool body (end-to-end wiring)
+"""
+from __future__ import annotations
+
+import json
+import os
+
+os.environ.setdefault("ENVIRONMENT", "test")
+
+import pytest  # noqa: E402
+
+
+@pytest.fixture
+def mcp_server(tmp_path, monkeypatch):
+    db_file = tmp_path / "mcp.db"
+    from src.config import app_config
+    from src.services import scheduler_service as ss
+    from src.shared.db import sqlite as db_mod
+
+    monkeypatch.setattr(app_config, "DB_PATH", str(db_file))
+    db_mod.reset_connection()
+    ss.reset_scheduler_cache()
+
+    from src.shared.db.sqlite import init_db
+    init_db()
+
+    from src.mcp.server import create_mcp_server
+    server = create_mcp_server()
+    yield server
+    ss.reset_scheduler_cache()
+    db_mod.reset_connection()
+
+
+async def _call(server, name: str, args: dict | None = None) -> dict | list:
+    tool = server._tool_manager._tools[name]
+    result = await tool.run(args or {})
+    return json.loads(result)
+
+
+CORE_TOOLS = {
+    # discovery
+    "status", "list_tools",
+    # wallet
+    "create_wallet", "list_wallets", "get_balances",
+    # dex
+    "list_dex_venues", "get_swap_quote", "execute_swap",
+    # market
+    "get_ohlcv", "get_market_data",
+    # signals
+    "list_signals",
+    # strategy
+    "create_strategy_autonomous", "create_strategy_manual",
+    "list_strategies", "get_strategy",
+    "update_strategy_status", "backtest_strategy", "evaluate_strategy",
+    # logs
+    "list_evaluations", "list_trades", "list_all_trades",
+    # kb
+    "kb_search",
+    # x402 demo
+    "hello_mangrove",
+}
+
+
+def test_all_expected_tools_registered(mcp_server):
+    registered = set(mcp_server._tool_manager._tools.keys())
+    missing = CORE_TOOLS - registered
+    extra = registered - CORE_TOOLS
+    assert not missing, f"missing tools: {missing}"
+    # Extra is OK (template might add more later); we just don't want missing.
+    assert extra == set() or extra, f"extra tools present: {extra}"
+
+
+@pytest.mark.asyncio
+async def test_status_free_no_auth(mcp_server):
+    result = await _call(mcp_server, "status")
+    assert result["version"] == "0.1.0"
+    assert "wallets_count" in result
+
+
+@pytest.mark.asyncio
+async def test_list_tools_free_no_auth(mcp_server):
+    result = await _call(mcp_server, "list_tools")
+    assert "tools" in result
+    names = {t["name"] for t in result["tools"]}
+    # Subset check — mirrors the top-level REST tool catalog
+    for core in ("status", "create_wallet", "execute_swap", "list_strategies"):
+        assert core in names
+
+
+@pytest.mark.asyncio
+async def test_list_wallets_rejects_missing_key(mcp_server):
+    result = await _call(mcp_server, "list_wallets")
+    assert result["error"] is True
+    assert result["code"] == "AUTH_INVALID_API_KEY"
+
+
+@pytest.mark.asyncio
+async def test_list_wallets_accepts_valid_key(mcp_server):
+    result = await _call(mcp_server, "list_wallets", {"api_key": "test-key-1"})
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_list_strategies_rejects_bad_key(mcp_server):
+    result = await _call(mcp_server, "list_strategies", {"api_key": "wrong-key"})
+    assert result["error"] is True
+    assert result["code"] == "AUTH_INVALID_API_KEY"

--- a/server/tests/integration/test_passthrough_routes.py
+++ b/server/tests/integration/test_passthrough_routes.py
@@ -68,7 +68,8 @@ def client(tmp_path, monkeypatch):
     ):
         monkeypatch.setattr(path, lambda s=sdk: s)
 
-    from src.app import app
+    from src.app import create_app
+    app = create_app()
     with TestClient(app) as c:
         yield c
     ss.reset_scheduler_cache()

--- a/server/tests/integration/test_passthrough_routes.py
+++ b/server/tests/integration/test_passthrough_routes.py
@@ -1,0 +1,188 @@
+"""Integration tests for market / on-chain / signals / kb pass-through routes.
+
+We only assert wiring: each route calls the expected SDK method and
+returns the SDK's response. Behavior of the SDK itself is its own
+responsibility.
+"""
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock
+
+os.environ.setdefault("ENVIRONMENT", "test")
+
+import pytest  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+_API_KEY = "test-key-1"
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    db_file = tmp_path / "pt.db"
+    from src.config import app_config
+    from src.services import scheduler_service as ss
+    from src.shared.db import sqlite as db_mod
+
+    monkeypatch.setattr(app_config, "DB_PATH", str(db_file))
+    db_mod.reset_connection()
+    ss.reset_scheduler_cache()
+
+    sdk = MagicMock()
+
+    # crypto_assets.*
+    def _resp(payload):
+        m = MagicMock()
+        m.model_dump.return_value = payload
+        return m
+
+    sdk.crypto_assets.get_ohlcv.return_value = _resp({"candles": [{"t": 1, "o": 1, "h": 2, "l": 1, "c": 2, "v": 100}]})
+    sdk.crypto_assets.get_market_data.return_value = _resp({"data": {"current_price": 2500.0}})
+    sdk.crypto_assets.get_trending.return_value = _resp({"trending": []})
+    sdk.crypto_assets.get_global_market.return_value = _resp({"btc_dominance": 0.52})
+
+    # on_chain.*
+    sdk.on_chain.get_smart_money_sentiment.return_value = _resp({"sentiment": "bullish"})
+    sdk.on_chain.get_whale_activity.return_value = _resp({"whale": "calm"})
+    sdk.on_chain.get_token_holders.return_value = _resp({"holders": []})
+
+    # signals.*
+    sig = MagicMock()
+    sig.model_dump.return_value = {"name": "rsi_oversold", "category": "overbought_oversold"}
+    page = MagicMock()
+    page.items = [sig]
+    page.total = 1
+    sdk.signals.list.return_value = page
+    sdk.signals.search.return_value = page
+    sdk.signals.get.return_value = sig
+
+    # kb.*
+    sdk.kb.search.query.return_value = _resp({"hits": []})
+    sdk.kb.glossary.get.return_value = _resp({"term": "rsi", "definition": "relative strength index"})
+
+    for path in (
+        "src.api.routes.market.mangroveai_client",
+        "src.api.routes.on_chain.mangroveai_client",
+        "src.api.routes.signals.mangroveai_client",
+        "src.api.routes.kb.mangroveai_client",
+    ):
+        monkeypatch.setattr(path, lambda s=sdk: s)
+
+    from src.app import app
+    with TestClient(app) as c:
+        yield c
+    ss.reset_scheduler_cache()
+    db_mod.reset_connection()
+
+
+def _auth() -> dict:
+    return {"X-API-Key": _API_KEY}
+
+
+# -- market ------------------------------------------------------------------
+
+
+def test_ohlcv(client):
+    r = client.get("/api/v1/agent/market/ohlcv",
+                   params={"symbol": "BTC", "timeframe": "1h", "lookback_days": 7},
+                   headers=_auth())
+    assert r.status_code == 200
+    assert "candles" in r.json()
+
+
+def test_market_data(client):
+    r = client.get("/api/v1/agent/market/data", params={"symbol": "ETH"}, headers=_auth())
+    assert r.status_code == 200
+    assert r.json()["data"]["current_price"] == 2500.0
+
+
+def test_trending(client):
+    r = client.get("/api/v1/agent/market/trending", headers=_auth())
+    assert r.status_code == 200
+    assert "trending" in r.json()
+
+
+def test_global_market(client):
+    r = client.get("/api/v1/agent/market/global", headers=_auth())
+    assert r.status_code == 200
+    assert r.json()["btc_dominance"] == 0.52
+
+
+# -- on-chain ---------------------------------------------------------------
+
+
+def test_smart_money(client):
+    r = client.get("/api/v1/agent/on-chain/smart-money",
+                   params={"symbol": "ETH", "chain": "ethereum"}, headers=_auth())
+    assert r.status_code == 200
+    assert r.json()["sentiment"] == "bullish"
+
+
+def test_whale_activity(client):
+    r = client.get("/api/v1/agent/on-chain/whale-activity",
+                   params={"symbol": "BTC"}, headers=_auth())
+    assert r.status_code == 200
+
+
+def test_token_holders(client):
+    r = client.get("/api/v1/agent/on-chain/token-holders/ETH", headers=_auth())
+    assert r.status_code == 200
+
+
+# -- signals ----------------------------------------------------------------
+
+
+def test_list_signals(client):
+    r = client.get("/api/v1/agent/signals", headers=_auth())
+    assert r.status_code == 200
+    body = r.json()
+    assert body["total"] == 1
+    assert body["items"][0]["name"] == "rsi_oversold"
+
+
+def test_list_signals_filters_by_category(client):
+    r = client.get("/api/v1/agent/signals", params={"category": "breakout"}, headers=_auth())
+    assert r.status_code == 200
+    # Only item is category overbought_oversold → filtered out
+    assert r.json()["items"] == []
+
+
+def test_get_signal(client):
+    r = client.get("/api/v1/agent/signals/rsi_oversold", headers=_auth())
+    assert r.status_code == 200
+    assert r.json()["name"] == "rsi_oversold"
+
+
+# -- kb ---------------------------------------------------------------------
+
+
+def test_kb_search(client):
+    r = client.get("/api/v1/agent/kb/search", params={"q": "RSI"}, headers=_auth())
+    assert r.status_code == 200
+
+
+def test_kb_glossary(client):
+    r = client.get("/api/v1/agent/kb/glossary/rsi", headers=_auth())
+    assert r.status_code == 200
+    assert r.json()["term"] == "rsi"
+
+
+# -- auth enforcement -------------------------------------------------------
+
+
+def test_auth_required_on_all_passthrough_routes(client):
+    endpoints = [
+        "/api/v1/agent/market/ohlcv?symbol=BTC",
+        "/api/v1/agent/market/data?symbol=BTC",
+        "/api/v1/agent/market/trending",
+        "/api/v1/agent/market/global",
+        "/api/v1/agent/on-chain/smart-money?symbol=ETH",
+        "/api/v1/agent/on-chain/whale-activity?symbol=ETH",
+        "/api/v1/agent/on-chain/token-holders/ETH",
+        "/api/v1/agent/signals",
+        "/api/v1/agent/signals/rsi_oversold",
+        "/api/v1/agent/kb/search?q=x",
+        "/api/v1/agent/kb/glossary/rsi",
+    ]
+    for ep in endpoints:
+        assert client.get(ep).status_code == 401, f"{ep} should require auth"

--- a/server/tests/integration/test_scheduler_nonblocking.py
+++ b/server/tests/integration/test_scheduler_nonblocking.py
@@ -61,7 +61,8 @@ def tmp_db(tmp_path, monkeypatch):
 
 def test_in_flight_tick_does_not_block_requests(tmp_db):
     """HTTP /health stays fast while a 3-second tick is running."""
-    from src.app import app
+    from src.app import create_app
+    app = create_app()
     from src.services import scheduler_service as ss
 
     _SLOW_TICK_DONE.clear()

--- a/server/tests/integration/test_strategy_routes.py
+++ b/server/tests/integration/test_strategy_routes.py
@@ -65,7 +65,8 @@ def client(tmp_path, monkeypatch):
     ):
         monkeypatch.setattr(path, lambda s=sdk: s)
 
-    from src.app import app
+    from src.app import create_app
+    app = create_app()
     with TestClient(app) as c:
         yield c
     ss.reset_scheduler_cache()

--- a/server/tests/integration/test_strategy_routes.py
+++ b/server/tests/integration/test_strategy_routes.py
@@ -1,0 +1,209 @@
+"""Integration tests for strategy routes."""
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock
+
+os.environ.setdefault("ENVIRONMENT", "test")
+
+import pytest  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+_API_KEY = "test-key-1"
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    db_file = tmp_path / "sr.db"
+    from src.config import app_config
+    from src.services import scheduler_service as ss
+    from src.shared.db import sqlite as db_mod
+
+    monkeypatch.setattr(app_config, "DB_PATH", str(db_file))
+    db_mod.reset_connection()
+    ss.reset_scheduler_cache()
+
+    # Reuse the catalog fixture from candidate_generator tests.
+    from tests.unit.test_candidate_generator import _catalog
+
+    sdk = MagicMock()
+    sdk.signals.list_iter.side_effect = lambda **kw: iter(_catalog())
+
+    bt = MagicMock()
+    bt.success = True
+    bt.metrics = {"irr_annualized": 0.4, "win_rate": 0.6, "total_trades": 25,
+                  "sharpe_ratio": 1.5, "max_drawdown": 0.1, "net_pnl": 2500.0}
+    bt.trade_count = 25
+    bt.trade_history = [{"entry": "2026-01-01", "pnl": 10}]
+    bt.error = None
+    sdk.backtesting.run.return_value = bt
+
+    counter = {"n": 0}
+
+    def _create(_req):
+        counter["n"] += 1
+        m = MagicMock()
+        m.id = f"mg-{counter['n']}"
+        m.name = getattr(_req, "name", "x")
+        m.asset = getattr(_req, "asset", "ETH")
+        m.status = "inactive"
+        return m
+
+    sdk.strategies.create.side_effect = _create
+    sdk.strategies.update_status.return_value = MagicMock(success=True)
+
+    eval_resp = MagicMock()
+    eval_resp.order_intents = []
+    eval_resp.orders = None
+    eval_resp.model_dump.return_value = {"orders": []}
+    sdk.execution.evaluate.return_value = eval_resp
+
+    for path in (
+        "src.services.candidate_generator.mangroveai_client",
+        "src.services.backtest_service.mangroveai_client",
+        "src.services.strategy_service.mangroveai_client",
+    ):
+        monkeypatch.setattr(path, lambda s=sdk: s)
+
+    from src.app import app
+    with TestClient(app) as c:
+        yield c
+    ss.reset_scheduler_cache()
+    db_mod.reset_connection()
+
+
+def _auth() -> dict:
+    return {"X-API-Key": _API_KEY}
+
+
+def test_create_autonomous(client):
+    r = client.post(
+        "/api/v1/agent/strategies/autonomous",
+        headers=_auth(),
+        json={"goal": "momentum on ETH", "asset": "ETH", "timeframe": "1h",
+              "candidate_count": 5, "seed": 1},
+    )
+    assert r.status_code == 201
+    body = r.json()
+    assert body["strategy"]["mangrove_id"].startswith("mg-")
+    assert body["generation_report"]["candidates_tried"] == 5
+    assert body["generation_report"]["candidates_passed_filter"] >= 1
+
+
+def test_create_manual(client):
+    r = client.post(
+        "/api/v1/agent/strategies/manual",
+        headers=_auth(),
+        json={"name": "my strat", "asset": "ETH", "timeframe": "1h",
+              "entry": [{"name": "rsi_oversold", "signal_type": "TRIGGER",
+                         "timeframe": "1h", "params": {}}]},
+    )
+    assert r.status_code == 201
+    assert r.json()["asset"] == "ETH"
+
+
+def test_create_manual_bad_composition_returns_400(client):
+    r = client.post(
+        "/api/v1/agent/strategies/manual",
+        headers=_auth(),
+        json={"name": "bad", "asset": "ETH", "timeframe": "1h",
+              "entry": [
+                  {"name": "a", "signal_type": "TRIGGER"},
+                  {"name": "b", "signal_type": "TRIGGER"},
+              ]},
+    )
+    assert r.status_code == 400
+    assert r.json()["code"] == "STRATEGY_INVALID_COMPOSITION"
+
+
+def test_list_and_get(client):
+    created = client.post(
+        "/api/v1/agent/strategies/manual",
+        headers=_auth(),
+        json={"name": "s", "asset": "ETH", "timeframe": "1h",
+              "entry": [{"name": "rsi_oversold", "signal_type": "TRIGGER",
+                         "timeframe": "1h"}]},
+    ).json()
+
+    lst = client.get("/api/v1/agent/strategies", headers=_auth())
+    assert lst.status_code == 200
+    assert any(s["id"] == created["id"] for s in lst.json())
+
+    got = client.get(f"/api/v1/agent/strategies/{created['id']}", headers=_auth())
+    assert got.status_code == 200
+    assert got.json()["id"] == created["id"]
+
+
+def test_get_missing_returns_404(client):
+    r = client.get("/api/v1/agent/strategies/nope", headers=_auth())
+    assert r.status_code == 404
+    assert r.json()["code"] == "STRATEGY_NOT_FOUND"
+
+
+def test_patch_status_requires_confirm_for_live(client):
+    created = client.post(
+        "/api/v1/agent/strategies/manual",
+        headers=_auth(),
+        json={"name": "s", "asset": "ETH", "timeframe": "1h",
+              "entry": [{"name": "rsi_oversold", "signal_type": "TRIGGER",
+                         "timeframe": "1h"}]},
+    ).json()
+    client.patch(f"/api/v1/agent/strategies/{created['id']}/status",
+                 headers=_auth(), json={"status": "inactive"})
+    # inactive → live without confirm
+    r = client.patch(
+        f"/api/v1/agent/strategies/{created['id']}/status",
+        headers=_auth(),
+        json={"status": "live",
+              "allocation": {"wallet_address": "0xabc", "token": "USDC",
+                              "token_address": "0xusdc", "amount": 100}},
+    )
+    assert r.status_code == 400
+    assert r.json()["code"] == "CONFIRMATION_REQUIRED"
+
+
+def test_backtest_full(client):
+    created = client.post(
+        "/api/v1/agent/strategies/manual",
+        headers=_auth(),
+        json={"name": "s", "asset": "ETH", "timeframe": "1h",
+              "entry": [{"name": "rsi_oversold", "signal_type": "TRIGGER",
+                         "timeframe": "1h"}]},
+    ).json()
+    r = client.post(
+        f"/api/v1/agent/strategies/{created['id']}/backtest",
+        headers=_auth(),
+        json={"mode": "full", "lookback_months": 3},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["success"] is True
+    assert body["metrics"]["irr_annualized"] == 0.4
+    assert body["trade_history"] == [{"entry": "2026-01-01", "pnl": 10}]
+
+
+def test_evaluate_manual_tick(client):
+    """POST /evaluate runs a tick and returns the latest evaluation row."""
+    created = client.post(
+        "/api/v1/agent/strategies/manual",
+        headers=_auth(),
+        json={"name": "s", "asset": "ETH", "timeframe": "1h",
+              "entry": [{"name": "rsi_oversold", "signal_type": "TRIGGER",
+                         "timeframe": "1h"}]},
+    ).json()
+    # Activate to paper so tick is meaningful.
+    client.patch(f"/api/v1/agent/strategies/{created['id']}/status",
+                 headers=_auth(), json={"status": "inactive"})
+    client.patch(f"/api/v1/agent/strategies/{created['id']}/status",
+                 headers=_auth(), json={"status": "paper"})
+
+    r = client.post(f"/api/v1/agent/strategies/{created['id']}/evaluate",
+                    headers=_auth())
+    assert r.status_code == 200
+    body = r.json()
+    assert body["status"] == "ok"
+    assert body["order_count"] == 0
+
+
+def test_auth_required(client):
+    assert client.get("/api/v1/agent/strategies").status_code == 401

--- a/server/tests/integration/test_wallet_routes.py
+++ b/server/tests/integration/test_wallet_routes.py
@@ -64,7 +64,8 @@ def client(tmp_path, monkeypatch):
     monkeypatch.setattr("src.services.wallet_manager.mangrovemarkets_client", lambda: sdk)
     monkeypatch.setattr("src.api.routes.wallet.mangrovemarkets_client", lambda: sdk)
 
-    from src.app import app
+    from src.app import create_app
+    app = create_app()
     with TestClient(app) as c:
         yield c
     ss.reset_scheduler_cache()

--- a/server/tests/integration/test_wallet_routes.py
+++ b/server/tests/integration/test_wallet_routes.py
@@ -1,0 +1,176 @@
+"""Integration tests for wallet routes — auth, CRUD, SDK pass-throughs."""
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock
+
+os.environ.setdefault("ENVIRONMENT", "test")
+
+import pytest  # noqa: E402
+from eth_account import Account  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+_API_KEY = "test-key-1"
+_TEST_PRIVKEY = "0x" + "11" * 32
+_TEST_ADDRESS = Account.from_key(_TEST_PRIVKEY).address
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    db_file = tmp_path / "wr.db"
+    from src.config import app_config
+    from src.services import scheduler_service as ss
+    from src.shared.db import sqlite as db_mod
+
+    monkeypatch.setattr(app_config, "DB_PATH", str(db_file))
+    db_mod.reset_connection()
+    ss.reset_scheduler_cache()
+
+    # Stub keyring (no real keychain inside the container).
+    store: dict = {}
+    monkeypatch.setattr("keyring.get_password", lambda s, u: store.get((s, u)))
+    monkeypatch.setattr("keyring.set_password",
+                        lambda s, u, p: store.update({(s, u): p}))
+    from src.shared.crypto import fernet as f
+    f.reset_master_key_cache()
+
+    # Stub SDK for wallet create + read endpoints.
+    create_result = MagicMock()
+    create_result.address = _TEST_ADDRESS
+    create_result.private_key = _TEST_PRIVKEY
+    create_result.seed_phrase = None
+    create_result.secret = None
+
+    sdk = MagicMock()
+    sdk.wallet.create.return_value = create_result
+
+    # dex.balances
+    balances = MagicMock()
+    balances.model_dump.return_value = {"balances": [{"token": "ETH", "amount": 1.5}]}
+    sdk.dex.balances.return_value = balances
+
+    # portfolio.*
+    for attr, payload in [
+        ("value", {"total_value_usd": 1000.0}),
+        ("pnl", {"pnl_usd": 50.0}),
+        ("tokens", {"tokens": []}),
+        ("defi", {"positions": []}),
+    ]:
+        m = MagicMock()
+        m.model_dump.return_value = payload
+        setattr(sdk.portfolio, attr, MagicMock(return_value=m))
+    sdk.portfolio.history.return_value = [MagicMock(model_dump=MagicMock(return_value={"tx": "0xabc"}))]
+
+    monkeypatch.setattr("src.services.wallet_manager.mangrovemarkets_client", lambda: sdk)
+    monkeypatch.setattr("src.api.routes.wallet.mangrovemarkets_client", lambda: sdk)
+
+    from src.app import app
+    with TestClient(app) as c:
+        yield c
+    ss.reset_scheduler_cache()
+    db_mod.reset_connection()
+    f.reset_master_key_cache()
+
+
+def _auth() -> dict:
+    return {"X-API-Key": _API_KEY}
+
+
+def test_create_wallet_happy_path(client):
+    r = client.post(
+        "/api/v1/agent/wallet/create",
+        headers=_auth(),
+        json={"chain": "evm", "network": "testnet", "chain_id": 84532, "label": "test"},
+    )
+    assert r.status_code == 201
+    body = r.json()
+    assert body["address"] == _TEST_ADDRESS
+    assert body["chain"] == "evm"
+    assert body["seed_phrase"] == _TEST_PRIVKEY  # one-time return
+    assert "chat transcript" in body["warning"]
+
+
+def test_create_wallet_xrpl_returns_501(client):
+    r = client.post(
+        "/api/v1/agent/wallet/create",
+        headers=_auth(),
+        json={"chain": "xrpl", "network": "testnet"},
+    )
+    assert r.status_code == 501
+    assert r.json()["code"] == "CHAIN_NOT_SUPPORTED_IN_V1"
+
+
+def test_auth_required(client):
+    r = client.post(
+        "/api/v1/agent/wallet/create",
+        json={"chain": "evm", "network": "testnet", "chain_id": 84532},
+    )
+    assert r.status_code == 401
+    assert r.json()["code"] in {"AUTH_MISSING_API_KEY", "AUTH_INVALID_API_KEY"}
+
+
+def test_auth_rejects_bad_key(client):
+    r = client.post(
+        "/api/v1/agent/wallet/create",
+        headers={"X-API-Key": "wrong-key"},
+        json={"chain": "evm", "network": "testnet", "chain_id": 84532},
+    )
+    assert r.status_code == 401
+    assert r.json()["code"] == "AUTH_INVALID_API_KEY"
+
+
+def test_list_wallets_redacts_secrets(client):
+    client.post(
+        "/api/v1/agent/wallet/create",
+        headers=_auth(),
+        json={"chain": "evm", "network": "testnet", "chain_id": 84532, "label": "a"},
+    )
+    r = client.get("/api/v1/agent/wallet/list", headers=_auth())
+    assert r.status_code == 200
+    items = r.json()
+    assert len(items) == 1
+    for forbidden in ("secret", "seed_phrase", "private_key", "encrypted_secret"):
+        assert forbidden not in items[0]
+
+
+def test_balances_passes_through_to_sdk(client):
+    r = client.get(
+        f"/api/v1/agent/wallet/{_TEST_ADDRESS}/balances",
+        params={"chain_id": 84532},
+        headers=_auth(),
+    )
+    assert r.status_code == 200
+    assert r.json() == {"balances": [{"token": "ETH", "amount": 1.5}]}
+
+
+def test_portfolio_aggregates_sdk_calls(client):
+    r = client.get(
+        f"/api/v1/agent/wallet/{_TEST_ADDRESS}/portfolio",
+        headers=_auth(),
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert set(body.keys()) == {"value", "pnl", "tokens", "defi"}
+    assert body["value"] == {"total_value_usd": 1000.0}
+
+
+def test_history_passes_through_to_sdk(client):
+    r = client.get(
+        f"/api/v1/agent/wallet/{_TEST_ADDRESS}/history",
+        params={"limit": 10},
+        headers=_auth(),
+    )
+    assert r.status_code == 200
+    assert r.json() == [{"tx": "0xabc"}]
+
+
+def test_correlation_id_on_error_response(client):
+    """Auth-rejected responses carry the spec-shaped error body with correlation_id."""
+    r = client.post(
+        "/api/v1/agent/wallet/create",
+        json={"chain": "evm", "network": "testnet", "chain_id": 84532},
+    )
+    body = r.json()
+    assert body["error"] is True
+    assert "correlation_id" in body
+    assert r.headers.get("x-correlation-id") == body["correlation_id"]


### PR DESCRIPTION
## Summary

Implements Phase 4 (7 tasks) of \`docs/implementation-plan.md\`. Every agent capability is now reachable via REST and MCP. This is the phase where the work finally becomes user-facing.

## Tasks

| # | Task | What it adds |
|---|------|--------------|
| 4.1 | Discovery | \`/status\`, \`/tools\` (free). Counts wallets, strategies-by-status, active cron jobs. |
| 4.2 | Wallet + auth dep | \`create/list/balances/portfolio/history\` + \`shared/auth/dependency.py\` |
| 4.3 | DEX | \`venues/pairs/quote/swap\`. \`/swap\` reuses \`order_executor.execute_one\` — same code as cron. |
| 4.4 | Pass-throughs | market (4), on-chain (3), signals (2), KB (2) — no wrapper services. |
| 4.5 | Strategy | autonomous, manual, list/get, patch-status, backtest, evaluate |
| 4.6 | Logs | evaluations, trades, all_trades |
| 4.7 | MCP registration | 22 core tools + hello_mangrove all mirror REST routes |

## Test results

\`\`\`
docker run ... pytest tests/
======================= 210 passed, 4 warnings in 5.86s ========================
\`\`\`

- **53 new integration tests** across the 7 route modules + MCP
- **157 Phase 1-3 tests** still passing

## Bug caught during Phase 4

\`AgentError\` was auto-generating a fresh UUID when raised — so the error body's \`correlation_id\` didn't match the response header's. Fixed to inherit the request-scoped id from the logging contextvar when raised inside a request. Test added to \`test_wallet_routes.py\` to enforce.

## Architectural discipline held

- No wrapper services for pass-through routes — they call SDK clients directly.
- \`/dex/swap\` and the cron tick share ONE execution path (\`order_executor.execute_one\`). No duplicate signing/quote code.
- MCP tools call the same service functions the REST routes do. Business logic lives in one place.
- All auth-gated routes use the shared \`require_api_key\` FastAPI dependency + the standard \`agent_error_handler\`.
- Every request carries a correlation_id; errors inherit it; responses echo it.

## Smoke tested

- \`docker compose up --build\`: container starts clean
- \`curl /api/v1/agent/tools -H X-API-Key: dev-key-1\`: returns 23 tools (22 core + hello_mangrove)
- Structured log events fire on startup: \`db.migrated\`, \`scheduler.started\`, \`app.startup\`

## Out of scope

- E2E testnet/mainnet swaps (Phase 5.3 / 5.4)
- README polish and verify-quickstart script (Phase 6.1)

## Test plan (reviewer)

- [x] \`pytest tests/\` shows 210 passed
- [x] \`ruff check server/\` clean
- [x] \`docker compose up --build\` boots cleanly
- [x] \`curl /api/v1/agent/tools\` with valid X-API-Key returns catalog

🤖 Generated with [Claude Code](https://claude.com/claude-code)