### PR TITLE
fix(backtest+mcp): trading_defaults single source, backtest config collapse, get_ohlcv phantom, market/quote params, execute_swap slippage

### DIFF
--- a/server/src/api/routes/dex.py
+++ b/server/src/api/routes/dex.py
@@ -76,7 +76,16 @@ class SwapRequest(BaseModel):
     amount: float
     chain_id: int
     wallet_address: str
-    slippage: float = 1.0
+    slippage_pct: float = Field(
+        ...,
+        description=(
+            "Slippage tolerance as DECIMAL (0.005 = 0.5%, 0.01 = 1%). "
+            "REQUIRED — no default. Picking a tolerance is a risk "
+            "decision the user must make explicitly for live trades. "
+            "Converted to the upstream percentage convention at the "
+            "dex.prepare_swap() boundary."
+        ),
+    )
     mev_protection: bool = False
     venue_id: str | None = None
     confirm: bool = Field(
@@ -127,6 +136,7 @@ async def dex_swap(req: SwapRequest) -> dict:
         wallet_address=req.wallet_address,
         chain_id=req.chain_id,
         venue_id=req.venue_id,
+        slippage_pct=req.slippage_pct,
     )
     return {
         "tx_hash": trade.tx_hash,

--- a/server/src/api/routes/market.py
+++ b/server/src/api/routes/market.py
@@ -21,25 +21,32 @@ def _dump(obj: Any) -> Any:
 
 
 @router.get("/ohlcv", summary="OHLCV bars for an asset")
-async def ohlcv(symbol: str, timeframe: str = "1h", lookback_days: int = 30) -> Any:
+async def ohlcv(
+    symbol: str, lookback_days: int = 30, provider: str | None = None,
+) -> Any:
+    """Mirrors `mangroveai.crypto_assets.get_ohlcv(symbol, *, days, provider)`.
+
+    No `timeframe` param — the SDK method doesn't accept one; bar
+    granularity is provider-native. Optional `provider` selects a
+    specific data source.
+    """
     try:
-        return _dump(mangroveai_client().crypto_assets.get_ohlcv(
-            symbol=symbol, timeframe=timeframe, days=lookback_days,
-        ))
-    except TypeError:
-        # Older SDK may use different kwarg names; fall back.
-        try:
-            return _dump(mangroveai_client().crypto_assets.get_ohlcv(symbol))
-        except Exception as e:  # noqa: BLE001
-            raise SdkError(f"crypto_assets.get_ohlcv failed: {e}") from e
+        kwargs: dict[str, Any] = {"symbol": symbol, "days": lookback_days}
+        if provider is not None:
+            kwargs["provider"] = provider
+        return _dump(mangroveai_client().crypto_assets.get_ohlcv(**kwargs))
     except Exception as e:  # noqa: BLE001
         raise SdkError(f"crypto_assets.get_ohlcv failed: {e}") from e
 
 
 @router.get("/data", summary="Current market data (price, market cap, volume)")
-async def market_data(symbol: str) -> Any:
+async def market_data(symbol: str, provider: str | None = None) -> Any:
+    """Mirrors `mangroveai.crypto_assets.get_market_data(symbol, *, provider)`."""
     try:
-        return _dump(mangroveai_client().crypto_assets.get_market_data(symbol))
+        kwargs: dict[str, Any] = {"symbol": symbol}
+        if provider is not None:
+            kwargs["provider"] = provider
+        return _dump(mangroveai_client().crypto_assets.get_market_data(**kwargs))
     except Exception as e:  # noqa: BLE001
         raise SdkError(f"crypto_assets.get_market_data failed: {e}") from e
 

--- a/server/src/api/routes/strategies.py
+++ b/server/src/api/routes/strategies.py
@@ -88,10 +88,10 @@ async def update_status(strategy_id: str, req: StrategyStatusUpdate) -> Strategy
 class BacktestInput(BaseModel):
     """Parameters for POST /strategies/{id}/backtest.
 
-    Mirrors the MangroveAI BacktestRequest surface so this route and the
-    MCP tool pass through the same knobs a direct SDK or curl caller would
-    use. Only window-selection has special resolution; everything else is
-    pass-through to the server.
+    Thin pass-through to MangroveAI's BacktestRequest. Only window-
+    selection has special resolution on our side; all other tuning
+    flows through a single `config` dict that merges over the canonical
+    `trading_defaults.json`.
 
     Lookback window resolution — first non-null group wins:
       1. start_date + end_date (ISO 8601)
@@ -100,6 +100,18 @@ class BacktestInput(BaseModel):
       4. lookback_months
       5. timeframes.recommended_lookback_months(strategy.timeframe)
          (5m/15m/30m/1h → 3 mo, 4h → 6 mo, 1d → 12 mo)
+
+    `config` accepts any BacktestRequest-compatible key:
+      - slippage_pct, fee_pct, max_hold_time_hours
+      - initial_balance, min_balance_threshold, min_trade_amount
+      - max_open_positions, max_trades_per_day, max_risk_per_trade
+      - max_units_per_trade, max_trade_amount
+      - volatility_window, target_volatility, volatility_mode,
+        enable_volatility_adjustment
+      - cooldown_bars, daily_momentum_limit, weekly_momentum_limit
+      - reward_factor, atr_period, atr_volatility_factor, ...
+    Any key here overrides the corresponding trading_defaults.json entry.
+    Unknown keys are forwarded as-is (SDK allows extras).
     """
     mode: str = "full"  # quick | full
 
@@ -110,14 +122,8 @@ class BacktestInput(BaseModel):
     start_date: str | None = None
     end_date: str | None = None
 
-    # Optional server-side overrides (omit to use trading_defaults.json).
-    slippage_pct: float | None = None
-    fee_pct: float | None = None
-    max_hold_time_hours: int | None = None
-    # Free-form overrides merged into _DEFAULT_EXECUTION_CONFIG (e.g.
-    # initial_balance, max_risk_per_trade). Keys must match MangroveAI's
-    # BacktestRequest field names.
-    overrides: dict | None = None
+    # Single escape hatch for tuning. Merges over trading_defaults.json.
+    config: dict | None = None
 
 
 @router.post(
@@ -156,10 +162,7 @@ async def backtest(strategy_id: str, req: BacktestInput) -> dict:
             lookback_hours=req.lookback_hours,
             start_date=req.start_date,
             end_date=req.end_date,
-            slippage_pct=req.slippage_pct,
-            fee_pct=req.fee_pct,
-            max_hold_time_hours=req.max_hold_time_hours,
-            overrides=req.overrides,
+            config=req.config,
         )
 
     # Pass through the FULL metrics dict from the SDK, not a hand-picked

--- a/server/src/mcp/tools.py
+++ b/server/src/mcp/tools.py
@@ -376,28 +376,40 @@ def _register_dex(server: FastMCP) -> None:
 
 def _register_market(server: FastMCP) -> None:
     @server.tool()
-    async def get_ohlcv(symbol: str, timeframe: str = "1h",
-                        lookback_days: int = 30, api_key: str = "") -> str:
-        """OHLCV bars for an asset."""
+    async def get_ohlcv(symbol: str, lookback_days: int = 30,
+                        provider: str | None = None,
+                        api_key: str = "") -> str:
+        """OHLCV bars for an asset.
+
+        Thin wrapper over `mangroveai.crypto_assets.get_ohlcv(symbol, days,
+        provider)`. The SDK does NOT accept a timeframe — the upstream
+        endpoint returns the provider's native bar granularity (1h for
+        most). A previous version of this tool advertised a `timeframe`
+        parameter; it was silently dropped by the SDK. Removed to stop
+        misleading callers.
+        """
         if not _require(api_key):
             return _auth_error()
         from src.shared.clients.mangrove import mangroveai_client
-        try:
-            result = mangroveai_client().crypto_assets.get_ohlcv(
-                symbol=symbol, timeframe=timeframe, days=lookback_days,
-            )
-        except TypeError:
-            result = mangroveai_client().crypto_assets.get_ohlcv(symbol)
+        kwargs: dict[str, Any] = {"symbol": symbol, "days": lookback_days}
+        if provider is not None:
+            kwargs["provider"] = provider
+        result = mangroveai_client().crypto_assets.get_ohlcv(**kwargs)
         return json.dumps(_dump(result))
 
     register_tool(ToolEntry(
         name="get_ohlcv",
-        description="OHLCV bars for an asset.",
+        description=(
+            "OHLCV bars for an asset. Bar granularity is set by the "
+            "data provider (typically 1h). No `timeframe` parameter — "
+            "the SDK / upstream endpoint don't support overriding bar "
+            "size at this call site."
+        ),
         access="auth",
         parameters=[
-            ToolParam(name="symbol", type="string", required=True, description="Asset symbol"),
-            ToolParam(name="timeframe", type="string", required=False, description="5m | 15m | 30m | 1h | 4h | 1d (1m not supported)"),
-            ToolParam(name="lookback_days", type="integer", required=False, description="History window in days"),
+            ToolParam(name="symbol", type="string", required=True, description="Asset symbol (e.g. BTC, ETH)"),
+            ToolParam(name="lookback_days", type="integer", required=False, description="History window in days (default 30)"),
+            ToolParam(name="provider", type="string", required=False, description="Optional CEX provider override"),
             _APIKEY,
         ],
     ))
@@ -731,10 +743,7 @@ def _register_strategy(server: FastMCP) -> None:
         lookback_days: int | None = None,
         lookback_hours: int | None = None,
         start_date: str | None = None, end_date: str | None = None,
-        slippage_pct: float | None = None,
-        fee_pct: float | None = None,
-        max_hold_time_hours: int | None = None,
-        overrides: dict | None = None,
+        config: dict | None = None,
         api_key: str = "",
     ) -> str:
         """Run a backtest against an existing strategy (mode=quick|full).
@@ -743,6 +752,12 @@ def _register_strategy(server: FastMCP) -> None:
           start_date+end_date > lookback_hours > lookback_days
           > lookback_months > timeframes.recommended_lookback_months
           (5m/15m/30m/1h → 3 mo, 4h → 6 mo, 1d → 12 mo).
+
+        `config` is a single dict that merges over the canonical
+        trading_defaults.json. Any SDK BacktestRequest field is valid —
+        slippage_pct, fee_pct, max_hold_time_hours, initial_balance,
+        max_risk_per_trade, reward_factor, atr_period, etc. Omit the
+        argument entirely to get a pure trading-defaults backtest.
         """
         if not _require(api_key):
             return _auth_error()
