### PR TITLE
refactor: hello_mangrove MCP tool uses x402 library's create_payment_wrapper

### DIFF
--- a/server/scripts/agent_pay_hello_mangrove_mcp.py
+++ b/server/scripts/agent_pay_hello_mangrove_mcp.py
@@ -1,17 +1,17 @@
 """Agent-native x402 payment over MCP — no human in the loop.
 
 Mirror of agent_pay_hello_mangrove.py (REST) for the MCP transport. Uses
-the stock x402.mcp.x402MCPClient, which automatically detects the
+the stock x402.mcp.x402MCPSession, which automatically detects the
 PAYMENT_REQUIRED response, signs an EIP-3009 authorization, and retries
-with payment attached — the same ergonomics as x402AsyncTransport on
-the REST side.
+with the payment attached via MCP _meta — the same ergonomics as
+x402AsyncTransport on the REST side.
 
 Requirements:
-    - Server running (default: http://127.0.0.1:8080)
-    - Server's hello_mangrove tool registered via x402.mcp.create_payment_wrapper
-      so the PAYMENT_REQUIRED shape matches what x402MCPClient extracts
-    - WALLET_SECRET env var with EVM private key funded on the active network
-      (~$0.05 USDC + a few cents of ETH for gas on Base mainnet)
+    - Server running (default: http://127.0.0.1:8080) with the hello_mangrove
+      tool registered via x402.mcp.create_payment_wrapper, so the 402 response
+      shape is what x402MCPSession expects
+    - WALLET_SECRET env var with an EVM private key funded on the active
+      network (~$0.05 USDC + a few cents of ETH for gas on Base mainnet)
 
 Usage:
     export WALLET_SECRET=0x...
@@ -22,7 +22,6 @@ Usage:
 from __future__ import annotations
 
 import asyncio
-import base64
 import json
 import os
 import sys

--- a/server/scripts/agent_pay_hello_mangrove_mcp.py
+++ b/server/scripts/agent_pay_hello_mangrove_mcp.py
@@ -1,20 +1,15 @@
 """Agent-native x402 payment over MCP — no human in the loop.
 
