### PR TITLE
chore/fix: gitignore .mcp.json, fresh-clone Stage 0 routing, backtest timeframe+window fixes

### DIFF
--- a/.claude/hooks/check-onboard.sh
+++ b/.claude/hooks/check-onboard.sh
@@ -1,24 +1,54 @@
 #!/bin/bash
-# Checks whether the user has completed onboarding on THIS machine.
+# SessionStart hook — routes the agent to the correct first action.
 #
-# Onboarding state is tracked via a gitignored marker file at
-# .claude/.onboarded. This is intentionally per-user / per-clone state,
-# not something that lives in the repo, so that anyone who clones a repo
-# previously onboarded by someone else is still prompted to onboard
-# themselves (the repo's CLAUDE.md may contain the maintainer's context,
-# which is not the cloner's).
+# This repo ships a ready-to-run Mangrove trading bot. The default path
+# for a fresh clone is:
+#   1. Read .claude/rules/trading-bot-workflow.md
+#   2. Eager-load the full MCP toolset
+#   3. Call list_wallets + list_strategies to detect fresh state
+#   4. If fresh, deliver Stage 0 greeter (security primer + wallet fork)
 #
-# If the marker is missing: inject a system reminder telling the agent to
-# run /onboard before anything else.
+# The /onboard skill is a SEPARATE path for users who want to rebrand the
+# template into a different app (NOT a trading bot). It must be invoked
+# explicitly by the user — never auto-fired on a fresh clone, or workshop
+# attendees get routed into a 4-phase design flow they don't need.
 #
-# If the marker is present: inject the Project Context from CLAUDE.md so
-# the agent picks up the user's configured identity + project immediately.
+# A gitignored marker file at .claude/.onboarded indicates the user has
+# explicitly run /onboard. If present, the hook surfaces the committed
+# Project Context (their persona + project identity) so the rebrand
+# persists across sessions. If absent, the hook tells the agent: you're
+# the trading bot — go to Stage 0.
 
 MARKER=".claude/.onboarded"
 CLAUDE_FILE="CLAUDE.md"
 
 if [ ! -f "$MARKER" ]; then
-  echo "ONBOARDING REQUIRED: This clone has not been onboarded on this machine. The Project Context you may see in CLAUDE.md belongs to whoever last committed to this repo, not to the current user. You MUST run /onboard before doing anything else. Do not skip this step. Greet the user warmly and begin the onboarding conversation."
+  cat <<'EOF'
+FRESH CLONE — TRADING BOT MODE.
+
+This repo is a ready-to-run Mangrove trading bot. Your first actions:
+
+1. Read .claude/rules/trading-bot-workflow.md — specifically the
+   "Stage 0 — First-run greeting" section.
+2. Eager-load the full MCP toolset per that rule file.
+3. Call list_wallets and list_strategies to determine trigger state.
+4. If list_wallets is empty, deliver the Stage 0 greeter exactly as
+   the rule specifies: brief introduction, the 6-bullet security
+   primer, a status sanity check, then ask "existing wallet or new?"
+5. Proceed per the user's answer.
+
+DO NOT invoke the /onboard skill. That skill is only for users who
+explicitly want to rebrand this template into a DIFFERENT project
+(not a trading bot). Workshop attendees and trading-bot users never
+need it. If you feel tempted to invoke /onboard on a fresh clone,
+stop and re-read this message.
+
+Your default persona is the one described in trading-bot-workflow.md
+(concise, security-conscious, strategy-first). Any CLAUDE.md
+"Default Persona" block that says "product owner" is template
+boilerplate from the rebrand path — ignore it unless .claude/.onboarded
+exists.
+EOF
   exit 0
 fi
 
@@ -27,15 +57,17 @@ if [ ! -f "$CLAUDE_FILE" ]; then
   exit 0
 fi
 
-# Extract everything after "## Project Context" until the next ## or EOF
+# Rebrand path: marker present means user has explicitly run /onboard.
+# Surface the Project Context they configured so the rebrand persona
+# and project identity carry across sessions.
 CONTEXT=$(awk '/^## Project Context/{found=1; next} /^## /{if(found) exit} found{print}' "$CLAUDE_FILE" \
   | grep -v '^$' \
   | grep -v '^<!--')
 
 if [ -z "$CONTEXT" ]; then
-  echo "Onboarding marker is present but Project Context in CLAUDE.md is empty. Re-run /onboard to repopulate, or remove .claude/.onboarded to start over."
+  echo "Onboarding marker is present but Project Context in CLAUDE.md is empty. Re-run /onboard to repopulate, or remove .claude/.onboarded to return to default trading-bot mode."
 else
-  echo "Project is onboarded. Context: $CONTEXT"
+  echo "User has run /onboard — using their rebrand context: $CONTEXT"
 fi
 
 exit 0

--- a/.claude/skills/onboard/SKILL.md
+++ b/.claude/skills/onboard/SKILL.md
@@ -1,22 +1,38 @@
 ---
 name: onboard
 description: >-
-  Use on first session in a fresh app-in-a-box repo. Guides the user through
-  project setup via conversation — learns what they're building, who they are,
-  and what kind of helper they want. The agent creates a persona for itself,
-  names itself, and becomes that helper for all future sessions. Populates
-  branding.json and the Project Context section of CLAUDE.md.
+  REBRAND PATH ONLY. Invoke ONLY when the user explicitly wants to rebrand
+  this template into a DIFFERENT project (not the default Mangrove trading
+  bot). Phrases that signal this: "I want to fork this template", "rebrand
+  this into my own app", "I'm building something else on top of this", or
+  the user types "/onboard" as an explicit slash command. NEVER auto-fire
+  on a fresh clone — fresh-clone users get the Stage 0 greeter in
+  .claude/rules/trading-bot-workflow.md instead. When invoked, guides the
+  user through project identity, creates an agent persona, and populates
+  branding.json + CLAUDE.md Project Context.
 ---
 