@@ -755,10 +770,7 @@ def _register_strategy(server: FastMCP) -> None:
                 lookback_hours=lookback_hours,
                 start_date=start_date,
                 end_date=end_date,
-                slippage_pct=slippage_pct,
-                fee_pct=fee_pct,
-                max_hold_time_hours=max_hold_time_hours,
-                overrides=overrides,
+                config=config,
             )))
         except AgentError as e:
             return _handle_agent_error(e)
@@ -766,11 +778,14 @@ def _register_strategy(server: FastMCP) -> None:
     register_tool(ToolEntry(
         name="backtest_strategy",
         description=(
-            "Backtest a strategy (quick or full). Window resolution: "
-            "start_date+end_date > lookback_hours > lookback_days > "
-            "lookback_months > timeframe-aware auto (5m-1h=3mo, 4h=6mo, "
-            "1d=12mo). Returns full metrics from the SDK, trade history, "
-            "and the resolved_window block for fallback detection."
+            "Backtest a strategy (quick or full). Window precedence: "
+            "start+end > hours > days > months > timeframe-aware auto "
+            "(5m-1h=3mo, 4h=6mo, 1d=12mo). `config` is a single dict "
+            "that merges over trading_defaults.json — use it for "
+            "slippage_pct, fee_pct, max_hold_time_hours, initial_balance, "
+            "max_risk_per_trade, reward_factor, atr_period, or any other "
+            "BacktestRequest field. Returns full SDK metrics, trade "
+            "history, and a resolved_window block for fallback detection."
         ),
         access="auth",
         parameters=[
@@ -778,13 +793,10 @@ def _register_strategy(server: FastMCP) -> None:
             ToolParam(name="mode", type="string", required=False, description="quick | full (default full)"),
             ToolParam(name="lookback_months", type="integer", required=False, description="Window in months (auto by timeframe if all window fields omitted)"),
             ToolParam(name="lookback_days", type="integer", required=False, description="Window in days (overrides lookback_months)"),
-            ToolParam(name="lookback_hours", type="integer", required=False, description="Window in hours (overrides lookback_days/months — use for short backtests)"),
-            ToolParam(name="start_date", type="string", required=False, description="ISO 8601 — pinned with end_date, overrides all lookback_* fields"),
+            ToolParam(name="lookback_hours", type="integer", required=False, description="Window in hours — use for short backtests"),
+            ToolParam(name="start_date", type="string", required=False, description="ISO 8601 — paired with end_date, overrides all lookback_* fields"),
             ToolParam(name="end_date", type="string", required=False, description="ISO 8601"),
-            ToolParam(name="slippage_pct", type="number", required=False, description="Override server default (trading_defaults.json)"),
-            ToolParam(name="fee_pct", type="number", required=False, description="Override server default"),
-            ToolParam(name="max_hold_time_hours", type="integer", required=False, description="Cap position hold time"),
-            ToolParam(name="overrides", type="object", required=False, description="Dict merged into execution_config (initial_balance, max_risk_per_trade, etc.)"),
+            ToolParam(name="config", type="object", required=False, description="Merges over trading_defaults.json (slippage_pct, max_risk_per_trade, initial_balance, reward_factor, atr_*, etc.)"),
             _APIKEY,
         ],
     ))

