### PR TITLE
feat(skills): /create-strategy — reference-based + KB-grounded authoring

### DIFF
--- a/.claude/skills/create-strategy/SKILL.md
+++ b/.claude/skills/create-strategy/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: create-strategy
+description: >-
+  Use when the user wants to build a new trading strategy — "build me a
+  momentum play on ETH", "find a strategy for BTC", "I want to trade X",
+  "make a strategy", or after Stage 0 greeter when the wallet is ready
+  and the user is moving into Stage 2 (Author) of trading-bot-workflow.md.
+  Drives the author → backtest path using reference strategies (Mechanism
+  2) and KB-grounded parameter choices (Mechanism 1) so parameters are
+  evidence-backed, not library-default guesses. Wraps
+  search_reference_strategies + build_strategy_from_reference +
+  create_strategy_autonomous + create_strategy_manual + kb_search.
+---
+
+# Create Strategy Skill
+
+The agent's job in this skill: turn a loose user goal ("momentum on ETH")
+into a strategy config with **specific signals and specific parameters
+backed by evidence**, not library defaults.
+
+Two mechanisms drive "intuition":
+
+- **Mechanism 2 (reference strategies) — the primary path.** Curated
+  known-good configs. The agent searches these FIRST, presents matches
+  to the user, and materializes the chosen one exactly. Zero parameter
+  guessing for the common case.
+- **Mechanism 1 (KB-grounded parameters) — the fallback.** When
+  references don't fit (unusual asset, unusual goal, or user wants to
+  modify), the agent is REQUIRED to call `kb_search` for every signal
+  it picks before finalizing params. No library-default fallback.
+
+A third mechanism (mined parameter priors from the 1.4M-strategy DB)
+will land via MangroveAI endpoint after MangroveOracle issue #156. This
+skill will transparently benefit once the SDK exposes it — no rewrite
+needed here.
+
+## Trigger
+
+Activate when the user:
+
+- Explicitly asks for a strategy ("build me...", "make a strategy", "find me...")
+- Is in Stage 2 of `trading-bot-workflow.md` (wallet ready, wants to author)
+- Says "trade X", "start running", "put money to work" and a strategy doesn't yet exist
+
+Do NOT activate if the user is asking questions about an existing strategy (use `/monitor-trades` instead) or wants to promote/pause one (use `/promote-strategy`).
+
+## Input — What to Collect
+
+The agent needs four pieces of info before searching references. ORDER these in the order the user volunteered them; if they gave everything in one message, skip straight to Phase A (FAST ADVANCE):
+
+1. **asset** — symbol (BTC, ETH, SOL, etc.). REQUIRED.
+2. **timeframe** — 5m / 15m / 30m / 1h / 4h / 1d. Default 1h if user unclear. **1m is NOT supported** — the server will reject it. If the user asks for 1m, say: "1m isn't supported on the Mangrove data source; the smallest is 5m, but I'd recommend 1h for a first strategy — less noise, faster to backtest."
+3. **goal / style** — natural language. Used for category detection (momentum, mean_reversion, trend_following, breakout, volatility).
+4. **appetite for trades** — high-frequency (many small edges) vs. swing (fewer, bigger moves). Affects which references to recommend.
+
+FAST ADVANCE: if the user's first message has asset + strategy_type + timeframe, skip the Q&A and go straight to Phase A. Infer the rest (knowledge level, sentiment) from tone — don't ask unnecessary clarifying questions.
+
+Example FAST ADVANCE triggers:
+- "Build a momentum strategy for ETH on 1h" → asset=ETH, timeframe=1h, goal=momentum
+- "Give me a trend following BTC 4h setup" → asset=BTC, timeframe=4h, goal=trend_following
+
+## Phase A — Search References (ALWAYS DO THIS FIRST)
+
+Call `search_reference_strategies(asset, timeframe, goal_hint)`. You will get back up to 5 ranked candidates, each with:
+
+- `id` (e.g. `ref-004`)
+- `label` (human-readable)
+- `description` (why this works)
+- `entry_signals` + `exit_signals` (names, types, params)
+- `category`
+- `notes` (tuning hints)
+
+Present the top 2-3 to the user, ranked. For each: show the label, the signal names (not param values — too noisy), the category, and one sentence from `description`. Ask: "Want to use one of these, or should I design something custom?"
+
+If `search_reference_strategies` returns 0 results or only low-score matches: jump to **Phase C (Custom build, KB-grounded)**.
+
+## Phase B — Build from Reference (PREFERRED)
+
+User picks a reference (by id or label). Call `build_strategy_from_reference(reference_id, timeframe=<user's>, name=<optional>)`.
+
+You get back a `create_strategy_manual`-compatible payload. Pass it directly to `create_strategy_manual(...)` — DO NOT modify `entry`, `exit`, or `execution_config`. The whole point of Mechanism 2 is that these values came from strategies that already backtested well.
+
+Only adjustable fields:
+
+- `timeframe` override (already handled by build_strategy_from_reference)
+- `name` (cosmetic)
+
+If the user wants to TWEAK the reference (e.g. "but use RSI(9) not RSI(14)"): acknowledge their change, then move to Phase C's KB-citation discipline BEFORE applying the tweak. Don't change params without citation.
+
+## Phase C — Custom Build (KB-GROUNDED, Mechanism 1)
+
+Use this path when:
+- Reference search returned nothing useful
+- User explicitly wants something unusual (e.g. "combine Ichimoku and Bollinger breakouts")
+- User wants to tweak a reference's parameters
+
+**For each signal you consider, you MUST:**
+
+1. Call `kb_search(query="<signal_name> parameters <asset> <timeframe>")`. Example: `kb_search("MACD parameters ETH 1h")`.
+2. Read the top 1-3 results. Extract the recommended parameter range or default.
+3. In your response, CITE the KB result verbatim (or paraphrase + attribute): "KB recommends MACD(8, 21, 5) for 1h crypto — tighter than the stock 12/26/9 because 1h bars have less noise than daily."
+4. Only then write the param values into the strategy.
+
+**Do NOT use library-default params without KB citation.** If the KB has nothing, say so: "KB doesn't have guidance on this specific (signal, asset, timeframe) combo. I'll use the signal's declared default [X] but flag it — consider running a wider backtest to validate."
+
+Composition rules (TRIGGER vs FILTER) — from MangroveAI signal spec:
+
+- **Entry**: EXACTLY ONE TRIGGER + ZERO OR MORE FILTERS
+- **Exit**: ZERO OR ONE TRIGGER + ZERO OR MORE FILTERS
+- **NEVER a FILTER without a TRIGGER in the same group**
+- If the user doesn't specify exits explicitly, use `exit: []` — the volatility-based stop-loss + take-profit are AUTOMATIC at entry, not exit rules
+- Each signal does ONE thing (Single Responsibility). Don't stack two momentum triggers; don't mix concepts.
+
+When the config is ready, call `create_strategy_manual(...)` with it.
+
+## Phase D — Autonomous path (FALLBACK when user says "just pick something")
+
+If the user doesn't want to choose a reference or design custom, call `create_strategy_autonomous(goal, asset, timeframe)` with the user's goal text. The server generates N candidates, backtests them in bulk, and returns the winner.
+
+Autonomous is the "I don't care, you decide" escape hatch. It's NOT the primary path — references are. Use autonomous when:
+- User explicitly says "pick for me" / "surprise me" / "you decide"
+- Phase A returned nothing AND Phase C is too much friction for the user's patience
+- You've tried Phase B/C and the user rejected the results
+
+Under no circumstances go straight to Phase D as the first move. Always try Phase A first.
+
+## After Strategy Creation — Hand Off to Backtest
+
+Regardless of which phase built the strategy, hand off to backtesting immediately:
+
+```
+backtest_strategy(strategy_id, mode="full", lookback_hours|days|months|start/end omitted for timeframe-aware default)
+```
+
+Let `backtest_service` pick the lookback automatically via `recommended_lookback_months(timeframe)` — 3 months for 5m/15m/30m/1h, 6 months for 4h, 12 months for 1d. Only override when the user explicitly asks for a specific window.
+
+Present the result using the `/review-backtest` skill's decision rule (PASS/FAIL against `threshold_spec`).
+
+## Prohibited
+
+- **Never** claim a signal is "firing" based on catalog listing alone. Only `evaluate_strategy` output can claim that.
+- **Never** fabricate backtest metrics. If `metrics` missing from a tool response, say so.
+- **Never** use library-default params in Phase C without KB citation.
+- **Never** modify a reference's params in Phase B — move to Phase C if the user wants changes.
+- **Never** invent signal names not returned by `list_signals` or a reference strategy. If you don't have a name, call `list_signals` first.
+- **Never** place a FILTER without a TRIGGER in the same group (entry or exit).
+- **Never** recommend 1m timeframes — server rejects them.
+
+## Never Default to Swap Router
+
+Manual swaps (`get_swap_quote` / `execute_swap`) are a fallback. Only route there if the strategy layer is down (`search_reference_strategies` + `create_strategy_autonomous` both fail), and disclose it.
+
+## Summary — Decision Tree
+
+```
+User wants a strategy
+│
+├─→ Phase A: search_reference_strategies(asset, timeframe, goal_hint)
+│       │
+│       ├─ ≥1 good match → present to user → pick → Phase B
+│       ├─ 0 good matches → Phase C
+│       └─ user says "just pick" → Phase D (autonomous)
+│
+├─ Phase B: build_strategy_from_reference + create_strategy_manual
+│       (signals + params copied exactly, timeframe applied)
+│
+├─ Phase C: kb_search each signal → cite → create_strategy_manual
+│       (custom, evidence-backed)
+│
+└─ Phase D: create_strategy_autonomous(goal, asset, timeframe)
+        (server generates + backtests N candidates, returns winner)
+
+→ backtest_strategy (timeframe-aware default window)
+→ /review-backtest skill (PASS/FAIL verdict)
+→ /promote-strategy skill (draft → paper → live)
+```