-# Onboarding
+# Onboarding (REBRAND PATH ONLY)
 
-Welcome the user to app-in-a-box. This skill runs once — on the first Claude session in a fresh repo.
+This skill transforms the trading-bot template into a different project. Use it only when the user has explicitly asked to rebrand or fork.
+
+**If the user is a trading-bot user (workshop attendee, operator running the bot that ships in this repo), DO NOT use this skill.** Their default path is the Stage 0 greeter in `.claude/rules/trading-bot-workflow.md`, which the SessionStart hook routes fresh clones to automatically.
+
+## When to invoke
+
+Only when the user explicitly says something like:
+- "I want to fork this template and build a different app"
+- "Help me rebrand this into a [non-trading-bot use case]"
+- "I'm using this as a scaffold for my own project"
+- Or the user types `/onboard` as an explicit slash command.
+
+If none of those have happened, do not invoke. Default to trading-bot mode.
 
 ## Detection
 
-The `SessionStart` hook (`/.claude/hooks/check-onboard.sh`) checks whether the **Project Context** section in `CLAUDE.md` has content. If it's empty, the hook injects a system reminder telling you to run this skill immediately.
+The `SessionStart` hook (`.claude/hooks/check-onboard.sh`) no longer auto-routes to this skill on fresh clones — it routes to the Stage 0 greeter. The marker file `.claude/.onboarded` is written by Phase 4 of this skill ONLY when a user has deliberately walked the rebrand flow, so fresh-clone users skip onboarding entirely.
 
-**You are onboarded when:** the Project Context section in CLAUDE.md contains the user's project info and your agent identity. If that section has content, do NOT re-run onboarding — just be yourself and pick up where you left off.
+**You are onboarded when:** `.claude/.onboarded` exists AND the Project Context section in CLAUDE.md contains user-supplied content. If both are true, do NOT re-run onboarding — just be yourself and pick up where you left off.
 
 ## Phase 1: Get to Know the User
 

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,11 @@ docker-compose.override.yml
 # intentionally NOT committed -- each clone re-onboards on first run.
 .claude/.onboarded
 
+# Claude Code MCP registration. Written by scripts/setup-mcp.sh into the
+# user's ~/.claude.json (user scope) and also as a convenience copy at
+# the repo root. Per-user state — never committed.
+.mcp.json
+
 # Internal docs (not for public repo)
 TEMPLATE-REVIEW.md
 ROADMAP.md

--- a/server/src/api/routes/strategies.py
+++ b/server/src/api/routes/strategies.py
@@ -86,10 +86,38 @@ async def update_status(strategy_id: str, req: StrategyStatusUpdate) -> Strategy
 
 
 class BacktestInput(BaseModel):
+    """Parameters for POST /strategies/{id}/backtest.
+
+    Mirrors the MangroveAI BacktestRequest surface so this route and the
+    MCP tool pass through the same knobs a direct SDK or curl caller would
+    use. Only window-selection has special resolution; everything else is
+    pass-through to the server.
+
+    Lookback window resolution — first non-null group wins:
+      1. start_date + end_date (ISO 8601)
+      2. lookback_hours
+      3. lookback_days
+      4. lookback_months
+      5. timeframes.recommended_lookback_months(strategy.timeframe)
+         (5m/15m/30m/1h → 3 mo, 4h → 6 mo, 1d → 12 mo)
+    """
     mode: str = "full"  # quick | full
-    lookback_months: int = 3
+
+    # Window selection. Leave all null to get timeframe-aware defaults.
+    lookback_months: int | None = None
+    lookback_days: int | None = None
+    lookback_hours: int | None = None
     start_date: str | None = None
     end_date: str | None = None
+
+    # Optional server-side overrides (omit to use trading_defaults.json).
+    slippage_pct: float | None = None
+    fee_pct: float | None = None
+    max_hold_time_hours: int | None = None
+    # Free-form overrides merged into _DEFAULT_EXECUTION_CONFIG (e.g.
+    # initial_balance, max_risk_per_trade). Keys must match MangroveAI's
+    # BacktestRequest field names.
+    overrides: dict | None = None
 
 
 @router.post(
@@ -108,30 +136,55 @@ async def backtest(strategy_id: str, req: BacktestInput) -> dict:
         exit=detail.exit,
     )
     if req.mode == "quick":