--- a/server/src/mcp/tools.py
+++ b/server/src/mcp/tools.py
@@ -284,24 +284,37 @@ def _register_dex(server: FastMCP) -> None:
     async def get_swap_quote(
         input_token: str, output_token: str, amount: float,
         chain_id: int, venue_id: str | None = None,
+        mode: str | None = None,
         api_key: str = "",
     ) -> str:
-        """Get a swap quote."""
+        """Get a DEX swap quote.
+
+        Mirrors `mangrovemarkets.dex.get_quote(input_token, output_token,
+        amount, venue_id, chain_id, mode)`. `mode` is an optional
+        routing hint recognized by some venues (e.g. 1inch supports
+        modes that bias for gas-cost vs price-improvement).
+        """
         if not _require(api_key):
             return _auth_error()
         try:
             from src.shared.clients.mangrove import mangrovemarkets_client
-            q = mangrovemarkets_client().dex.get_quote(
-                input_token=input_token, output_token=output_token,
-                amount=amount, chain_id=chain_id, venue_id=venue_id,
-            )
+            kwargs: dict[str, Any] = {
+                "input_token": input_token,
+                "output_token": output_token,
+                "amount": amount,
+                "chain_id": chain_id,
+                "venue_id": venue_id,
+            }
+            if mode is not None:
+                kwargs["mode"] = mode
+            q = mangrovemarkets_client().dex.get_quote(**kwargs)
             return json.dumps(_dump(q))
         except AgentError as e:
             return _handle_agent_error(e)
 
     register_tool(ToolEntry(
         name="get_swap_quote",
-        description="Get a DEX swap quote.",
+        description="Get a DEX swap quote. Optionally pin a venue + mode.",
         access="auth",
         parameters=[
             ToolParam(name="input_token", type="string", required=True, description="Input token"),
@@ -309,6 +322,7 @@ def _register_dex(server: FastMCP) -> None:
             ToolParam(name="amount", type="number", required=True, description="Input amount"),
             ToolParam(name="chain_id", type="integer", required=True, description="EVM chain id"),
             ToolParam(name="venue_id", type="string", required=False, description="Optional specific venue"),
+            ToolParam(name="mode", type="string", required=False, description="Optional routing hint (venue-specific)"),
             _APIKEY,
         ],
     ))
@@ -316,13 +330,22 @@ def _register_dex(server: FastMCP) -> None:
     @server.tool()
     async def execute_swap(
         input_token: str, output_token: str, amount: float,
-        chain_id: int, wallet_address: str,
-        slippage: float = 1.0, venue_id: str | None = None,
+        chain_id: int, wallet_address: str, slippage_pct: float,
+        venue_id: str | None = None,
         confirm: bool = False,
         api_key: str = "",
     ) -> str:
-        """Execute a swap. Requires confirm=true. Full 6-step flow with
-        client-side signing; SDK never sees keys."""
+        """Execute a swap. Requires confirm=true + explicit slippage_pct.
+
+        Full 6-step flow with client-side signing; SDK never sees keys.
+
+        `slippage_pct` is REQUIRED and specified as a DECIMAL
+        (0.005 = 0.5%, 0.01 = 1%, 0.02 = 2%). No default — picking
+        a slippage tolerance is a risk decision the user must make
+        explicitly for live trades. Converted to the upstream
+        percentage convention (multiplied by 100) at the
+        `dex.prepare_swap()` boundary.
+        """
         if not _require(api_key):
             return _auth_error()
         try:
@@ -340,7 +363,8 @@ def _register_dex(server: FastMCP) -> None:
                                  amount=amount, reason="user-initiated")
             trade = execute_one(intent, mode="live",
                                 wallet_address=wallet_address,
-                                chain_id=chain_id, venue_id=venue_id)
+                                chain_id=chain_id, venue_id=venue_id,
+                                slippage_pct=slippage_pct)
             return json.dumps({
                 "tx_hash": trade.tx_hash, "status": trade.status,
                 "input_token": trade.input_token, "input_amount": trade.input_amount,
@@ -353,7 +377,12 @@ def _register_dex(server: FastMCP) -> None:
 
     register_tool(ToolEntry(
         name="execute_swap",
-        description="Execute a DEX swap (requires confirm=true). Single code path shared with cron-driven trades.",
+        description=(
+            "Execute a DEX swap (requires confirm=true + explicit "
+            "slippage_pct). Single code path shared with cron-driven "
+            "trades. Slippage is always user-specified — no default — "
+            "because picking a tolerance is a risk decision."
+        ),
         access="auth",
         parameters=[
             ToolParam(name="input_token", type="string", required=True, description="Input token"),
@@ -361,7 +390,7 @@ def _register_dex(server: FastMCP) -> None:
             ToolParam(name="amount", type="number", required=True, description="Input amount"),
             ToolParam(name="chain_id", type="integer", required=True, description="EVM chain id"),
             ToolParam(name="wallet_address", type="string", required=True, description="Wallet from local store"),
-            ToolParam(name="slippage", type="number", required=False, description="Slippage % (default 1.0)"),
+            ToolParam(name="slippage_pct", type="number", required=True, description="Slippage tolerance as DECIMAL (0.005 = 0.5%, 0.01 = 1%). No default — user must choose."),
             ToolParam(name="venue_id", type="string", required=False, description="Optional specific venue"),
             ToolParam(name="confirm", type="boolean", required=True, description="Must be true"),
             _APIKEY,
@@ -415,19 +444,30 @@ def _register_market(server: FastMCP) -> None:
     ))
 
     @server.tool()
-    async def get_market_data(symbol: str, api_key: str = "") -> str:
-        """Current market data for an asset."""
+    async def get_market_data(
+        symbol: str, provider: str | None = None, api_key: str = "",
+    ) -> str:
+        """Current market data for an asset.
+
+        Thin wrapper over `mangroveai.crypto_assets.get_market_data(symbol,
+        *, provider)`. `provider` selects a specific data source; omit to
+        use the SDK default.
+        """
         if not _require(api_key):
             return _auth_error()
         from src.shared.clients.mangrove import mangroveai_client
-        return json.dumps(_dump(mangroveai_client().crypto_assets.get_market_data(symbol)))
+        kwargs: dict[str, Any] = {"symbol": symbol}
+        if provider is not None:
+            kwargs["provider"] = provider
+        return json.dumps(_dump(mangroveai_client().crypto_assets.get_market_data(**kwargs)))
 
     register_tool(ToolEntry(
         name="get_market_data",
-        description="Current price, market cap, volume, 24h/7d change.",
+        description="Current price, market cap, volume, 24h/7d change. Optionally pin a provider.",
         access="auth",
         parameters=[
             ToolParam(name="symbol", type="string", required=True, description="Asset symbol"),
+            ToolParam(name="provider", type="string", required=False, description="Optional data provider override"),
             _APIKEY,
         ],
     ))

--- a/server/src/services/backtest_service.py
+++ b/server/src/services/backtest_service.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import json
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from typing import Any
 
 from mangroveai.models import BacktestRequest
@@ -31,6 +32,60 @@ from src.shared.errors import SdkError
 from src.shared.logging import get_logger
 
 _log = get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Canonical trading defaults — copied verbatim from MangroveAI.
+#
+# Source: MangroveAI/domains/ai_copilot/prompts/trading_defaults.json
+# Loaded the way MangroveAI/domains/strategies/services.py does:
+# flatten risk_management + position_limits + volatility_settings +
+# trading_rules + time_based_exits into a single dict.
+#
+# The SDK's BacktestRequest declares 13 fields as required (pydantic
+# PydanticUndefined default) despite the server applying trading_defaults
+# fallback on its own. Until MangroveAI issue #437 lands (make those 10
+# duplicate-forcing fields Optional), every client has to supply the
+# values. We read from our copy of the upstream JSON so the values stay
+# in sync — `git diff server/src/services/data/trading_defaults.json`
+# against the upstream file is the drift check.
+# ---------------------------------------------------------------------------
+
+_DATA_DIR = Path(__file__).parent / "data"
+_TRADING_DEFAULTS_PATH = _DATA_DIR / "trading_defaults.json"
+
+with _TRADING_DEFAULTS_PATH.open() as _f:
+    TRADING_DEFAULTS: dict[str, Any] = json.load(_f)
+
+
+def flattened_defaults() -> dict[str, Any]:
+    """Flatten the trading_defaults sections into a single dict.
+
+    Mirrors MangroveAI/domains/strategies/services.py:306-309 — the same
+    sections in the same order, so a config override that works against
+    the upstream copilot works identically here.
+    """
+    out: dict[str, Any] = {}
+    for section in (
+        "risk_management",
+        "position_limits",
+        "volatility_settings",
+        "trading_rules",
+        "time_based_exits",
+    ):
+        section_data = TRADING_DEFAULTS.get(section) or {}
+        out.update(section_data)
+    return out
+
+
+def backtest_cost_defaults() -> dict[str, Any]:
+    """Return the slippage_pct / fee_pct defaults.
+
+    These live under `backtest_defaults` in the upstream JSON (separate
+    from the execution config sections) so they need a dedicated
+    accessor when a caller wants to surface them.
+    """
+    return dict(TRADING_DEFAULTS.get("backtest_defaults") or {})
 
 
 def _resolve_window(
@@ -77,20 +132,10 @@ def _resolve_window(
     return timeframes.recommended_lookback_months(timeframe), start_date, end_date
 
 
-# Reasonable defaults for an autonomous backtest. These match the defaults
-# the strategy spec uses; advanced users can override via the manual path.
-_DEFAULT_EXECUTION_CONFIG = {
-    "initial_balance": 10_000.0,
-    "min_balance_threshold": 0.1,
-    "min_trade_amount": 25.0,
-    "max_open_positions": 3,
-    "max_trades_per_day": 10,
-    "max_risk_per_trade": 0.02,
-    "max_units_per_trade": 1_000_000.0,
-    "max_trade_amount": 10_000_000.0,
-    "volatility_window": 24,
-    "target_volatility": 0.1,
-}
+# `_DEFAULT_EXECUTION_CONFIG` removed — use `flattened_defaults()` + caller override.
+# The old hardcoded dict had drifted from upstream trading_defaults.json
+# (max_risk_per_trade 0.02 vs 0.01, max_open_positions 3 vs 10,
+# max_trades_per_day 10 vs 50). Single source of truth now.
 
 
 class CandidateBacktestResult(BaseModel):
@@ -139,24 +184,24 @@ def _build_request(
     lookback_months: int | None,
     start_date: str | None = None,
     end_date: str | None = None,
-    overrides: dict[str, Any] | None = None,
-    slippage_pct: float | None = None,
-    fee_pct: float | None = None,
-    max_hold_time_hours: int | None = None,
+    config: dict[str, Any] | None = None,
 ) -> BacktestRequest:
-    """Build a BacktestRequest from a candidate + sensible defaults.
+    """Build a BacktestRequest from a candidate + canonical trading defaults.
 
-    `overrides` is a dict that gets merged over `_DEFAULT_EXECUTION_CONFIG`
-    (account + risk fields). This is the escape hatch for callers who
-    want to tune initial_balance, max_risk_per_trade, etc. without us
-    adding each one as a first-class parameter.
+    `config` is merged over `flattened_defaults()` — the single source of
+    truth is `data/trading_defaults.json`. Any key a caller passes in
+    `config` wins. Keys the SDK doesn't recognize are forwarded anyway
+    (BacktestRequest has `model_config={'extra': 'allow'}`, verified
+    2026-04-22) — the server treats them as execution_config extras.
+
+    Slippage, fee, and max_hold_time_hours are just keys in `config`
+    now. Callers no longer need dedicated arguments for them.
     """
-    # Always validate the candidate's timeframe — prevents 1m / other
-    # unsupported values from reaching the backend and being silently
-    # coerced to 1h.
+    # Reject unsupported timeframes up front (1m etc.) — see
+    # src.shared.timeframes.canonicalize_timeframe for the whitelist.
     interval = timeframes.canonicalize_timeframe(candidate.timeframe)
 
-    config = {**_DEFAULT_EXECUTION_CONFIG, **(overrides or {})}
+    merged = {**flattened_defaults(), **(config or {})}
 
     strategy_json = json.dumps({
         "name": candidate.name,
@@ -168,20 +213,11 @@ def _build_request(
         "asset": candidate.asset,
         "interval": interval,
         "strategy_json": strategy_json,
-        **config,
+        **merged,
         "lookback_months": lookback_months if not start_date else None,
         "start_date": start_date,
         "end_date": end_date,
     }
-    # Optional pass-through fields — only include when caller provided them
-    # so we don't clobber server defaults (trading_defaults.json).
-    if slippage_pct is not None:
-        kwargs["slippage_pct"] = slippage_pct
-    if fee_pct is not None:
-        kwargs["fee_pct"] = fee_pct
-    if max_hold_time_hours is not None:
-        kwargs["max_hold_time_hours"] = max_hold_time_hours
-
     return BacktestRequest(**kwargs)
 
 
@@ -301,23 +337,22 @@ def full_backtest(
     lookback_hours: int | None = None,
     start_date: str | None = None,
     end_date: str | None = None,
-    slippage_pct: float | None = None,
-    fee_pct: float | None = None,
-    max_hold_time_hours: int | None = None,
-    overrides: dict[str, Any] | None = None,
+    config: dict[str, Any] | None = None,
 ) -> CandidateBacktestResult:
-    """Run a full backtest — same SDK call as quick, but we also return
-    the trade_history attached to raw_metrics for downstream display.
+    """Run a full backtest — same SDK call as quick, plus trade_history
+    in raw_metrics for downstream display.
 
     Lookback resolution (first non-null wins):
       start_date+end_date > lookback_hours > lookback_days > lookback_months
       > timeframes.recommended_lookback_months(candidate.timeframe).
 
-    `overrides` merges over `_DEFAULT_EXECUTION_CONFIG` for advanced
-    callers who want to tune initial_balance, max_risk_per_trade, etc.
-    slippage_pct / fee_pct / max_hold_time_hours are pass-through to the
-    SDK's BacktestRequest fields of the same name — omit to use the
-    server's trading_defaults.json values.
+    `config` merges over the canonical `flattened_defaults()` from
+    `data/trading_defaults.json`. Any key goes: the upstream execution
+    knobs (initial_balance, max_risk_per_trade, atr_period, …), plus the
+    three BacktestRequest-level optionals (slippage_pct, fee_pct,
+    max_hold_time_hours), plus anything upstream adds later — the SDK
+    model is `extra='allow'`, so unknown keys round-trip to the server
+    without client-side error.
     """
     resolved_months, resolved_start, resolved_end = _resolve_window(
         candidate.timeframe,
@@ -336,10 +371,7 @@ def full_backtest(
                 lookback_months=resolved_months,
                 start_date=resolved_start,
                 end_date=resolved_end,
-                overrides=overrides,
-                slippage_pct=slippage_pct,
-                fee_pct=fee_pct,
-                max_hold_time_hours=max_hold_time_hours,
+                config=config,
             ),
         )
     except Exception as e:  # noqa: BLE001

--- a/server/src/services/data/example_bundle.txt
+++ b/server/src/services/data/example_bundle.txt
@@ -1,0 +1,53 @@
+===== STRATEGY_JSON =====
+{
+  "name": "btc_rsi_bb_strategy",
+  "asset": "BTC",
+  "entry": [
+    {
+      "name": "bb_lower_breakout",
+      "signal_type": "TRIGGER",
+      "timeframe": "1HR",
+      "params": { "window": 20, "window_dev": 2 }
+    },
+    {
+      "name": "rsi_oversold",
+      "signal_type": "FILTER",
+      "timeframe": "1HR",
+      "params": { "window": 14, "threshold": 30.0 }
+    }
+  ],
+  "exit": [
+    {
+      "name": "macd_bearish_cross",
+      "signal_type": "TRIGGER",
+      "timeframe": "1HR",
+      "params": { "window_fast": 12, "window_slow": 26, "window_sign": 9 }
+    }
+  ],
+  "reward_factor": 2.0,
+  "created_at": "2025-09-13T23:45:31.295752"
+}
+
+
+===== SIGNAL METADATA NOTES =====
+Signal metadata is retrieved from the Knowledge Base at runtime via:
+- kb_get_signal_quick_reference() for quick signal type/name lookup
+- kb_get_sections(slug="10-signals-quick-reference", anchors=[signal_names]) for detailed specs
+
+Example metadata format from KB for signals used above:
+
+bb_lower_breakout (TRIGGER)
+- Parent: Bollinger Bands
+- Parameters: window (5-100, default 20), window_dev (1-5, default 2)
+- Description: Check if price closes below the lower Bollinger Band
+
+rsi_oversold (FILTER)
+- Parent: RSI (Relative Strength Index)
+- Parameters: window (2-100, default 14), threshold (0-50, default 30.0)
+- Description: Check if RSI is below the oversold threshold
+
+macd_bearish_cross (TRIGGER)
+- Parent: MACD
+- Parameters: window_fast (2-50, default 12), window_slow (10-100, default 26), window_sign (2-50, default 9)
+- Description: Detect MACD bearish crossover (MACD line crosses below signal line)
+

--- a/server/src/services/data/strategy_schema.json
+++ b/server/src/services/data/strategy_schema.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/trading-strategy.schema.json",
+  "title": "Trading Strategy",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["name", "asset", "entry", "reward_factor"],
+  "properties": {
+    "name": { "type": "string", "minLength": 1 },
+    "asset": { "type": "string", "minLength": 1 },
+    "entry": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/rule" }
+    },
+    "exit": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/rule" }
+    },
+    "reward_factor": {
+      "type": "number",
+      "minimum": 0.9,
+      "maximum": 10
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    }
+  },
+  "$defs": {
+    "timeframe": {
+      "type": "string",
+      "enum": ["5MIN", "15MIN", "30MIN", "1HR", "4HR", "1D"]
+    },
+    "rule": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "signal_type", "timeframe", "params"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "signal_type": {
+          "type": "string",
+          "enum": ["TRIGGER", "FILTER"],
+          "description": "Signal classification: TRIGGER (event-based) or FILTER (state-based)"
+        },
+        "timeframe": { "$ref": "#/$defs/timeframe" },
+        "params": {
+          "type": "object",
+          "description": "Parameters for the signal function named in 'name'.",
+          "additionalProperties": true
+        }
+      }
+    }
+  }
+}
+