-Mirror of agent_pay_hello_mangrove.py but for the MCP transport instead of
-REST. Demonstrates the MCP-native x402 pattern used by the hello_mangrove
-tool (`payment` parameter on the tool call) rather than the HTTP 402 +
-X-PAYMENT header pattern used by the REST endpoint.
-
-Flow:
-    1. Connect to the MCP server at SERVER_URL/mcp/ via Streamable HTTP
-    2. Call hello_mangrove() with empty payment -> receive payment requirements
-       in the tool response body
-    3. Sign an EIP-3009 payment authorization against those requirements
-    4. Call hello_mangrove(payment=<base64>) -> receive the message plus
-       settlement receipt (network, payer, transaction hash)
+Mirror of agent_pay_hello_mangrove.py (REST) for the MCP transport. Uses
+the stock x402.mcp.x402MCPClient, which automatically detects the
+PAYMENT_REQUIRED response, signs an EIP-3009 authorization, and retries
+with payment attached — the same ergonomics as x402AsyncTransport on
+the REST side.
 
 Requirements:
     - Server running (default: http://127.0.0.1:8080)
+    - Server's hello_mangrove tool registered via x402.mcp.create_payment_wrapper
+      so the PAYMENT_REQUIRED shape matches what x402MCPClient extracts
     - WALLET_SECRET env var with EVM private key funded on the active network
       (~$0.05 USDC + a few cents of ETH for gas on Base mainnet)
 
@@ -27,6 +22,7 @@ Usage:
 from __future__ import annotations
 
 import asyncio
+import base64
 import json
 import os
 import sys
@@ -35,21 +31,20 @@ from eth_account import Account
 from mcp import ClientSession
 from mcp.client.streamable_http import streamablehttp_client
 from x402 import x402Client
-from x402.http.utils import encode_payment_signature_header
+from x402.mcp import x402MCPSession
 from x402.mechanisms.evm.exact import ExactEvmClientScheme
 from x402.mechanisms.evm.signers import EthAccountSigner
-from x402.schemas import PaymentRequired, ResourceInfo
 
 
-def _parse_tool_result(result) -> dict:
-    """Extract the first TextContent block and parse as JSON."""
-    if not result.content:
-        raise RuntimeError(f"Tool returned empty content: {result}")
-    first = result.content[0]
-    text = getattr(first, "text", None) or first.get("text", "")
-    if not text:
-        raise RuntimeError(f"No text in tool response: {result}")
-    return json.loads(text)
+def _extract_message(content) -> str:
+    if not content:
+        return "(no content)"
+    first = content[0]
+    text = getattr(first, "text", None) or (first.get("text", "") if isinstance(first, dict) else "")
+    try:
+        return json.loads(text).get("message", text)
+    except (ValueError, TypeError):
+        return text
 
 
 async def main() -> int:
@@ -60,57 +55,39 @@ async def main() -> int:
 
     base_url = os.environ.get("SERVER_URL", "http://127.0.0.1:8080").rstrip("/")
     mcp_url = f"{base_url}/mcp/"
+    network = os.environ.get("X402_NETWORK", "eip155:8453")
 
     account = Account.from_key(secret)
     print(f"Payer address: {account.address}")
     print(f"MCP endpoint:  {mcp_url}")
 
+    payment_client = x402Client()
+    payment_client.register(network, ExactEvmClientScheme(EthAccountSigner(account)))
+
     async with streamablehttp_client(mcp_url) as (read, write, _):
         async with ClientSession(read, write) as session:
-            await session.initialize()
+            x402_mcp = x402MCPSession(session, payment_client, auto_payment=True)
+            await x402_mcp.initialize()
 
-            # Step 1: call without payment; server returns requirements in body
-            first = await session.call_tool("hello_mangrove", {})
-            body = _parse_tool_result(first)
-            if not body.get("error"):
-                print("Unexpected: tool returned non-error on empty payment.")
-                print(json.dumps(body, indent=2))
-                return 1
-            print(f"Unpaid call:  {body.get('code', '?')} — {body.get('message', '')}")
+            result = await x402_mcp.call_tool("hello_mangrove", {})
 
-            payment_required = PaymentRequired.model_validate(body["payment_required_decoded"])
-            first_accept = payment_required.accepts[0]
-            print(f"Requirement:  {first_accept.amount} base units on {first_accept.network} -> {first_accept.pay_to}")
-
-            # Step 2: sign a payment authorization against the requirements
-            x402_client = x402Client()
-            x402_client.register(
-                first_accept.network,
-                ExactEvmClientScheme(EthAccountSigner(account)),
-            )
-            payload = await x402_client.create_payment_payload(
-                payment_required,
-                resource=ResourceInfo(url=payment_required.resource.url),
-            )
-            signed = encode_payment_signature_header(payload)
-
-            # Step 3: call again with payment attached as tool arg
-            second = await session.call_tool("hello_mangrove", {"payment": signed})
-            result = _parse_tool_result(second)
-
-            if result.get("error"):
-                print(f"Paid call failed: {result.get('code')} — {result.get('message')}")
+            if result.is_error:
+                print(f"Tool call errored: {_extract_message(result.content)}")
                 return 1
 
-            print(f"Paid call:    {result.get('message', '(no message)')}")
-            settlement = result.get("settlement", {})
-            if settlement:
-                tx = settlement.get("transaction", "")
-                print(f"Payer:        {settlement.get('payer')}")
-                print(f"Network:      {settlement.get('network')}")
-                print(f"Transaction:  {tx}")
-                if tx and str(settlement.get("network", "")).endswith(":8453"):
-                    print(f"BaseScan:     https://basescan.org/tx/{tx}")
+            print(f"Payment made:  {result.payment_made}")
+            print(f"Message:       {_extract_message(result.content)}")
+
+            pr = result.payment_response
+            if pr is not None:
+                tx = getattr(pr, "transaction", None) or (pr.get("transaction") if isinstance(pr, dict) else None)
+                payer = getattr(pr, "payer", None) or (pr.get("payer") if isinstance(pr, dict) else None)
+                network = getattr(pr, "network", None) or (pr.get("network") if isinstance(pr, dict) else None)
+                print(f"Payer:         {payer}")
+                print(f"Network:       {network}")
+                print(f"Transaction:   {tx}")
+                if tx and str(network or "").endswith(":8453"):
+                    print(f"BaseScan:      https://basescan.org/tx/{tx}")
     return 0
 
 

--- a/server/src/mcp/tools.py
+++ b/server/src/mcp/tools.py
@@ -816,20 +816,47 @@ def _register_kb(server: FastMCP) -> None:
 
 
 def _register_hello_mangrove(server: FastMCP) -> None:
-    @server.tool()
-    async def hello_mangrove(payment: str = "") -> str:
-        """x402 demo tool. $0.05 USDC on Base. Smoke test for the payment path."""
-        if payment:
-            from src.shared.x402.server import verify_and_settle_payment
-            settlement = await verify_and_settle_payment(payment)
-            if settlement.get("error"):
-                return json.dumps(settlement)
-            from src.services.hello_mangrove import get_hello_mangrove
-            result = get_hello_mangrove()
-            result["settlement"] = settlement
-            return json.dumps(result)
-        from src.shared.x402.server import build_hello_mangrove_requirements
-        return json.dumps(build_hello_mangrove_requirements())
+    """Register hello_mangrove via the x402 library's MCP payment wrapper.
+
+    The wrapper intercepts tool calls, reads payment from MCP ``_meta``, verifies
+    and settles via the shared x402ResourceServer, and attaches the settlement
+    receipt to the result's ``_meta``. Clients using ``x402.mcp.x402MCPClient``
+    auto-handle the empty-payment -> sign -> retry round-trip.
+    """
+    from x402 import ResourceConfig
+    from x402.mcp import create_payment_wrapper
+    from x402.schemas import ResourceInfo as X402ResourceInfo
+
+    from src.services.hello_mangrove import get_hello_mangrove as _impl
+    from src.shared.x402.config import get_network, get_pay_to
+    from src.shared.x402.server import _ensure_initialized
+
+    resource_server = _ensure_initialized()
+    accepts = resource_server.build_payment_requirements(
+        ResourceConfig(
+            scheme="exact",
+            network=get_network(),
+            pay_to=get_pay_to(),
+            price="$0.05",
+        )
+    )
+
+    wrapper = create_payment_wrapper(
+        resource_server,
+        accepts=accepts,
+        resource=X402ResourceInfo(
+            url="mcp://hello_mangrove",
+            description="hello_mangrove message — $0.05 USDC donation",
+        ),
+    )
+
+    @server.tool(
+        name="hello_mangrove",
+        description="x402 demo: $0.05 USDC on Base. Smoke test for the payment path.",
+    )
+    @wrapper
+    async def hello_mangrove() -> str:
+        return json.dumps(_impl())
 
     register_tool(ToolEntry(
         name="hello_mangrove",
@@ -837,10 +864,5 @@ def _register_hello_mangrove(server: FastMCP) -> None:
         access="x402",
         price="$0.05 USDC",
         network="base",
-        parameters=[
-            ToolParam(
-                name="payment", type="string", required=False,
-                description="Base64-encoded x402 payment signature. Call with no parameters to get payment requirements.",
-            ),
-        ],
+        parameters=[],
     ))

--- a/server/tests/test_mcp_auth.py
+++ b/server/tests/test_mcp_auth.py
@@ -1,8 +1,9 @@
 """MCP tool auth and x402 payment enforcement tests.
 
-Verifies the x402-gated hello_mangrove tool:
-- Returns payment requirements when called without credentials
-- Rejects malformed payment strings
+Verifies the x402-gated hello_mangrove tool returns x402-native payment
+requirements when called without payment in the MCP _meta. Garbage-payment
+rejection is no longer in our code path — it's handled inside the x402
+library's create_payment_wrapper, which has its own tests upstream.
 
 Phase 4 will add auth tests for the defi-agent tools once they exist.
 """
@@ -16,30 +17,29 @@ import pytest  # noqa: E402
 from src.mcp.server import create_mcp_server  # noqa: E402
 
 
-async def _call_tool(server, tool_name: str, args: dict | None = None) -> dict | list:
-    """Call a named tool on the MCP server and return parsed JSON."""
+async def _call_tool(server, tool_name: str, args: dict | None = None):
+    """Call a named tool on the MCP server and return the CallToolResult.
+
+    Tools wrapped with x402.mcp.create_payment_wrapper return a CallToolResult
+    (with content + isError) rather than a raw JSON string, so callers unpack
+    .content[0].text themselves when they need the body.
+    """
     tools = server._tool_manager._tools
     tool = tools[tool_name]
-    result = await tool.run(args or {})
-    return json.loads(result)
+    return await tool.run(args or {})
 
 
 @pytest.mark.asyncio
 async def test_hello_mangrove_returns_payment_requirements_without_credentials():
     server = create_mcp_server()
     result = await _call_tool(server, "hello_mangrove")
-    assert result["error"] is True
-    assert result["code"] == "PAYMENT_REQUIRED"
-    assert "payment_required" in result
-    assert "payment_required_decoded" in result
-    decoded = result["payment_required_decoded"]
-    assert "accepts" in decoded
-    assert len(decoded["accepts"]) > 0
-
-
-@pytest.mark.asyncio
-async def test_hello_mangrove_rejects_garbage_payment():
-    server = create_mcp_server()
-    result = await _call_tool(server, "hello_mangrove", {"payment": "not-valid-base64!!!"})
-    assert result["error"] is True
-    assert result["code"] == "INVALID_PAYMENT"
+    assert result.isError is True
+    assert result.content, "payment-required result should carry content"
+    body = json.loads(result.content[0].text)
+    assert body.get("x402Version") == 2
+    accepts = body.get("accepts", [])
+    assert len(accepts) > 0
+    first = accepts[0]
+    assert first["scheme"] == "exact"
+    assert first["payTo"]
+    assert first["network"]


### PR DESCRIPTION
## Summary

Follow-up to #41. Replaces the hand-rolled `payment: str = ""` inline pattern in the `hello_mangrove` MCP tool with the x402 library's canonical MCP integration (`x402.mcp.create_payment_wrapper` on the server, `x402.mcp.x402MCPSession` on the client). Matches the `x402AsyncTransport` ergonomics on the REST side: library-native on both ends, zero custom round-trip glue.

This is the follow-up I should have bundled into #41 from the start — flagging it explicitly because I'd initially deferred it as "not required" when it was exactly the thing that makes this tool consumable by any agent using the stock x402 library.

## Changes

**Server (`server/src/mcp/tools.py::_register_hello_mangrove`):**
- Builds payment requirements once at registration time via `resource_server.build_payment_requirements(ResourceConfig(...))`
- Wraps the tool handler with `x402.mcp.create_payment_wrapper(resource_server, accepts=..., resource=ResourceInfo(...))`
- Tool signature is now `hello_mangrove()` with no `payment` parameter; payment is conveyed through MCP `_meta` per the x402 spec
- Wrapper handles: empty-payment → 402, verify, settle, and `_meta` attachment of the settlement receipt
- `ResourceInfo` imported from `x402.schemas` (not `x402.mcp`) — see "library inconsistency" below

**Client (`server/scripts/agent_pay_hello_mangrove_mcp.py`):**
- Replaces the manual empty-payment → parse → sign → retry loop with `x402MCPSession(session, payment_client, auto_payment=True)` — one `call_tool` invocation, payment is transparent
- Mirrors REST-side ergonomics from `agent_pay_hello_mangrove.py`

## Verified on Base mainnet

$0.05 USDC settled: BaseScan [`0xf4a553…56f1c03`](https://basescan.org/tx/0xf4a553779a2e0231492a8057eb6dd06522185e739a4537ccc8a75686256f1c03)

## Library inconsistency (worth reporting upstream to coinbase/x402)

`x402.mcp.__init__.py` exports `ResourceInfo` from `x402.mcp.types` (a dataclass, no `model_dump`), but `create_payment_wrapper` internally expects `x402.schemas.payments.ResourceInfo` (Pydantic model with `model_dump`). Passing the top-level import produces `AttributeError: 'ResourceInfo' object has no attribute 'model_dump'` at tool-call time.

This PR imports from `x402.schemas` directly. Upstream fix would be to re-export the pydantic version from `x402.mcp` or harmonize the two types.

## Test plan

- [x] `pip install -r requirements.txt` + `uvicorn src.app:app --port 8081` boots cleanly (server initializes facilitator at registration time)
- [x] Agent-native payment via `x402MCPSession.call_tool("hello_mangrove", {})` → 200 with settlement in `_meta`
- [x] Settlement tx visible on BaseScan (above)
- [ ] Reviewer: confirm server startup time is acceptable (the `_ensure_initialized()` call at registration time makes one HTTP call to the CDP facilitator's `/supported` endpoint)

## Related

- Closes the follow-up flagged at the end of #41's description
- Referenced by MangroveMarkets-MCP-Server#58 as the recommended template for server-side x402 on MCP

🤖 Generated with [Claude Code](https://claude.com/claude-code)