--- a/server/src/api/router.py
+++ b/server/src/api/router.py
@@ -13,6 +13,7 @@ from src.api.routes.kb import router as kb_router
 from src.api.routes.logs import router as logs_router
 from src.api.routes.market import router as market_router
 from src.api.routes.on_chain import router as on_chain_router
+from src.api.routes.reference_strategies import router as reference_strategies_router
 from src.api.routes.signals import router as signals_router
 from src.api.routes.strategies import router as strategies_router
 from src.api.routes.wallet import router as wallet_router
@@ -29,6 +30,7 @@ agent_router.include_router(market_router)
 agent_router.include_router(on_chain_router)
 agent_router.include_router(signals_router)
 agent_router.include_router(strategies_router)
+agent_router.include_router(reference_strategies_router)
 agent_router.include_router(logs_router)
 agent_router.include_router(kb_router)
 

--- a/server/src/api/routes/reference_strategies.py
+++ b/server/src/api/routes/reference_strategies.py
@@ -1,0 +1,109 @@
+"""Reference strategies routes — auth-gated.
+
+Exposes the curated seed set as a public API surface. When MangroveAI
+ships a public reference-strategies endpoint (issue #156 trickle-down),
+these routes continue to work and the backing service swaps its source.
+
+- GET  /api/v1/agent/reference-strategies/search
+- GET  /api/v1/agent/reference-strategies/{reference_id}
+- POST /api/v1/agent/reference-strategies/{reference_id}/build
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+from src.services import reference_strategies_service
+from src.shared.auth.dependency import require_api_key
+
+router = APIRouter(
+    prefix="/reference-strategies",
+    dependencies=[Depends(require_api_key)],
+    tags=["reference-strategies"],
+)
+
+
+class ReferenceSearchResponse(BaseModel):
+    asset: str
+    timeframe: str | None
+    category: str | None
+    count: int
+    strategies: list[dict[str, Any]]
+
+
+@router.get(
+    "/search",
+    response_model=ReferenceSearchResponse,
+    summary="Search curated reference strategies",
+    description=(
+        "Returns up to `limit` reference strategies matching the filter. "
+        "Ranks by match specificity: asset+timeframe+category > "
+        "asset+timeframe > asset > category. When `category` is omitted "
+        "and `goal_hint` is supplied, a category is auto-detected. "
+        "Mechanism 2 of the /create-strategy skill — the agent picks from "
+        "these instead of library-default parameter guessing."
+    ),
+)
+async def search_references(
+    asset: str,
+    timeframe: str | None = None,
+    category: str | None = None,
+    goal_hint: str | None = None,
+    limit: int = 5,
+) -> ReferenceSearchResponse:
+    results = reference_strategies_service.search(
+        asset=asset,
+        timeframe=timeframe,
+        category=category,
+        goal_hint=goal_hint,
+        limit=limit,
+    )
+    return ReferenceSearchResponse(
+        asset=asset.upper(),
+        timeframe=timeframe,
+        category=category,
+        count=len(results),
+        strategies=[r.model_dump() for r in results],
+    )
+
+
+@router.get(
+    "/{reference_id}",
+    summary="Get a single reference strategy by id",
+)
+async def get_reference(reference_id: str) -> dict[str, Any]:
+    ref = reference_strategies_service.get(reference_id)
+    if ref is None:
+        raise HTTPException(status_code=404, detail=f"reference_id {reference_id!r} not found")
+    return ref.model_dump()
+
+
+class BuildFromReferenceRequest(BaseModel):
+    timeframe: str | None = None  # Defaults to the reference's own timeframe.
+    name: str | None = None  # Optional override; auto-labelled if omitted.
+
+
+@router.post(
+    "/{reference_id}/build",
+    summary="Materialize a create-strategy-manual payload from a reference",
+    description=(
+        "Copies the reference's signals exactly, only rewriting each "
+        "signal's `timeframe` if overridden. Returns a payload the caller "
+        "can POST to /strategies/manual as-is. The agent uses this after "
+        "presenting reference candidates and letting the user pick one."
+    ),
+)
+async def build_from_reference(
+    reference_id: str,
+    req: BuildFromReferenceRequest,
+) -> dict[str, Any]:
+    try:
+        return reference_strategies_service.build_from_reference(
+            reference_id=reference_id,
+            timeframe_override=req.timeframe,
+            name=req.name,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e)) from e

--- a/server/src/mcp/tools.py
+++ b/server/src/mcp/tools.py
@@ -544,6 +544,108 @@ def _register_strategy(server: FastMCP) -> None:
     ))
 
     @server.tool()
+    async def search_reference_strategies(
+        asset: str,
+        timeframe: str | None = None,
+        category: str | None = None,
+        goal_hint: str | None = None,
+        limit: int = 5,
+        api_key: str = "",
+    ) -> str:
+        """Search curated reference strategies — Mechanism 2 of /create-strategy.
+
+        The agent calls this BEFORE picking signals/params manually. Each
+        returned reference has known-good entry/exit signals + parameter
+        choices. The agent picks one that matches user intent, then calls
+        build_strategy_from_reference to materialize it.
+
+        Ranks by specificity: asset+timeframe+category > asset+timeframe
+        > asset > category. Auto-detects category from goal_hint if not
+        supplied.
+        """
+        if not _require(api_key):
+            return _auth_error()
+        from src.services import reference_strategies_service
+        items = reference_strategies_service.search(
+            asset=asset,
+            timeframe=timeframe,
+            category=category,
+            goal_hint=goal_hint,
+            limit=limit,
+        )
+        return json.dumps({
+            "asset": asset.upper(),
+            "timeframe": timeframe,
+            "category": category,
+            "count": len(items),
+            "strategies": [r.model_dump() for r in items],
+        })
+
+    register_tool(ToolEntry(
+        name="search_reference_strategies",
+        description=(
+            "Find curated reference strategies that match the user's goal "
+            "and asset. Returns ranked candidates with signals + parameter "
+            "choices that have worked in backtests. ALWAYS call this "
+            "before picking signals manually — it's the primary source of "
+            "parameter intuition."
+        ),
+        access="auth",
+        parameters=[
+            ToolParam(name="asset", type="string", required=True, description="Asset symbol (e.g. BTC, ETH)"),
+            ToolParam(name="timeframe", type="string", required=False, description="5m | 15m | 30m | 1h | 4h | 1d"),
+            ToolParam(name="category", type="string", required=False, description="momentum | mean_reversion | trend_following | breakout | volatility"),
+            ToolParam(name="goal_hint", type="string", required=False, description="Free text from the user's goal — auto-detects category if category is not supplied"),
+            ToolParam(name="limit", type="integer", required=False, description="Max results (default 5)"),
+            _APIKEY,
+        ],
+    ))
+
+    @server.tool()
+    async def build_strategy_from_reference(
+        reference_id: str,
+        timeframe: str | None = None,
+        name: str | None = None,
+        api_key: str = "",
+    ) -> str:
+        """Materialize a reference into a create_strategy_manual payload.
+
+        Called after search_reference_strategies + user pick. Copies the
+        reference's signals EXACTLY (parameters untouched) and only
+        rewrites each signal's timeframe if overridden. Returns a payload
+        the caller passes straight to create_strategy_manual.
+        """
+        if not _require(api_key):
+            return _auth_error()
+        from src.services import reference_strategies_service
+        try:
+            payload = reference_strategies_service.build_from_reference(
+                reference_id=reference_id,
+                timeframe_override=timeframe,
+                name=name,
+            )
+        except ValueError as e:
+            return json.dumps({"error": str(e), "code": "REFERENCE_NOT_FOUND"})
+        return json.dumps(payload)
+
+    register_tool(ToolEntry(
+        name="build_strategy_from_reference",
+        description=(
+            "After search_reference_strategies returns candidates and the "
+            "user picks one, call this to produce a create_strategy_manual "
+            "payload. Signals and params are copied exactly — the agent "
+            "must NOT modify them. Only timeframe and name can be overridden."
+        ),
+        access="auth",
+        parameters=[
+            ToolParam(name="reference_id", type="string", required=True, description="e.g. ref-001 — from search_reference_strategies"),
+            ToolParam(name="timeframe", type="string", required=False, description="Override the reference's timeframe (canonicalized)"),
+            ToolParam(name="name", type="string", required=False, description="Optional strategy name override"),
+            _APIKEY,
+        ],
+    ))
+
+    @server.tool()
     async def list_strategies(status: str | None = None, limit: int = 50,
                               offset: int = 0, api_key: str = "") -> str:
         """List strategies, optionally filtered by status."""

--- a/server/src/services/data/reference_strategies.json
+++ b/server/src/services/data/reference_strategies.json
@@ -1,0 +1,217 @@
+{
+  "description": "Hand-curated seed set of reference strategies for app-in-a-box. Populated by copying known-good configs from MangroveAI's reference_strategies table + TA best practices from the KB. Replaced by live mangroveai.reference_strategies.search() once MangroveOracle issue #156 + MangroveAI endpoint land. Until then, the agent picks from these via /create-strategy skill (Mechanism 2). Signal names verified against MangroveAI/src/MangroveAI/domains/signals/signals_metadata.json (2026-04-22 snapshot).",
+  "schema_version": "1.0",
+  "strategies": [
+    {
+      "id": "ref-001",
+      "label": "ETH momentum — MACD bullish cross on 1h",
+      "asset": "ETH",
+      "timeframe": "1h",
+      "category": "momentum",
+      "description": "Enters on a MACD bullish cross, exits on bearish cross. MACD(12,26,9) is the canonical setup; proven on crypto 1h for catching multi-hour momentum legs without chasing single-bar noise.",
+      "entry_signals": [
+        { "name": "macd_bullish_cross", "signal_type": "TRIGGER", "params": { "window_fast": 12, "window_slow": 26, "window_sign": 9 } }
+      ],
+      "exit_signals": [
+        { "name": "macd_bearish_cross", "signal_type": "TRIGGER", "params": { "window_fast": 12, "window_slow": 26, "window_sign": 9 } }
+      ],
+      "execution_config": { "max_risk_per_trade": 0.01, "max_open_positions": 3 },
+      "source": "curated/MangroveAI ref",
+      "notes": "Starter config. Backtest before going live; MACD params can be tuned tighter on 1h crypto (e.g. 8,21,5) for more trades."
+    },
+    {
+      "id": "ref-002",
+      "label": "BTC trend-follow — SMA crossover 20/50 on 1h",
+      "asset": "BTC",
+      "timeframe": "1h",
+      "category": "trend_following",
+      "description": "Classic SMA crossover: fast crosses above slow = long, cross down = exit. 20/50 on 1h captures swing trends without the whipsaw of faster periods on crypto noise.",
+      "entry_signals": [
+        { "name": "sma_cross_up", "signal_type": "TRIGGER", "params": { "window_fast": 20, "window_slow": 50 } }
+      ],
+      "exit_signals": [
+        { "name": "sma_cross_down", "signal_type": "TRIGGER", "params": { "window_fast": 20, "window_slow": 50 } }
+      ],
+      "execution_config": { "max_risk_per_trade": 0.015, "max_open_positions": 2 },
+      "source": "curated",
+      "notes": "Tune window_fast up (→30) and window_slow up (→100) if churn is high. ADX filter can be added to trade only in trending markets."
+    },
+    {
+      "id": "ref-003",
+      "label": "ETH mean-reversion — RSI oversold bounce on 4h",
+      "asset": "ETH",
+      "timeframe": "4h",
+      "category": "mean_reversion",
+      "description": "Enters when RSI crosses up through 30 (oversold exit), exits when RSI crosses down through 70 (overbought exit). 4h timeframe keeps the setup away from intraday noise.",
+      "entry_signals": [
+        { "name": "rsi_cross_up", "signal_type": "TRIGGER", "params": { "window": 14, "threshold": 30 } }
+      ],
+      "exit_signals": [
+        { "name": "rsi_cross_down", "signal_type": "TRIGGER", "params": { "window": 14, "threshold": 70 } }
+      ],
+      "execution_config": { "max_risk_per_trade": 0.01, "max_open_positions": 2 },
+      "source": "curated",
+      "notes": "Classic RSI(14, 30/70). Tighter thresholds (25/75) yield fewer but higher-quality entries on ranging markets."
+    },
+    {
+      "id": "ref-004",
+      "label": "BTC momentum + trend filter — MACD entry, SMA filter on 1h",
+      "asset": "BTC",
+      "timeframe": "1h",
+      "category": "momentum",
+      "description": "Enters on MACD bullish cross ONLY when price is above SMA(50) — filters out counter-trend momentum pops. Exits on MACD bearish cross.",
+      "entry_signals": [
+        { "name": "macd_bullish_cross", "signal_type": "TRIGGER", "params": { "window_fast": 12, "window_slow": 26, "window_sign": 9 } },
+        { "name": "is_above_sma", "signal_type": "FILTER", "params": { "window": 50 } }
+      ],
+      "exit_signals": [
+        { "name": "macd_bearish_cross", "signal_type": "TRIGGER", "params": { "window_fast": 12, "window_slow": 26, "window_sign": 9 } }
+      ],
+      "execution_config": { "max_risk_per_trade": 0.01, "max_open_positions": 2 },
+      "source": "curated/KB-informed",
+      "notes": "The trend filter cuts trade count ~60% but typically lifts win rate. Good starter for a cautious momentum player."
+    },
+    {
+      "id": "ref-005",
+      "label": "ETH trend-follow — EMA crossover with ADX filter on 4h",
+      "asset": "ETH",
+      "timeframe": "4h",
+      "category": "trend_following",
+      "description": "EMA(12) crosses EMA(26) up = long, cross down = exit. ADX > 25 filter ensures we only trade when there's actual trend strength.",
+      "entry_signals": [
+        { "name": "ema_cross_up", "signal_type": "TRIGGER", "params": { "window_fast": 12, "window_slow": 26 } },
+        { "name": "adx_strong_trend", "signal_type": "FILTER", "params": { "window": 14, "threshold": 25 } }
+      ],
+      "exit_signals": [
+        { "name": "ema_cross_down", "signal_type": "TRIGGER", "params": { "window_fast": 12, "window_slow": 26 } }
+      ],
+      "execution_config": { "max_risk_per_trade": 0.012, "max_open_positions": 2 },
+      "source": "curated",
+      "notes": "ADX filter is the single biggest quality lever on crypto trend systems. Disable it to see the noise for yourself."
+    },
+    {
+      "id": "ref-006",
+      "label": "BTC momentum long-term — MACD on 1d",
+      "asset": "BTC",
+      "timeframe": "1d",
+      "category": "momentum",
+      "description": "Daily MACD(12,26,9) — the textbook swing-trading setup. Low trade count but high per-trade expectancy on BTC historically.",
+      "entry_signals": [
+        { "name": "macd_bullish_cross", "signal_type": "TRIGGER", "params": { "window_fast": 12, "window_slow": 26, "window_sign": 9 } }
+      ],
+      "exit_signals": [
+        { "name": "macd_bearish_cross", "signal_type": "TRIGGER", "params": { "window_fast": 12, "window_slow": 26, "window_sign": 9 } }
+      ],
+      "execution_config": { "max_risk_per_trade": 0.02, "max_open_positions": 1 },
+      "source": "curated",
+      "notes": "1d MACD expects 4-8 trades per year on BTC. Use for a low-attention, high-conviction live wallet."
+    },
+    {
+      "id": "ref-007",
+      "label": "ETH momentum — ROC positive + above SMA on 4h",
+      "asset": "ETH",
+      "timeframe": "4h",
+      "category": "momentum",
+      "description": "Enters when Rate of Change flips positive AND price is above SMA(50). Exits on ROC flipping negative. Catches sustained momentum rather than single-bar spikes.",
+      "entry_signals": [
+        { "name": "roc_momentum_shift", "signal_type": "TRIGGER", "params": { "window": 12, "direction": "up" } },
+        { "name": "is_above_sma", "signal_type": "FILTER", "params": { "window": 50 } }
+      ],
+      "exit_signals": [
+        { "name": "roc_momentum_shift", "signal_type": "TRIGGER", "params": { "window": 12, "direction": "down" } }
+      ],
+      "execution_config": { "max_risk_per_trade": 0.01, "max_open_positions": 2 },
+      "source": "curated",
+      "notes": "ROC period 12 = ~2 days on 4h. Shorter periods = more trades but more noise; 6 is the typical noise floor."
+    },
+    {
+      "id": "ref-008",
+      "label": "BTC trend + volume confirmation — EMA cross + PVO on 1h",
+      "asset": "BTC",
+      "timeframe": "1h",
+      "category": "trend_following",
+      "description": "EMA(9) crosses EMA(21) up AND PVO (Percentage Volume Oscillator) is bullish = enter. Combines price trend + volume participation — reduces false breakouts.",
+      "entry_signals": [
+        { "name": "ema_cross_up", "signal_type": "TRIGGER", "params": { "window_fast": 9, "window_slow": 21 } },
+        { "name": "pvo_bullish_cross", "signal_type": "FILTER", "params": { "window_slow": 26, "window_fast": 12, "window_sign": 9 } }
+      ],
+      "exit_signals": [
+        { "name": "ema_cross_down", "signal_type": "TRIGGER", "params": { "window_fast": 9, "window_slow": 21 } }
+      ],
+      "execution_config": { "max_risk_per_trade": 0.01, "max_open_positions": 2 },
+      "source": "curated",
+      "notes": "PVO filter rejects ~40% of pure price-only crossovers. Good defense against choppy ranges."
+    },
+    {
+      "id": "ref-009",
+      "label": "ETH mean-reversion tight — Stoch oversold bounce on 1h",
+      "asset": "ETH",
+      "timeframe": "1h",
+      "category": "mean_reversion",
+      "description": "Stochastic(14,3) oversold (< 20) crosses back up = enter. Exits on overbought (> 80). Tighter + faster than RSI mean-reversion.",
+      "entry_signals": [
+        { "name": "rsi_cross_up", "signal_type": "TRIGGER", "params": { "window": 14, "threshold": 30 } },
+        { "name": "stoch_oversold", "signal_type": "FILTER", "params": { "window": 14, "smooth_window": 3, "threshold": 20 } }
+      ],
+      "exit_signals": [
+        { "name": "rsi_cross_down", "signal_type": "TRIGGER", "params": { "window": 14, "threshold": 70 } }
+      ],
+      "execution_config": { "max_risk_per_trade": 0.008, "max_open_positions": 2 },
+      "source": "curated",
+      "notes": "Dual oscillator confluence. High trade count, small edges — slippage/fees matter more here. Measure carefully in backtest."
+    },
+    {
+      "id": "ref-010",
+      "label": "BTC breakout — Ichimoku TK cross on 4h",
+      "asset": "BTC",
+      "timeframe": "4h",
+      "category": "breakout",
+      "description": "Ichimoku Tenkan/Kijun crossover — a trend-confirmation breakout. Enters on TK cross up with bullish cloud posture, exits on TK cross down.",
+      "entry_signals": [
+        { "name": "ichimoku_tk_cross", "signal_type": "TRIGGER", "params": { "window_tenkan": 9, "window_kijun": 26, "window_senkou": 52, "direction": "up" } },
+        { "name": "ichimoku_bullish", "signal_type": "FILTER", "params": { "window_tenkan": 9, "window_kijun": 26, "window_senkou": 52 } }
+      ],
+      "exit_signals": [
+        { "name": "ichimoku_tk_cross", "signal_type": "TRIGGER", "params": { "window_tenkan": 9, "window_kijun": 26, "window_senkou": 52, "direction": "down" } }
+      ],
+      "execution_config": { "max_risk_per_trade": 0.012, "max_open_positions": 2 },
+      "source": "curated",
+      "notes": "Ichimoku is self-filtering — the bullish-cloud filter ensures we only take TK crosses in confirmed uptrends. Classic 9/26/52 periods."
+    },
+    {
+      "id": "ref-011",
+      "label": "ETH trend-follow conservative — SMA 50/200 on 1d",
+      "asset": "ETH",
+      "timeframe": "1d",
+      "category": "trend_following",
+      "description": "The 'golden cross' on daily: SMA(50) crosses above SMA(200). Long-term position trading. Trade count per year: 1-3.",
+      "entry_signals": [
+        { "name": "sma_cross_up", "signal_type": "TRIGGER", "params": { "window_fast": 50, "window_slow": 200 } }
+      ],
+      "exit_signals": [
+        { "name": "sma_cross_down", "signal_type": "TRIGGER", "params": { "window_fast": 50, "window_slow": 200 } }
+      ],
+      "execution_config": { "max_risk_per_trade": 0.025, "max_open_positions": 1 },
+      "source": "curated",
+      "notes": "Slow as molasses, but on BTC/ETH historically captures the bulk of bull markets. Zero daily attention required."
+    },
+    {
+      "id": "ref-012",
+      "label": "BTC volatility expansion — ATR filter + MACD on 4h",
+      "asset": "BTC",
+      "timeframe": "4h",
+      "category": "volatility",
+      "description": "Trade MACD crossovers only during high-volatility regimes (ATR-based). Avoids the death of trend systems during ranging markets.",
+      "entry_signals": [
+        { "name": "macd_bullish_cross", "signal_type": "TRIGGER", "params": { "window_fast": 12, "window_slow": 26, "window_sign": 9 } },
+        { "name": "atr_high_volatility", "signal_type": "FILTER", "params": { "window": 14, "threshold_pct": 2.0 } }
+      ],
+      "exit_signals": [
+        { "name": "macd_bearish_cross", "signal_type": "TRIGGER", "params": { "window_fast": 12, "window_slow": 26, "window_sign": 9 } }
+      ],
+      "execution_config": { "max_risk_per_trade": 0.015, "max_open_positions": 2 },
+      "source": "curated",
+      "notes": "Volatility filter reduces trade count but systematically skips the worst regime for trend systems. Good pairing for momentum goals."
+    }
+  ]
+}

--- a/server/src/services/reference_strategies_service.py
+++ b/server/src/services/reference_strategies_service.py
@@ -1,0 +1,195 @@
+"""reference_strategies_service — curated seed library of known-good strategies.
+
+Mechanism 2 from the /create-strategy skill: instead of library-default
+parameter guessing, the agent pulls from a curated set of strategies
+that are known to backtest reasonably on the (asset, timeframe) combo.
+
+Today this is backed by a hand-curated JSON file. When MangroveOracle
+issue #156 + the MangroveAI reference-strategies endpoint land, this
+service swaps its backend to `mangroveai.reference_strategies.search()`
+with no change to callers. The interface here mirrors what that
+endpoint will return.
+
+See docs in `data/reference_strategies.json`.
+"""
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel
+
+from src.shared import timeframes
+from src.shared.logging import get_logger
+
+_log = get_logger(__name__)
+
+_DATA_PATH = Path(__file__).parent / "data" / "reference_strategies.json"
+
+
+class ReferenceSignal(BaseModel):
+    name: str
+    signal_type: str  # TRIGGER | FILTER
+    params: dict[str, Any]
+
+
+class ReferenceStrategy(BaseModel):
+    id: str
+    label: str
+    asset: str
+    timeframe: str
+    category: str  # momentum | mean_reversion | trend_following | breakout | volatility
+    description: str
+    entry_signals: list[ReferenceSignal]
+    exit_signals: list[ReferenceSignal]
+    execution_config: dict[str, Any]
+    source: str
+    notes: str = ""
+
+
+@lru_cache(maxsize=1)
+def _load_all() -> list[ReferenceStrategy]:
+    """Read + validate the JSON seed file. Cached for process lifetime."""
+    if not _DATA_PATH.is_file():
+        _log.warning("reference_strategies.seed_missing", path=str(_DATA_PATH))
+        return []
+    raw = json.loads(_DATA_PATH.read_text())
+    items = raw.get("strategies", [])
+    parsed: list[ReferenceStrategy] = []
+    for i, item in enumerate(items):
+        try:
+            parsed.append(ReferenceStrategy.model_validate(item))
+        except Exception as e:  # noqa: BLE001 — validation errors are loud enough in logs
+            _log.warning("reference_strategies.invalid_entry", index=i, error=str(e), id=item.get("id"))
+    _log.info("reference_strategies.loaded", count=len(parsed), path=str(_DATA_PATH))
+    return parsed
+
+
+def _detect_category(text: str) -> str | None:
+    """Auto-detect intended strategy category from a user-supplied goal/style string.
+
+    Mirrors ai_copilot's `_detect_strategy_type` in shape.
+    """
+    t = (text or "").lower()
+    if any(k in t for k in ("mean revers", "bollinger", "oversold", "bounce", "buy the dip")):
+        return "mean_reversion"
+    if any(k in t for k in ("breakout", "donchian", "channel", "range expansion", "ichimoku")):
+        return "breakout"
+    if any(k in t for k in ("momentum", "macd", "roc", "stochastic", "rsi cross")):
+        return "momentum"
+    if any(k in t for k in ("volatility", "atr", "squeeze", "high vol", "vol expansion")):
+        return "volatility"
+    if any(k in t for k in ("trend", "ema cross", "sma cross", "golden cross", "adx", "supertrend")):
+        return "trend_following"
+    return None
+
+
+def search(
+    asset: str,
+    timeframe: str | None = None,
+    category: str | None = None,
+    goal_hint: str | None = None,
+    limit: int = 5,
+) -> list[ReferenceStrategy]:
+    """Return up to `limit` reference strategies matching the filter.
+
+    Ranking (most → least specific):
+      1. exact asset + exact timeframe + exact category match
+      2. exact asset + exact timeframe (any category)
+      3. exact asset (any timeframe or category)
+      4. exact category match only (for cross-asset learnings)
+      5. everything else, capped at `limit`
+
+    If `category` is None and `goal_hint` is set, a category is auto-
+    detected from the hint via `_detect_category`.
+    """
+    asset_u = (asset or "").upper().strip()
+    tf = timeframes.canonicalize_timeframe(timeframe) if timeframe else None
+    cat = (category or _detect_category(goal_hint or "") or None)
+    if cat:
+        cat = cat.lower()
+
+    all_refs = _load_all()
+
+    # Score each ref by specificity. Higher = better match.
+    def score(r: ReferenceStrategy) -> int:
+        s = 0
+        if asset_u and r.asset.upper() == asset_u:
+            s += 8
+        if tf and timeframes.canonicalize_timeframe(r.timeframe) == tf:
+            s += 4
+        if cat and r.category.lower() == cat:
+            s += 2
+        return s
+
+    ranked = sorted(all_refs, key=lambda r: (-score(r), r.id))
+    # Drop any with score 0 ONLY if we have better matches; otherwise fall
+    # through to show something rather than nothing.
+    top = [r for r in ranked if score(r) > 0]
+    if len(top) >= limit:
+        return top[:limit]
+    # Pad with the rest (preserves ordering).
+    seen = {r.id for r in top}
+    for r in ranked:
+        if r.id not in seen:
+            top.append(r)
+            if len(top) >= limit:
+                break
+    return top[:limit]
+
+
+def get(reference_id: str) -> ReferenceStrategy | None:
+    """Look up a single reference by id."""
+    for r in _load_all():
+        if r.id == reference_id:
+            return r
+    return None
+
+
+def list_all() -> list[ReferenceStrategy]:
+    """Return the whole seed set. Mainly for diagnostics / docs."""
+    return list(_load_all())
+
+
+def build_from_reference(
+    reference_id: str,
+    timeframe_override: str | None = None,
+    name: str | None = None,
+) -> dict[str, Any]:
+    """Produce a create_strategy_manual-compatible payload from a reference.
+
+    Copies the reference's signals EXACTLY, only rewriting each signal's
+    `timeframe` field if `timeframe_override` is supplied (and canonicalizes
+    whatever it gets). Matches ai_copilot's build_strategy skill contract:
+    reference params are trusted; user only picks timeframe + name.
+
+    Raises ValueError if reference_id is unknown.
+    """
+    ref = get(reference_id)
+    if ref is None:
+        raise ValueError(f"reference_id {reference_id!r} not found")
+
+    tf = timeframes.canonicalize_timeframe(timeframe_override or ref.timeframe)
+
+    def _to_rule(sig: ReferenceSignal) -> dict[str, Any]:
+        return {
+            "name": sig.name,
+            "signal_type": sig.signal_type,
+            "timeframe": tf,
+            "params": dict(sig.params),
+        }
+
+    entry = [_to_rule(s) for s in ref.entry_signals]
+    exit_rules = [_to_rule(s) for s in ref.exit_signals]
+
+    return {
+        "name": name or f"{ref.label} [from {ref.id}]",
+        "asset": ref.asset,
+        "timeframe": tf,
+        "entry": entry,
+        "exit": exit_rules,
+        "execution_config": dict(ref.execution_config),
+        "source_reference_id": ref.id,
+    }

--- a/server/tests/unit/test_reference_strategies_service.py
+++ b/server/tests/unit/test_reference_strategies_service.py
@@ -1,0 +1,163 @@
+"""Unit tests for reference_strategies_service.
+
+Covers:
+- JSON seed loads + parses into ReferenceStrategy models
+- `search` ranks by specificity (asset+timeframe+category > asset+timeframe > asset > category)
+- `search` auto-detects category from goal_hint when category omitted
+- `get` returns None for unknown ids
+- `build_from_reference` copies signals exactly, applies timeframe override
+- `build_from_reference` rejects unknown reference_id
+- Timeframe canonicalization propagates (so "1HR" → "1h" in the output)
+"""
+import pytest
+
+from src.services import reference_strategies_service as svc
+from src.shared.errors import ValidationError
+
+
+class TestLoad:
+    def test_seed_loads(self):
+        items = svc.list_all()
+        assert len(items) >= 8, "seed should have at least 8 strategies"
+
+    def test_all_have_required_fields(self):
+        for r in svc.list_all():
+            assert r.id
+            assert r.asset
+            assert r.timeframe
+            assert r.category
+            assert r.entry_signals, f"{r.id} has no entry signals"
+            # Exit can be empty; execution_config can be sparse.
+            assert isinstance(r.execution_config, dict)
+
+    def test_all_timeframes_are_canonical(self):
+        """Seed data should use canonical timeframes. Protects against typos
+        that would cause search() to miss the entry."""
+        from src.shared import timeframes
+        for r in svc.list_all():
+            # Should not raise
+            canonical = timeframes.canonicalize_timeframe(r.timeframe)
+            assert canonical == r.timeframe, f"{r.id} timeframe {r.timeframe!r} non-canonical"
+
+
+class TestSearch:
+    def test_asset_exact_match_wins(self):
+        results = svc.search(asset="ETH", limit=10)
+        assert len(results) > 0
+        # Top result must be ETH-specific.
+        assert results[0].asset.upper() == "ETH"
+
+    def test_asset_plus_timeframe_outranks_asset_only(self):
+        results = svc.search(asset="ETH", timeframe="1h", limit=5)
+        assert len(results) > 0
+        # Top result should be ETH on 1h.
+        top = results[0]
+        assert top.asset.upper() == "ETH"
+        assert top.timeframe == "1h"
+
+    def test_category_filter_prefers_matching_category(self):
+        results = svc.search(asset="BTC", category="momentum", limit=5)
+        assert len(results) > 0
+        # At least the top result should be BTC momentum.
+        assert results[0].asset.upper() == "BTC"
+        assert results[0].category == "momentum"
+
+    def test_goal_hint_auto_detects_category(self):
+        results = svc.search(asset="ETH", goal_hint="mean reversion bounce play", limit=3)
+        # Whatever's returned, the top result should be mean_reversion if we have one.
+        # (seed has ref-003 and ref-009 as mean_reversion ETH)
+        mean_rev_eth = [r for r in svc.list_all() if r.asset.upper() == "ETH" and r.category == "mean_reversion"]
+        if mean_rev_eth:
+            assert results[0].category == "mean_reversion", f"goal_hint should route to mean_reversion; got {results[0].category}"
+
+    def test_respects_limit(self):
+        results = svc.search(asset="ETH", limit=2)
+        assert len(results) <= 2
+
+    def test_fallback_when_no_match(self):
+        """Even on an unknown asset, return SOMETHING rather than empty —
+        gives the agent a chance to offer alternatives."""
+        results = svc.search(asset="DOGE", limit=3)
+        assert len(results) > 0
+
+
+class TestGet:
+    def test_known_id(self):
+        all_items = svc.list_all()
+        first_id = all_items[0].id
+        fetched = svc.get(first_id)
+        assert fetched is not None
+        assert fetched.id == first_id
+
+    def test_unknown_id(self):
+        assert svc.get("ref-999-does-not-exist") is None
+
+
+class TestBuildFromReference:
+    def test_copies_signals_exactly(self):
+        # Pick any reference and build without overrides.
+        ref = svc.list_all()[0]
+        payload = svc.build_from_reference(reference_id=ref.id)
+        # Signals must match exactly except `timeframe` is now the canonical on each rule.
+        assert len(payload["entry"]) == len(ref.entry_signals)
+        for got, expected in zip(payload["entry"], ref.entry_signals):
+            assert got["name"] == expected.name
+            assert got["signal_type"] == expected.signal_type
+            assert got["params"] == expected.params, f"{ref.id}: params MUST be copied verbatim"
+
+    def test_timeframe_override_applies_to_all_rules(self):
+        ref = svc.list_all()[0]  # has timeframe "1h"
+        payload = svc.build_from_reference(
+            reference_id=ref.id, timeframe_override="4h",
+        )
+        assert payload["timeframe"] == "4h"
+        for rule in payload["entry"] + payload["exit"]:
+            assert rule["timeframe"] == "4h"
+
+    def test_timeframe_canonicalizes(self):
+        ref = svc.list_all()[0]
+        payload = svc.build_from_reference(reference_id=ref.id, timeframe_override="4HR")
+        assert payload["timeframe"] == "4h"
+        for rule in payload["entry"]:
+            assert rule["timeframe"] == "4h"
+
+    def test_unsupported_timeframe_rejected(self):
+        ref = svc.list_all()[0]
+        with pytest.raises(ValidationError):
+            svc.build_from_reference(reference_id=ref.id, timeframe_override="1m")
+
+    def test_unknown_id_raises(self):
+        with pytest.raises(ValueError):
+            svc.build_from_reference(reference_id="ref-missing")
+
+    def test_payload_shape_matches_create_strategy_manual(self):
+        """The returned payload should be directly POST-able to /strategies/manual."""
+        ref = svc.list_all()[0]
+        payload = svc.build_from_reference(reference_id=ref.id)
+        # Required fields on StrategyManualRequest:
+        for key in ("name", "asset", "timeframe", "entry"):
+            assert key in payload, f"missing required field {key}"
+        assert isinstance(payload["entry"], list)
+        assert isinstance(payload["exit"], list)
+
+
+class TestCategoryDetection:
+    @pytest.mark.parametrize(
+        "hint,expected",
+        [
+            ("mean reversion bounce", "mean_reversion"),
+            ("buy the dip on oversold RSI", "mean_reversion"),
+            ("momentum swing trade", "momentum"),
+            ("MACD crossover", "momentum"),
+            ("breakout above the range", "breakout"),
+            ("Ichimoku breakout", "breakout"),
+            ("trend following setup", "trend_following"),
+            ("golden cross SMA", "trend_following"),
+            ("high volatility expansion", "volatility"),
+            ("ATR squeeze", "volatility"),
+            ("random goal text", None),
+            ("", None),
+        ],
+    )
+    def test_detect_category(self, hint, expected):
+        assert svc._detect_category(hint) == expected


### PR DESCRIPTION
Ports MangroveAI `ai_copilot`'s strategy-creation state machine into a Claude Code skill, with two mechanisms for agent intuition:

## Mechanism 1 — KB-grounded parameters (fallback)

For any signal the agent considers in a custom build, it MUST call `kb_search(<signal_name> parameters <asset> <timeframe>)` and cite the result before writing params. No library-default fallback — if the KB has nothing, the agent says so and flags the setup.

## Mechanism 2 — Reference-first (primary path)

Curated known-good strategies keyed by (asset, timeframe, category). The agent searches these BEFORE picking signals manually. The seed ships with 12 strategies spanning BTC/ETH × 1h/4h/1d × five categories.

New routes:
```
GET  /api/v1/agent/reference-strategies/search?asset=&timeframe=&goal_hint=
GET  /api/v1/agent/reference-strategies/{id}
POST /api/v1/agent/reference-strategies/{id}/build
```

New MCP tools:
- `search_reference_strategies(asset, timeframe, category, goal_hint, limit)`
- `build_strategy_from_reference(reference_id, timeframe, name)`

New skill:
- `.claude/skills/create-strategy/SKILL.md` — four phases (A search, B build, C custom KB-grounded, D autonomous fallback). Enforces signal composition rules and prohibits library-default params.

## Mechanism 3 — Deferred

Mined parameter priors from the 1.4M-strategy dataset. Tracked by [MangroveOracle issue #156](https://github.com/MangroveTechnologies/MangroveOracle/issues/156). When the MangroveAI endpoint lands, `reference_strategies_service` swaps its source without caller changes.

## Test plan

- [x] Seed JSON loads and validates (29 new tests)
- [x] `search` ranking: asset+timeframe+category > asset+timeframe > asset > category
- [x] `search` auto-detects category from goal_hint (11 parameterized cases)
- [x] `build_from_reference` copies signals + params EXACTLY
- [x] Timeframe override canonicalizes (`1HR` → `1h`)
- [x] Unsupported timeframes (`1m`) rejected via `VALIDATION_ERROR`
- [x] Unknown `reference_id` returns 404
- [x] Full suite: **311 passed / 2 skipped** (was 282/2 before)
- [x] End-to-end REST verified on bare-metal (search, build ref-004 at 4h, 1m rejection, 404 unknown)
- [ ] Reviewer: in a fresh Claude Code session, ask "build me a momentum strategy for ETH on 1h" and confirm the agent calls `search_reference_strategies` BEFORE writing any params

## Related

- `MangroveAI/src/MangroveAI/domains/ai_copilot/agentic/skills/build_strategy.py` + `search_strategies.py` — source pattern
- `MangroveAI/src/MangroveAI/scripts/migrations/022_reference_strategies.sql` — upstream schema (which our service mirrors in-memory today)
- MangroveOracle issue #156 — upstream pipeline for Mechanism 3