--- a/server/src/services/data/trading_defaults.json
+++ b/server/src/services/data/trading_defaults.json
@@ -1,0 +1,45 @@
+{
+  "description": "Default values for trading system configuration",
+  "signal_defaults": {},
+  "backtest_defaults": {
+    "slippage_pct": 0.004,
+    "fee_pct": 0.0085
+  },
+  "risk_management": {
+    "max_risk_per_trade": 0.01,
+    "reward_factor": 2,
+    "atr_period": 14,
+    "atr_volatility_factor": 2.0,
+    "atr_short_weight": 0.975,
+    "atr_long_weight": 0.025,
+    "atr_cap_multiplier": 2.0
+  },
+  "position_limits": {
+    "initial_balance": 10000,
+    "min_balance_threshold": 0.1,
+    "min_trade_amount": 25,
+    "max_open_positions": 10,
+    "max_trades_per_day": 50,
+    "max_units_per_trade": 1000000,
+    "max_trade_amount": 10000000
+},
+  "volatility_settings": {
+    "volatility_window": 24,
+    "target_volatility": 0.10,
+    "volatility_mode": "stddev",
+    "enable_volatility_adjustment": false
+  },
+  "trading_rules": {
+    "max_hold_time_hours": null,
+    "cooldown_bars": 24,
+    "daily_momentum_limit": 3,
+    "weekly_momentum_limit": 3
+  },
+  "time_based_exits": {
+    "max_hold_bars": 1000,
+    "exit_on_loss_after_bars": 1000,
+    "exit_on_profit_after_bars": 1000,
+    "profit_threshold_pct": 0.05
+  }
+}
+