+        # Quick mode is summary-only; it uses the bulk path which only
+        # understands lookback_months. If the caller passed finer
+        # granularity, translate it best-effort (days → months, hours
+        # too short to make sense in quick mode — fall through to
+        # timeframe-aware default).
+        months = req.lookback_months
+        if months is None and req.lookback_days:
+            months = max(1, req.lookback_days // 30)
         results = backtest_service.quick_backtest_all(
-            [candidate], lookback_months=req.lookback_months,
+            [candidate], lookback_months=months,
         )
         result = results[0]
     else:
         result = backtest_service.full_backtest(
             candidate,
             lookback_months=req.lookback_months,
+            lookback_days=req.lookback_days,
+            lookback_hours=req.lookback_hours,
             start_date=req.start_date,
             end_date=req.end_date,
+            slippage_pct=req.slippage_pct,
+            fee_pct=req.fee_pct,
+            max_hold_time_hours=req.max_hold_time_hours,
+            overrides=req.overrides,
         )
+
+    # Pass through the FULL metrics dict from the SDK, not a hand-picked
+    # subset. Keeps this route aligned with what a direct curl or SDK
+    # call would return and surfaces upstream metrics (sortino, calmar,
+    # profit_factor, etc.) we can't anticipate here.
+    full_metrics: dict = dict(result.raw_metrics) if result.raw_metrics else {}
+    # Stable top-level aliases for existing callers + generation_report
+    # schema. Overwrite whatever shape came from the server to keep
+    # callers simple.
+    full_metrics.update({
+        "irr_annualized": result.irr_annualized,
+        "win_rate": result.win_rate,
+        "total_trades": result.total_trades,
+        "sharpe_ratio": result.sharpe_ratio,
+        "max_drawdown": result.max_drawdown,
+        "net_pnl": result.net_pnl,
+    })
 
     return {
         "strategy_id": strategy_id,
         "mode": req.mode,
-        "metrics": {
-            "irr_annualized": result.irr_annualized,
-            "win_rate": result.win_rate,
-            "total_trades": result.total_trades,
-            "sharpe_ratio": result.sharpe_ratio,
-            "max_drawdown": result.max_drawdown,
-            "net_pnl": result.net_pnl,
-        },
+        "metrics": full_metrics,
         "trade_history": result.raw_metrics.get("trade_history") if req.mode == "full" else None,
+        "resolved_window": result.raw_metrics.get("resolved_window"),
         "success": result.success,
         "error": result.error,
     }

--- a/server/src/mcp/tools.py
+++ b/server/src/mcp/tools.py
@@ -396,7 +396,7 @@ def _register_market(server: FastMCP) -> None:
         access="auth",
         parameters=[
             ToolParam(name="symbol", type="string", required=True, description="Asset symbol"),
-            ToolParam(name="timeframe", type="string", required=False, description="1m | 5m | 15m | 1h | 4h | 1d"),
+            ToolParam(name="timeframe", type="string", required=False, description="5m | 15m | 30m | 1h | 4h | 1d (1m not supported)"),
             ToolParam(name="lookback_days", type="integer", required=False, description="History window in days"),
             _APIKEY,
         ],
@@ -497,9 +497,9 @@ def _register_strategy(server: FastMCP) -> None:
         parameters=[
             ToolParam(name="goal", type="string", required=True, description="Natural-language goal"),
             ToolParam(name="asset", type="string", required=True, description="Asset symbol"),
-            ToolParam(name="timeframe", type="string", required=True, description="1m | 5m | 15m | 1h | 4h | 1d"),
+            ToolParam(name="timeframe", type="string", required=True, description="5m | 15m | 30m | 1h | 4h | 1d (1m not supported)"),
             ToolParam(name="candidate_count", type="integer", required=False, description="5-10"),
-            ToolParam(name="backtest_lookback_months", type="integer", required=False, description="Default 3"),
+            ToolParam(name="backtest_lookback_months", type="integer", required=False, description="Default: auto by timeframe (5m-1h=3mo, 4h=6mo, 1d=12mo)"),
             ToolParam(name="seed", type="integer", required=False, description="Reproducibility seed"),
             _APIKEY,
         ],
@@ -535,7 +535,7 @@ def _register_strategy(server: FastMCP) -> None:
         parameters=[
             ToolParam(name="name", type="string", required=True, description="Strategy name"),
             ToolParam(name="asset", type="string", required=True, description="Asset symbol"),
-            ToolParam(name="timeframe", type="string", required=True, description="Timeframe"),
+            ToolParam(name="timeframe", type="string", required=True, description="5m | 15m | 30m | 1h | 4h | 1d (1m not supported)"),
             ToolParam(name="entry", type="array", required=True, description="Entry rules"),
             ToolParam(name="exit", type="array", required=False, description="Exit rules"),
             ToolParam(name="execution_config", type="object", required=False, description="Override exec params"),
@@ -625,32 +625,64 @@ def _register_strategy(server: FastMCP) -> None:
     @server.tool()
     async def backtest_strategy(
         strategy_id: str, mode: str = "full",
-        lookback_months: int = 3,
+        lookback_months: int | None = None,
+        lookback_days: int | None = None,
+        lookback_hours: int | None = None,
         start_date: str | None = None, end_date: str | None = None,
+        slippage_pct: float | None = None,
+        fee_pct: float | None = None,
+        max_hold_time_hours: int | None = None,
+        overrides: dict | None = None,
         api_key: str = "",
     ) -> str:
-        """Run a backtest against an existing strategy (mode=quick|full)."""
+        """Run a backtest against an existing strategy (mode=quick|full).
+
+        Window resolution (first non-null wins):
+          start_date+end_date > lookback_hours > lookback_days
+          > lookback_months > timeframes.recommended_lookback_months
+          (5m/15m/30m/1h → 3 mo, 4h → 6 mo, 1d → 12 mo).
+        """
         if not _require(api_key):
             return _auth_error()
         try:
             from src.api.routes.strategies import BacktestInput, backtest
             return json.dumps(await backtest(strategy_id, BacktestInput(
-                mode=mode, lookback_months=lookback_months,
-                start_date=start_date, end_date=end_date,
+                mode=mode,
+                lookback_months=lookback_months,
+                lookback_days=lookback_days,
+                lookback_hours=lookback_hours,
+                start_date=start_date,
+                end_date=end_date,
+                slippage_pct=slippage_pct,
+                fee_pct=fee_pct,
+                max_hold_time_hours=max_hold_time_hours,
+                overrides=overrides,
             )))
         except AgentError as e:
             return _handle_agent_error(e)
 
     register_tool(ToolEntry(
         name="backtest_strategy",
-        description="Backtest a strategy (quick or full).",
+        description=(
+            "Backtest a strategy (quick or full). Window resolution: "
+            "start_date+end_date > lookback_hours > lookback_days > "
+            "lookback_months > timeframe-aware auto (5m-1h=3mo, 4h=6mo, "
+            "1d=12mo). Returns full metrics from the SDK, trade history, "
+            "and the resolved_window block for fallback detection."
+        ),
         access="auth",
         parameters=[
             ToolParam(name="strategy_id", type="string", required=True, description="Agent strategy UUID"),
-            ToolParam(name="mode", type="string", required=False, description="quick | full"),
-            ToolParam(name="lookback_months", type="integer", required=False, description="Default 3"),
-            ToolParam(name="start_date", type="string", required=False, description="ISO 8601"),
+            ToolParam(name="mode", type="string", required=False, description="quick | full (default full)"),
+            ToolParam(name="lookback_months", type="integer", required=False, description="Window in months (auto by timeframe if all window fields omitted)"),
+            ToolParam(name="lookback_days", type="integer", required=False, description="Window in days (overrides lookback_months)"),
+            ToolParam(name="lookback_hours", type="integer", required=False, description="Window in hours (overrides lookback_days/months — use for short backtests)"),
+            ToolParam(name="start_date", type="string", required=False, description="ISO 8601 — pinned with end_date, overrides all lookback_* fields"),
             ToolParam(name="end_date", type="string", required=False, description="ISO 8601"),
+            ToolParam(name="slippage_pct", type="number", required=False, description="Override server default (trading_defaults.json)"),
+            ToolParam(name="fee_pct", type="number", required=False, description="Override server default"),
+            ToolParam(name="max_hold_time_hours", type="integer", required=False, description="Cap position hold time"),
+            ToolParam(name="overrides", type="object", required=False, description="Dict merged into execution_config (initial_balance, max_risk_per_trade, etc.)"),
             _APIKEY,
         ],
     ))

--- a/server/src/services/backtest_service.py
+++ b/server/src/services/backtest_service.py
@@ -17,6 +17,7 @@ vary. We look up several common spellings and return 0.0 if none present.
 from __future__ import annotations
 
 import json
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from mangroveai.models import BacktestRequest
@@ -24,11 +25,56 @@ from pydantic import BaseModel
 
 from src.config import app_config
 from src.services.candidate_generator import StrategyCandidate
+from src.shared import timeframes
 from src.shared.clients.mangrove import mangroveai_client
 from src.shared.errors import SdkError
 from src.shared.logging import get_logger
 
 _log = get_logger(__name__)
+
+
+def _resolve_window(
+    timeframe: str,
+    lookback_months: int | None,
+    lookback_days: int | None = None,
+    lookback_hours: int | None = None,
+    start_date: str | None = None,
+    end_date: str | None = None,
+) -> tuple[int | None, str | None, str | None]:
+    """Resolve a lookback specification to (lookback_months, start_date, end_date).
+
+    Precedence (most specific first):
+      1. explicit start_date + end_date (pass-through)
+      2. lookback_hours (converted to pinned ISO window ending now)
+      3. lookback_days (same)
+      4. lookback_months (pass-through — server converts using 30d/month)
+      5. if none given, recommended by timeframe via
+         `timeframes.recommended_lookback_months`
+
+    Returns a tuple where the lookback_months entry is ``None`` whenever
+    explicit dates are returned (matches BacktestRequest's "dates take
+    precedence over lookback_months" contract).
+    """
+    # 1. pass-through for explicit dates
+    if start_date and end_date:
+        return None, start_date, end_date
+
+    # 2/3. hours and days → compute ISO window ending now (UTC)
+    if lookback_hours is not None and lookback_hours > 0:
+        end = datetime.now(timezone.utc)
+        start = end - timedelta(hours=lookback_hours)
+        return None, start.isoformat(), end.isoformat()
+    if lookback_days is not None and lookback_days > 0:
+        end = datetime.now(timezone.utc)
+        start = end - timedelta(days=lookback_days)
+        return None, start.isoformat(), end.isoformat()
+
+    # 4. explicit months
+    if lookback_months is not None and lookback_months > 0:
+        return lookback_months, start_date, end_date
+
+    # 5. auto by timeframe (matches MangroveAI prompt_builder.py defaults)
+    return timeframes.recommended_lookback_months(timeframe), start_date, end_date
 
 
 # Reasonable defaults for an autonomous backtest. These match the defaults
@@ -90,26 +136,53 @@ def _int_metric(metrics: dict[str, Any] | None, *keys: str, default: int = 0) ->
 
 def _build_request(
     candidate: StrategyCandidate,
-    lookback_months: int,
+    lookback_months: int | None,
     start_date: str | None = None,
     end_date: str | None = None,
+    overrides: dict[str, Any] | None = None,
+    slippage_pct: float | None = None,
+    fee_pct: float | None = None,
+    max_hold_time_hours: int | None = None,
 ) -> BacktestRequest:
-    """Build a BacktestRequest from a candidate + sensible defaults."""
+    """Build a BacktestRequest from a candidate + sensible defaults.
+
+    `overrides` is a dict that gets merged over `_DEFAULT_EXECUTION_CONFIG`
+    (account + risk fields). This is the escape hatch for callers who
+    want to tune initial_balance, max_risk_per_trade, etc. without us
+    adding each one as a first-class parameter.
+    """
+    # Always validate the candidate's timeframe — prevents 1m / other
+    # unsupported values from reaching the backend and being silently
+    # coerced to 1h.
+    interval = timeframes.canonicalize_timeframe(candidate.timeframe)
+
+    config = {**_DEFAULT_EXECUTION_CONFIG, **(overrides or {})}
+
     strategy_json = json.dumps({
         "name": candidate.name,
         "asset": candidate.asset,
         "entry": candidate.entry,
         "exit": candidate.exit or [],
     })
-    return BacktestRequest(
-        asset=candidate.asset,
-        interval=candidate.timeframe,
-        strategy_json=strategy_json,
-        **_DEFAULT_EXECUTION_CONFIG,
-        lookback_months=lookback_months if not start_date else None,
-        start_date=start_date,
-        end_date=end_date,
-    )
+    kwargs: dict[str, Any] = {
+        "asset": candidate.asset,
+        "interval": interval,
+        "strategy_json": strategy_json,
+        **config,
+        "lookback_months": lookback_months if not start_date else None,
+        "start_date": start_date,
+        "end_date": end_date,
+    }
+    # Optional pass-through fields — only include when caller provided them
+    # so we don't clobber server defaults (trading_defaults.json).
+    if slippage_pct is not None:
+        kwargs["slippage_pct"] = slippage_pct
+    if fee_pct is not None:
+        kwargs["fee_pct"] = fee_pct
+    if max_hold_time_hours is not None:
+        kwargs["max_hold_time_hours"] = max_hold_time_hours
+
+    return BacktestRequest(**kwargs)
 
 
 def _summarize(
@@ -144,7 +217,16 @@ def quick_backtest_all(
 ) -> list[CandidateBacktestResult]:
     """Run a backtest for every candidate. Per-candidate failures do not
     abort the batch — the result's .success and .error fields carry the
-    outcome."""
+    outcome.
+
+    If `lookback_months` is None, picks the timeframe-aware recommended
+    default per `timeframes.recommended_lookback_months`. All candidates
+    are assumed to share the same timeframe (they come from one
+    candidate_generator.generate() call), so the first one drives the
+    recommendation.
+    """
+    if lookback_months is None and candidates:
+        lookback_months = timeframes.recommended_lookback_months(candidates[0].timeframe)
     if lookback_months is None:
         lookback_months = int(app_config.BACKTEST_DEFAULT_LOOKBACK_MONTHS)
 
@@ -215,18 +297,50 @@ def filter_and_rank(
 def full_backtest(
     candidate: StrategyCandidate,
     lookback_months: int | None = None,
+    lookback_days: int | None = None,
+    lookback_hours: int | None = None,
     start_date: str | None = None,
     end_date: str | None = None,
+    slippage_pct: float | None = None,
+    fee_pct: float | None = None,
+    max_hold_time_hours: int | None = None,
+    overrides: dict[str, Any] | None = None,
 ) -> CandidateBacktestResult:
     """Run a full backtest — same SDK call as quick, but we also return
-    the trade_history attached to raw_metrics for downstream display."""
-    if lookback_months is None:
-        lookback_months = int(app_config.BACKTEST_DEFAULT_LOOKBACK_MONTHS)
+    the trade_history attached to raw_metrics for downstream display.
+
+    Lookback resolution (first non-null wins):
+      start_date+end_date > lookback_hours > lookback_days > lookback_months
+      > timeframes.recommended_lookback_months(candidate.timeframe).
+
+    `overrides` merges over `_DEFAULT_EXECUTION_CONFIG` for advanced
+    callers who want to tune initial_balance, max_risk_per_trade, etc.
+    slippage_pct / fee_pct / max_hold_time_hours are pass-through to the
+    SDK's BacktestRequest fields of the same name — omit to use the
+    server's trading_defaults.json values.
+    """
+    resolved_months, resolved_start, resolved_end = _resolve_window(
+        candidate.timeframe,
+        lookback_months,
+        lookback_days=lookback_days,
+        lookback_hours=lookback_hours,
+        start_date=start_date,
+        end_date=end_date,
+    )
 
     client = mangroveai_client()
     try:
         raw = client.backtesting.run(
-            _build_request(candidate, lookback_months, start_date, end_date),
+            _build_request(
+                candidate,
+                lookback_months=resolved_months,
+                start_date=resolved_start,
+                end_date=resolved_end,
+                overrides=overrides,
+                slippage_pct=slippage_pct,
+                fee_pct=fee_pct,
+                max_hold_time_hours=max_hold_time_hours,
+            ),
         )
     except Exception as e:  # noqa: BLE001
         raise SdkError(
@@ -240,6 +354,17 @@ def full_backtest(
     trade_history = getattr(raw, "trade_history", None)
     if trade_history is not None:
         summary.raw_metrics = {**summary.raw_metrics, "trade_history": trade_history}
+    # Record the resolved window so downstream callers can surface it to
+    # the user (and detect fallbacks from the server).
+    summary.raw_metrics = {
+        **summary.raw_metrics,
+        "resolved_window": {
+            "lookback_months": resolved_months,
+            "start_date": resolved_start,
+            "end_date": resolved_end,
+            "requested_timeframe": candidate.timeframe,
+        },
+    }
 
     _log.info(
         "backtest.full_completed",
@@ -247,5 +372,8 @@ def full_backtest(
         irr=summary.irr_annualized,
         win_rate=summary.win_rate,
         total_trades=summary.total_trades,
+        resolved_months=resolved_months,
+        resolved_start=resolved_start,
+        resolved_end=resolved_end,
     )
     return summary

--- a/server/src/services/strategy_service.py
+++ b/server/src/services/strategy_service.py
@@ -32,6 +32,7 @@ from src.services import (
     scheduler_service,
     trade_log,
 )
+from src.shared import timeframes
 from src.shared.clients.mangrove import mangroveai_client
 from src.shared.db.sqlite import get_connection
 from src.shared.errors import (
@@ -66,7 +67,10 @@ class StrategyAutonomousRequest(BaseModel):
     asset: str
     timeframe: str
     candidate_count: int = Field(7, ge=5, le=10)
-    backtest_lookback_months: int = 3
+    # None = auto-pick from timeframes.recommended_lookback_months(timeframe):
+    #   5m/15m/30m/1h → 3 months; 4h → 6 months; 1d → 12 months.
+    # Explicit value overrides the recommendation.
+    backtest_lookback_months: int | None = None
     seed: int | None = None  # reproducibility
 
 
@@ -216,13 +220,24 @@ def create_autonomous(req: StrategyAutonomousRequest) -> tuple[StrategyDetailRes
     Returns (strategy_detail_response, generation_report). The report is
     also persisted in the local strategies cache for audit.
     """
+    # Reject unsupported timeframes (e.g. 1m) up front — the server would
+    # otherwise silently fall back to 1h and produce misleading results.
+    timeframe = timeframes.canonicalize_timeframe(req.timeframe)
+
     candidates = candidate_generator.generate(
-        goal=req.goal, asset=req.asset, timeframe=req.timeframe,
+        goal=req.goal, asset=req.asset, timeframe=timeframe,
         n=req.candidate_count, seed=req.seed,
     )
 
+    # Use timeframe-aware recommended lookback if caller didn't specify one.
+    lookback_months = (
+        req.backtest_lookback_months
+        if req.backtest_lookback_months is not None
+        else timeframes.recommended_lookback_months(timeframe)
+    )
+
     results = backtest_service.quick_backtest_all(
-        candidates, lookback_months=req.backtest_lookback_months,
+        candidates, lookback_months=lookback_months,
     )
     survivors, rejected = backtest_service.filter_and_rank(results)
 
@@ -234,7 +249,7 @@ def create_autonomous(req: StrategyAutonomousRequest) -> tuple[StrategyDetailRes
 
     winner = survivors[0]
     full = backtest_service.full_backtest(
-        winner.candidate, lookback_months=req.backtest_lookback_months,
+        winner.candidate, lookback_months=lookback_months,
     )
 
     # Build the SDK request from the winning candidate.
@@ -287,6 +302,18 @@ def create_autonomous(req: StrategyAutonomousRequest) -> tuple[StrategyDetailRes
 
 def create_manual(req: StrategyManualRequest) -> StrategyDetailResponse:
     """Manual creation — caller supplies explicit entry/exit rules."""
+    # Reject unsupported timeframes up front. For manual strategies the
+    # timeframe is embedded in each entry/exit rule; we also accept a
+    # top-level req.timeframe which takes precedence when set.
+    if getattr(req, "timeframe", None):
+        timeframes.canonicalize_timeframe(req.timeframe)
+    else:
+        # Validate the per-rule timeframe — matches what _extract_timeframe
+        # would pull when there's no top-level field.
+        inferred = req.entry[0].get("timeframe") if req.entry else None
+        if inferred:
+            timeframes.canonicalize_timeframe(inferred)
+
     _validate_composition(req.entry, req.exit)
 
     try:

--- a/server/src/shared/timeframes.py
+++ b/server/src/shared/timeframes.py
@@ -1,0 +1,94 @@
+"""Canonical timeframe whitelist + recommended-lookback mapping.
+
+Mirrors MangroveAI's `SUPPORTED_TIMEFRAMES` (utils/time_utils.py) and the
+docstring contract in `ai_copilot/agentic/prompt_builder.py` that
+declares per-timeframe lookback defaults. This is the single source of
+truth on the app-in-a-box side so strategy creation, backtesting, and
+tool descriptions stay consistent.
+
+Upstream reference (MangroveAI):
+  utils/time_utils.py
+      SUPPORTED_TIMEFRAMES = ("5m", "15m", "30m", "1h", "4h", "1D")
+  ai_copilot/agentic/prompt_builder.py
+      "5m/15m/30m/1h: 3 months
+       4h: 6 months
+       1d: 12 months"
+
+NOTE: 1m is NOT supported. The upstream API dataclass docstring and the
+backtesting route model mention "1m" in their examples (historical noise),
+but the server's `_TIMEFRAME_TO_MINUTES` map does not contain "1m" —
+`normalize_timeframe("1m")` silently falls back to "1h". We reject 1m
+up front with a clear error so the agent doesn't create a strategy it
+can't run.
+"""
+from __future__ import annotations
+
+from src.shared.errors import ValidationError
+
+# Canonical form. "1d" and "1D" both normalize to "1d" on our side for
+# consistency; the server tolerates both via `normalize_timeframe`.
+SUPPORTED_TIMEFRAMES: tuple[str, ...] = ("5m", "15m", "30m", "1h", "4h", "1d")
+
+# Aliases the user or agent might pass — we accept any of these and
+# canonicalize before validation. Keep conservative: anything outside
+# this set is an error, not a silent normalization.
+_ALIASES: dict[str, str] = {
+    "5m": "5m", "5min": "5m", "5MIN": "5m",
+    "15m": "15m", "15min": "15m", "15MIN": "15m",
+    "30m": "30m", "30min": "30m", "30MIN": "30m",
+    "1h": "1h", "1hr": "1h", "1HR": "1h",
+    "4h": "4h", "4hr": "4h", "4HR": "4h",
+    "1d": "1d", "1D": "1d", "1day": "1d", "1DAY": "1d",
+}
+
+# Recommended default lookback per timeframe, matching upstream's
+# documented defaults. Only applied when the caller does NOT provide
+# explicit lookback_months / lookback_days / lookback_hours / start_date /
+# end_date. Caller overrides always win.
+_RECOMMENDED_LOOKBACK_MONTHS: dict[str, int] = {
+    "5m": 3,
+    "15m": 3,
+    "30m": 3,
+    "1h": 3,
+    "4h": 6,
+    "1d": 12,
+}
+
+
+def canonicalize_timeframe(tf: str | None) -> str:
+    """Normalize a timeframe string to canonical form.
+
+    Raises ValidationError if the input is missing or not in SUPPORTED_TIMEFRAMES
+    (after alias resolution).
+    """
+    if not tf:
+        raise ValidationError(
+            "timeframe is required",
+            suggestion=f"Supported: {', '.join(SUPPORTED_TIMEFRAMES)}",
+        )
+    key = str(tf).strip()
+    canonical = _ALIASES.get(key) or _ALIASES.get(key.lower()) or _ALIASES.get(key.upper())
+    if canonical is None or canonical not in SUPPORTED_TIMEFRAMES:
+        raise ValidationError(
+            f"timeframe '{tf}' is not supported",
+            suggestion=(
+                f"Supported timeframes: {', '.join(SUPPORTED_TIMEFRAMES)}. "
+                "Sub-5-minute resolutions (e.g. 1m) are not available on the "
+                "MangroveAI data source; the server would silently fall back "
+                "to 1h, producing misleading backtest results."
+            ),
+        )
+    return canonical
+
+
+def recommended_lookback_months(tf: str) -> int:
+    """Return the recommended lookback window (in months) for a given timeframe.
+
+    Matches upstream's `ai_copilot/agentic/prompt_builder.py` declared
+    defaults: shorter timeframes need shorter history; 1d needs a full year
+    to produce statistically meaningful backtests.
+
+    Raises ValidationError via canonicalize_timeframe if tf is unsupported.
+    """
+    canonical = canonicalize_timeframe(tf)
+    return _RECOMMENDED_LOOKBACK_MONTHS[canonical]

--- a/server/tests/unit/test_timeframes.py
+++ b/server/tests/unit/test_timeframes.py
@@ -1,0 +1,64 @@
+"""Unit tests for src.shared.timeframes.
+
+Covers:
+- Canonical whitelist matches upstream SUPPORTED_TIMEFRAMES.
+- 1m is explicitly rejected (the agent tried this, got silent 1h fallback).
+- Aliases resolve to canonical form.
+- recommended_lookback_months matches the upstream prompt_builder doc
+  (5m/15m/30m/1h → 3, 4h → 6, 1d → 12).
+"""
+import pytest
+
+from src.shared import timeframes
+from src.shared.errors import ValidationError
+
+
+class TestCanonicalize:
+    @pytest.mark.parametrize("tf", ["5m", "15m", "30m", "1h", "4h", "1d"])
+    def test_canonical_accepted(self, tf):
+        assert timeframes.canonicalize_timeframe(tf) == tf
+
+    @pytest.mark.parametrize(
+        "alias,canonical",
+        [
+            ("1HR", "1h"), ("1hr", "1h"),
+            ("4HR", "4h"), ("4hr", "4h"),
+            ("1D", "1d"), ("1DAY", "1d"), ("1day", "1d"),
+            ("5MIN", "5m"), ("5min", "5m"),
+            ("15min", "15m"),
+            ("30MIN", "30m"),
+        ],
+    )
+    def test_aliases_canonicalize(self, alias, canonical):
+        assert timeframes.canonicalize_timeframe(alias) == canonical
+
+    def test_1m_rejected(self):
+        # This is the exact case that bit the agent — 1m silently fell
+        # back to 1h on the server. We reject it here with a clear error.
+        with pytest.raises(ValidationError) as exc:
+            timeframes.canonicalize_timeframe("1m")
+        assert "not supported" in str(exc.value)
+        assert "1h" in exc.value.suggestion or "supported" in exc.value.suggestion.lower()
+
+    @pytest.mark.parametrize("tf", ["", None, "2h", "1week", "1y", "nonsense"])
+    def test_other_unsupported_rejected(self, tf):
+        with pytest.raises(ValidationError):
+            timeframes.canonicalize_timeframe(tf)
+
+
+class TestRecommendedLookback:
+    @pytest.mark.parametrize(
+        "tf,expected_months",
+        [
+            ("5m", 3), ("15m", 3), ("30m", 3), ("1h", 3),
+            ("4h", 6),
+            ("1d", 12), ("1D", 12),
+        ],
+    )
+    def test_matches_upstream_doc(self, tf, expected_months):
+        """Must match MangroveAI's ai_copilot/agentic/prompt_builder.py."""
+        assert timeframes.recommended_lookback_months(tf) == expected_months
+
+    def test_unsupported_tf_raises(self):
+        with pytest.raises(ValidationError):
+            timeframes.recommended_lookback_months("1m")


### PR DESCRIPTION
Three follow-ups to PR #39, one branch, commit-by-commit reviewable.

## 1. `.gitignore` — ignore `.mcp.json`

`scripts/setup-mcp.sh` writes MCP registration to `~/.claude.json` (user scope — reliable while upstream [#9189](https://github.com/anthropics/claude-code/issues/9189) persists). A convenience copy lands at the repo root. It was already untracked but not explicitly ignored — now is.

## 2. SessionStart hook — route fresh clones to Stage 0, not `/onboard`

Surfaced live: a fresh Claude Code session routed straight into the `/onboard` skill (4-phase rebrand flow) instead of the Stage 0 trading-bot greeter built in PR #39.

Root cause: `check-onboard.sh` emitted `ONBOARDING REQUIRED: ... You MUST run /onboard before doing anything else.` on any clone without `.claude/.onboarded`. Correct for template rebranders, wrong for trading-bot users (the default after Tim's pivot).

Fix:
- **`.claude/hooks/check-onboard.sh`** — marker-missing branch now instructs the agent: read `trading-bot-workflow.md`, eager-load MCP, check `list_wallets`, deliver Stage 0. Pre-empts persona drift: "ignore CLAUDE.md `Default Persona: product owner` unless `.claude/.onboarded` exists."
- **`.claude/skills/onboard/SKILL.md`** — description rewritten as REBRAND PATH ONLY. Lists the exact phrases that signal rebrand intent. Explicitly forbids auto-firing on a fresh clone.
- CLAUDE.md intentionally unchanged (the hook's persona override makes a CLAUDE.md edit unnecessary for routing).

## 3. Backtest — reject 1m, auto-lookback by timeframe, full interface exposure

Two bugs surfaced during a live 1m SMA(3/5) backtest:
- **"24 hours" widened to 13 days.** The MCP tool only exposed `lookback_months` (min 1 ≈ 30d). Agent rounded up and got clamped.
- **1m became 1h silently.** No client-side `interval` validation; `"1m"` passed through to the backend's `normalize_timeframe()` which doesn't know `"1m"` and falls back to `"1h"` without warning.

Root-cause alignment: MangroveAI's own [`ai_copilot/agentic/prompt_builder.py`](https://github.com/MangroveTechnologies/MangroveAI) documents the authoritative whitelist and per-timeframe lookback defaults. App-in-a-box wasn't using either.

Fix:
- **`src/shared/timeframes.py`** (new) — canonical whitelist `{"5m","15m","30m","1h","4h","1d"}` matching upstream `SUPPORTED_TIMEFRAMES`. `canonicalize_timeframe()` rejects 1m + unknowns with a clear `ValidationError`. `recommended_lookback_months()` returns 3/3/3/3/6/12 per the upstream `prompt_builder` doc.
- **`strategy_service.create_autonomous` / `create_manual`** — canonicalize requested timeframe before generating candidates / writing to cache. `backtest_lookback_months` now `Optional[int]` — `None` → timeframe-aware default.
- **`backtest_service`** — new `_resolve_window(tf, months, days, hours, start, end)` with precedence `start+end > hours > days > months > recommended(tf)`. `full_backtest()` takes `lookback_days`, `lookback_hours`, `slippage_pct`, `fee_pct`, `max_hold_time_hours`, and `overrides` (dict merged into `_DEFAULT_EXECUTION_CONFIG`). `_build_request` validates the candidate's timeframe pre-payload. Result carries `resolved_window` in `raw_metrics` so callers can detect server-side fallback.
- **`BacktestInput`** (POST `/strategies/{id}/backtest`) — mirrors the new surface. Returns the FULL SDK metrics dict (sortino, calmar, profit_factor, whatever upstream adds) instead of a hand-picked 6-field subset. Stable typed fields merged on top for backward compat.
- **`backtest_strategy` MCP tool** — signature mirrors the route's new surface. Description documents window-resolution precedence and timeframe-aware fallback.
- **Tool descriptions fixed** — `get_ohlcv`, `create_strategy_autonomous`, `create_strategy_manual` no longer advertise `1m`. All now read `"5m | 15m | 30m | 1h | 4h | 1d (1m not supported)"`.

## Test plan

- [x] `git check-ignore -v .mcp.json` matches the new ignore rule
- [x] Hook with marker missing → emits `FRESH CLONE — TRADING BOT MODE` + Stage 0 directive
- [x] Hook with marker present → surfaces user's `/onboard` Project Context (rebrand path)
- [x] `timeframes.canonicalize_timeframe("1m")` raises `ValidationError`
- [x] `timeframes.canonicalize_timeframe("1HR") == "1h"` (alias)
- [x] `timeframes.recommended_lookback_months("1d") == 12`
- [x] `backtest_strategy` MCP tool accepts `lookback_hours=24`, converts to ISO window, and records `resolved_window` in the response
- [x] `pytest tests/` — **282 passed, 2 skipped** (was 250 passed / 2 skipped before these changes)
- [ ] Reviewer: on a fresh clone, open Claude Code, confirm Stage 0 fires and `/onboard` does not
- [ ] Reviewer: ask the agent to backtest a 1m strategy — tool should refuse with the supported-list error before the request reaches the SDK