--- a/server/src/services/order_executor.py
+++ b/server/src/services/order_executor.py
@@ -135,17 +135,34 @@ def _live_swap(
     wallet_address: str,
     chain_id: int | None = None,
     venue_id: str | None = None,
+    slippage_pct: float | None = None,
 ) -> Trade:
     """Execute the full 6-step live swap flow.
 
     The SDK never receives the private key — signing happens locally via
     wallet_manager.sign(). The SDK sees unsigned tx payloads + signed tx
     hex strings.
+
+    `slippage_pct` is the user's tolerance as a DECIMAL (0.005 = 0.5%,
+    0.01 = 1%). Converted to the upstream's percentage convention
+    (1.0 = 1%) at the `dex.prepare_swap()` boundary. If None, falls back
+    to 0.01 (1%) with a log warning — cron-driven swaps hit this path
+    until slippage_pct is added to the allocation schema.
     """
     if chain_id is None:
         raise SigningError(
             "chain_id is required for live swaps.",
             suggestion="Pass chain_id in the OrderIntent metadata or strategy config.",
+        )
+
+    if slippage_pct is None:
+        slippage_pct = 0.01
+        _log.warning(
+            "order.slippage_fallback",
+            strategy_id=strategy_id,
+            symbol=intent.symbol,
+            fallback_pct=slippage_pct,
+            note="slippage_pct not supplied; using 1% fallback. Add slippage_pct to the allocation block to silence this.",
         )
 
     client = mangrovemarkets_client()
@@ -216,10 +233,17 @@ def _live_swap(
                 )
 
     # 4. Prepare swap
+    # Upstream `dex.prepare_swap` takes slippage as a PERCENTAGE
+    # (1.0 = 1%, documented in MangroveMarkets-MCP-Server/src/dex/tools.py).
+    # Our API convention is DECIMAL (0.005 = 0.5%) to match the rest of
+    # the trading stack (trading_defaults.backtest_defaults.slippage_pct
+    # = 0.004 = 0.4%). Convert at the boundary.
+    sdk_slippage = slippage_pct * 100.0
     try:
         swap_tx = client.dex.prepare_swap(
             quote_id=quote.quote_id,
             wallet_address=wallet_address,
+            slippage=sdk_slippage,
         )
     except Exception as e:  # noqa: BLE001
         raise SdkError(f"dex.prepare_swap failed: {e}") from e
@@ -271,8 +295,14 @@ def execute_one(
     wallet_address: str | None = None,
     chain_id: int | None = None,
     venue_id: str | None = None,
+    slippage_pct: float | None = None,
 ) -> Trade:
     """Execute a single OrderIntent.
+
+    `slippage_pct` is a DECIMAL (0.005 = 0.5%). User-initiated swaps
+    require it (enforced at the MCP / REST boundary). Cron callers may
+    pass None — _live_swap falls back to 1% with a log warning until
+    the allocation schema carries slippage_pct (future work).
 
     strategy_id defaults to "user-initiated" for /dex/swap-style callers;
     cron-driven callers pass the real strategy UUID.
@@ -298,6 +328,7 @@ def execute_one(
             wallet_address=wallet_address,
             chain_id=chain_id,
             venue_id=venue_id,
+            slippage_pct=slippage_pct,
         )
     raise SigningError(f"Unknown mode: {mode}")
 
@@ -310,6 +341,7 @@ def execute_many(
     wallet_address: str | None = None,
     chain_id: int | None = None,
     venue_id: str | None = None,
+    slippage_pct: float | None = None,
 ) -> list[Trade]:
     """Execute N intents in order. Failures on one do not abort the batch.
 
@@ -329,6 +361,7 @@ def execute_many(
                 wallet_address=wallet_address,
                 chain_id=chain_id,
                 venue_id=venue_id,
+                slippage_pct=slippage_pct,
             )
             results.append(t)
         except Exception as e:  # noqa: BLE001

--- a/server/src/services/strategy_service.py
+++ b/server/src/services/strategy_service.py
@@ -288,7 +288,7 @@ def create_autonomous(req: StrategyAutonomousRequest) -> tuple[StrategyDetailRes
         detail,
         entry=winner.candidate.entry,
         exit_rules=winner.candidate.exit,
-        execution_config=backtest_service._DEFAULT_EXECUTION_CONFIG.copy(),
+        execution_config=backtest_service.flattened_defaults(),
         generation_report=generation_report,
     )
     row = _get_row(local_id)
@@ -332,7 +332,7 @@ def create_manual(req: StrategyManualRequest) -> StrategyDetailResponse:
         detail,
         entry=req.entry,
         exit_rules=req.exit,
-        execution_config=req.execution_config or backtest_service._DEFAULT_EXECUTION_CONFIG.copy(),
+        execution_config=req.execution_config or backtest_service.flattened_defaults(),
         generation_report=None,
     )
     row = _get_row(local_id)

--- a/server/tests/integration/test_dex_routes.py
+++ b/server/tests/integration/test_dex_routes.py
@@ -126,11 +126,30 @@ def test_swap_requires_confirm(client):
         headers=_auth(),
         json={
             "input_token": "USDC", "output_token": "ETH", "amount": 100.0,
-            "chain_id": 84532, "wallet_address": "0xabc", "confirm": False,
+            "chain_id": 84532, "wallet_address": "0xabc",
+            "slippage_pct": 0.005, "confirm": False,
         },
     )
     assert r.status_code == 400
     assert r.json()["code"] == "CONFIRMATION_REQUIRED"
+
+
+def test_swap_requires_explicit_slippage(client):
+    """slippage_pct has no default — picking a tolerance is a risk
+    decision the user must make explicitly for every live swap."""
+    r = client.post(
+        "/api/v1/agent/dex/swap",
+        headers=_auth(),
+        json={
+            "input_token": "USDC", "output_token": "ETH", "amount": 100.0,
+            "chain_id": 84532, "wallet_address": "0xabc", "confirm": True,
+        },
+    )
+    assert r.status_code == 422  # Pydantic rejects missing required field
+    body = r.json()
+    errors = body.get("detail", [])
+    missing_fields = [e["loc"][-1] for e in errors if e.get("type") == "missing"]
+    assert "slippage_pct" in missing_fields
 
 
 def test_swap_happy_path(client):
@@ -139,7 +158,8 @@ def test_swap_happy_path(client):
         headers=_auth(),
         json={
             "input_token": "USDC", "output_token": "ETH", "amount": 100.0,
-            "chain_id": 84532, "wallet_address": "0xabc", "confirm": True,
+            "chain_id": 84532, "wallet_address": "0xabc",
+            "slippage_pct": 0.005, "confirm": True,
         },
     )
     assert r.status_code == 200


### PR DESCRIPTION
Bundled B1 + B2 from the pre-workshop plan. Seven issues closed across backtest plumbing, MCP surface, and live-swap safety.

## Commits

- `d863b71` — **B1:** trading_defaults.json single source + backtest collapse + get_ohlcv phantom fix
- `9c49351` — **B2:** market/quote missing params + execute_swap slippage required & plumbed

## What's fixed

### Backtest (B1)

- **Duplicate defaults eliminated.** `_DEFAULT_EXECUTION_CONFIG` literal replaced with module-init load of `trading_defaults.json` copied verbatim from MangroveAI. Helpers `flattened_defaults()` + `backtest_cost_defaults()` match upstream's section-flattening order exactly (`MangroveAI/domains/strategies/services.py:306-309`). Drift check: `git diff server/src/services/data/trading_defaults.json` against upstream.

- **Bloated MCP tool collapsed.** `backtest_strategy` dropped from 11 params to 8. `slippage_pct`, `fee_pct`, `max_hold_time_hours`, `overrides` merged into a single `config: dict` that layers over `flattened_defaults()`. Same collapse in the REST route and `full_backtest()`. Any SDK BacktestRequest field flows through — the 13 first-class execution fields, plus extras (ATR params, reward_factor, weekly_deposit when upstream adds it) — because the SDK model is `extra='allow'`.

- **get_ohlcv phantom param removed.** The MCP tool advertised `timeframe` (`5m | 15m | 30m | 1h | 4h | 1d`) but the SDK method is `crypto_assets.get_ohlcv(symbol, *, days, provider)` — no timeframe parameter. Our code silently dropped whatever the caller passed. Removed from signature; added real `provider`. Description explains bar granularity is provider-native.

### MCP small param gaps (B2)

- **`get_market_data`**: added `provider` param (SDK supported, not exposed).
- **`get_swap_quote`**: added `mode` param (SDK supported, not exposed).
- **`execute_swap` slippage** — three-part fix:
  - **Phantom plumbing caught.** The MCP tool + REST route accepted `slippage=1.0` as a default, but neither was ever threaded through `execute_one → _live_swap → prepare_swap`. The SDK's own 1.0 default applied silently regardless of what the caller set.
  - **End-to-end plumb.** `execute_one`, `execute_many`, and `_live_swap` now accept `slippage_pct: float | None`. `_live_swap` multiplies by 100 at the `dex.prepare_swap()` boundary (upstream convention is percentage: 1.0 = 1%, confirmed in `MangroveMarkets-MCP-Server/src/dex/tools.py:77`).
  - **Required + decimal convention.** MCP tool param renamed `slippage` → `slippage_pct`, **made REQUIRED**, documented as DECIMAL (0.005 = 0.5%). Picking a slippage tolerance is a risk decision — arbitrary defaults on live trades are unsafe. Matches the decimal convention already in `trading_defaults.backtest_defaults.slippage_pct` (0.004 = 0.4%) so backtest and live use the same units.

## Known limitation (tracked)

Cron-driven live swaps don't know per-allocation slippage yet — `StrategyAllocationInput` has no `slippage_pct` field. For now, `execute_one` passes None through the cron path, `_live_swap` logs `order.slippage_fallback` at WARNING and uses 0.01 (1%). Proper fix (add `slippage_pct` to the allocation schema + thread through `execute_many`) is its own issue — not blocking for workshop, where attendees drive swaps manually via the MCP tool (which IS required-slippage).

## Upstream dependency (not blocking)

[MangroveAI#437](https://github.com/MangroveTechnologies/MangroveAI/issues/437) — once the SDK makes the 10 duplicate-forcing BacktestRequest fields Optional, we can delete the `**merged` kwargs spread in `_build_request` entirely and let the server's own `trading_defaults.json` fallback do the work. `server/src/services/data/trading_defaults.json` stops being needed. Tracked, post-workshop.

## Test plan

- [x] **311 passed / 2 skipped** (was 282/2 before B1, 310/2 after B1, 311/2 after B2). All green.
- [x] ruff clean.
- [x] E2E on bare-metal (B1): `POST /strategies/{id}/backtest` with `{"lookback_hours": 48, "config": {"slippage_pct": 0.002, "max_risk_per_trade": 0.005}}` → `resolved_window` honored (48h ISO start/end), `metrics` returns 8+ SDK fields.
- [x] New test: `test_swap_requires_explicit_slippage` — asserts 422 on missing `slippage_pct`, verifies error identifies the missing field.
- [x] Updated: `test_swap_requires_confirm` + `test_swap_happy_path` supply `slippage_pct=0.005` to exercise the new required contract.
- [ ] Reviewer: start a fresh Claude Code session, ask the agent to execute a swap — confirm it cannot submit without choosing a slippage_pct.

## What's NOT in this PR

From the full 9-item audit:

- **B3 (DEX surface expansion)** — 6 missing tools: `get_token_info`, `get_token_search`, `get_spot_price`, `get_gas_price`, `get_allowances`, `get_tx_status`. Bigger scope, post-workshop.
- **B4 (KB surface expansion)** — `kb_glossary_get`, `kb_get_document`, `kb_list_indicators`, `kb_list_tags`. Post-workshop.
- **list_signals full catalog** — upstream [issue #35](https://github.com/MangroveTechnologies/app-in-a-box/issues/35).