### PR TITLE
feat: workshop hardening — git-hook guard, allocation slippage_pct + 0.25% cap, /create-strategy review phase, stage gates

### DIFF
--- a/.claude/hooks/block-main-commits.sh
+++ b/.claude/hooks/block-main-commits.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+# block-main-commits.sh — refuse git write operations on main/master.
+#
+# Why this exists:
+#   The git-workflow rule (.claude/rules/git-workflow.md) says NEVER
+#   commit directly to main. Agents have slipped this rule twice in
+#   recent sessions and had to move commits to feature branches after
+#   the fact. This hook makes the rule harness-enforced instead of
+#   convention-enforced.
+#
+# Registered as a PreToolUse hook on the Bash tool in
+# .claude/settings.json — it intercepts Bash tool calls before they
+# run, inspects the command, and blocks if the agent is about to
+# commit to main or push to origin/main.
+#
+# Hook protocol (Claude Code):
+#   stdin  — JSON with tool_name + tool_input.command
+#   exit 0 — allow
+#   exit 2 — block; stderr becomes the blocking message to the LLM
+#
+# The hook is permissive outside a git repo (no-op) and on non-Bash
+# tools (no-op). It only engages when:
+#   * tool_name == "Bash"
+#   * cwd is inside a git repo
+#   * command matches a git write-operation pattern
+#   * current branch is main or master
+#
+# Human commits via git CLI directly are NOT blocked by this hook —
+# it only sees agent Bash tool calls. For human-side enforcement, use
+# GitHub branch protection in the repo settings (separate toggle).
+
+set -uo pipefail
+
+INPUT="$(cat)"
+
+# Extract tool_name + the command payload. The PreToolUse JSON shape is
+#   {"tool_name": "Bash", "tool_input": {"command": "...", ...}}
+# jq would be cleaner; we use Python for portability (macOS ships awk +
+# python3 but not jq by default).
+TOOL_NAME="$(printf '%s' "$INPUT" | python3 -c "
+import json, sys
+try:
+    d = json.load(sys.stdin)
+    print(d.get('tool_name', ''))
+except Exception:
+    print('')
+" 2>/dev/null)"
+
+if [ "$TOOL_NAME" != "Bash" ]; then
+    exit 0
+fi
+
+COMMAND="$(printf '%s' "$INPUT" | python3 -c "
+import json, sys
+try:
+    d = json.load(sys.stdin)
+    print(d.get('tool_input', {}).get('command', ''))
+except Exception:
+    print('')
+" 2>/dev/null)"
+
+if [ -z "$COMMAND" ]; then
+    exit 0
+fi
+
+# Only inspect git commands. Anything else — passes through.
+case "$COMMAND" in
+    *'git commit'*|*'git push'*|*'git merge'*|*'git rebase'*|*'git reset --hard'*|*'git reset HEAD~'*)
+        ;;
+    *)
+        exit 0
+        ;;
+esac
+
+# Find git repo; if none, nothing to guard.
+if ! git rev-parse --show-toplevel >/dev/null 2>&1; then
+    exit 0
+fi
+
+CURRENT_BRANCH="$(git branch --show-current 2>/dev/null)"
+
+# --- Rule 1: git commit / merge / rebase / reset-hard on main or master -------
+
+case "$CURRENT_BRANCH" in
+    main|master)
+        case "$COMMAND" in
+            *'git commit'*|*'git merge'*|*'git rebase'*|*'git reset --hard'*|*'git reset HEAD~'*)
+                cat >&2 <<EOF
+BLOCKED by .claude/hooks/block-main-commits.sh
+
+Refusing to run this git command while on branch "$CURRENT_BRANCH":
+
+  $COMMAND
+
+The git-workflow rule (.claude/rules/git-workflow.md) requires every
+change to go through a feature branch + PR. No direct commits to main.
+
+Fix:
+  git checkout -b feature/<short-description>   # move to a feature branch
+  # then re-run your original command
+
+If you intended to rebase, merge, or reset main to track origin, do it
+from a throwaway branch or via the GitHub UI so the history is reviewed.
+EOF
+                exit 2
+                ;;
+        esac
+        ;;
+esac
+
+# --- Rule 2: git push origin main / master -----------------------------------
+
+case "$COMMAND" in
+    *'git push'*'origin main'*|*'git push'*'origin master'*|\
+    *'git push origin HEAD:main'*|*'git push origin HEAD:master'*|\
+    *'git push --force'*'main'*|*'git push --force'*'master'*|\
+    *'git push -f'*'main'*|*'git push -f'*'master'*)
+        cat >&2 <<EOF
+BLOCKED by .claude/hooks/block-main-commits.sh
+
+Refusing to push directly to origin/main or origin/master:
+
+  $COMMAND
+
+Every change to main goes through a pull request. Push to a feature
+branch and open a PR:
+
+  git checkout -b feature/<short-description>
+  git push -u origin feature/<short-description>
+  gh pr create
+EOF
+        exit 2
+        ;;
+esac
+
+exit 0

--- a/.claude/rules/trading-bot-workflow.md
+++ b/.claude/rules/trading-bot-workflow.md
@@ -139,26 +139,59 @@ Once a wallet exists (either imported or created and confirmed-backed-up via `co
 
 ## Stage 3 — Review backtest
 
-- Present the **winning strategy** and 1–2 runners-up:
-  - Entry / exit signals (by name) + KB citation for each
-  - Key metrics: total return, Sharpe, max drawdown, win rate, trade count
-  - Ranked rationale: why this one won
+Detailed review flow (thresholds, PASS/FAIL decision rule, no-fabrication rule) lives in the `/create-strategy` skill's **Phase F**. Load and follow that.
+
+High-level summary for orientation:
+- Present the winning strategy + 1–2 runners-up with signal names, KB citations, and metrics
+- Verdict against 6 thresholds from `server/src/services/data/threshold_spec.json` (sortino ≥ 1.5, sharpe ≥ 1.2, calmar ≥ 1.0, irr ≥ 0.15, max_drawdown ≤ 0.7, win_rate ≥ 0.25)
+- Never invent missing metrics — if `total_trades == 0`, report as INSUFFICIENT_TRADES
 - Ask: "Promote to paper, iterate the goal, or reject?"
 
 ## Stage 4 — Paper
 
-- On approval, `update_strategy_status` with `status="paper"`.
+- On approval, `update_strategy_status(strategy_id, status="paper")`.
+- Paper promotion is **unrestricted** — no allocation, no backup check, no confirm flag required. Paper evaluations simulate fills at current market price; no real funds move.
 - Confirm the cron job registered (`status.active_cron_jobs` increments).
 - Tell the user: "Paper running. Will evaluate every {timeframe}. Check `list_evaluations` anytime."
 
 ## Stage 5 — Promote to live
 
-- After the user is satisfied with paper evaluations, prompt for live promotion.
-- **Precondition check:** the allocation's wallet must have `backup_confirmed_at` set. If it's null (wallet not backed up), tell the user:
-  > "This wallet's secret isn't confirmed backed-up yet. Run `./scripts/reveal-secret.sh --address {addr}` to see the secret, save it, then `./scripts/confirm-backup.sh {addr}` to unlock live trading. I can't execute live trades without this."
-- Gather the allocation block: wallet address, cap (absolute USD or % of balance), slippage tolerance, venue preference (default 1inch).
-- Call `update_strategy_status` with `status="live"`, `confirm=true`, `allocation={...}`.
-- Confirm live cron running. Executor routes firing evaluations through 1inch via `mangrovemarkets`.
+Live promotion is gated — it's the moment real money starts moving through the bot. Four things must be true at call time:
+
+**1. User has actively asked for live.**
+Do not auto-promote. The user says "go live" / "activate with real funds" / equivalent.
+
+**2. Target wallet has `backup_confirmed_at` set.**
+Check via `list_wallets`. If null, refuse the promotion and redirect:
+> "This wallet's secret isn't confirmed backed-up yet. Run `./scripts/reveal-secret.sh --address {addr}` to see the secret, save it, then `./scripts/confirm-backup.sh {addr}` to unlock live trading. I can't execute live trades without this."
+
+**3. Allocation block is complete.**
+Gather from the user:
+- `wallet_address` (must match one of `list_wallets`)
+- `token` + `token_address` (usually USDC — pre-fill the standard mainnet address unless user specifies otherwise)
+- `amount` — **capped at 10–20% of the wallet's balance for the first live allocation on this wallet, regardless of backtest numbers.** Per ai_copilot's "small first allocation" principle. If the user insists on more, push back once: "First live allocation on a new wallet is capped conservatively — you can scale up after you've seen a few real executions."
+- `slippage_pct` — REQUIRED, DECIMAL (0.005 = 0.5%), **max 0.0025 (0.25%)** per the Pydantic validator. Pitch 0.001-0.002 for liquid pairs (USDC/ETH, USDC/BTC on Base), 0.002-0.0025 for less liquid. Never ask "what slippage do you want?" cold — propose a value based on the pair and let the user confirm or adjust.
+
+**4. `confirm=true` is set on the update_status call.**
+The Pydantic validator rejects live-promotion without it.
+
+Call shape:
+```
+update_strategy_status(
+    strategy_id=...,
+    status="live",
+    confirm=true,
+    allocation={
+        "wallet_address": "0x...",
+        "token": "USDC",
+        "token_address": "0x...",
+        "amount": ...,
+        "slippage_pct": 0.002,   # decimal, ≤ 0.0025
+    },
+)
+```
+
+Confirm live cron running (`status.active_cron_jobs` incremented). Executor routes firing evaluations through 1inch via `mangrovemarkets`. Cron-fired swaps use the allocation's `slippage_pct` — no fallback, no silent defaults.
 
 ## Stage 6 — Monitor
 

--- a/.claude/rules/trading-bot-workflow.md
+++ b/.claude/rules/trading-bot-workflow.md
@@ -129,13 +129,14 @@ Once a wallet exists (either imported or created and confirmed-backed-up via `co
 
 ## Stage 2 — Author
 
-- Prefer `create_strategy_autonomous` with:
-  - `goal`: plain-English objective ("conservative ETH entry from USDC, trend-following, low churn")
-  - `asset`: symbol (e.g. `ETH`)
-  - `timeframe`: `"1h"` / `"4h"` / `"1d"`
-  - `candidate_count`: 5–10 (default 7)
-  - `backtest_lookback_months`: 3–6
-- Tell the user what you're doing: "Generating {N} candidate strategies, backtesting each over {M} months, picking the winner."
+Detailed authoring flow (reference-first, KB-grounded, autonomous fallback) lives in the **`/create-strategy` skill**. Load and follow that — it covers:
+
+- **Phase A** — `search_reference_strategies` first (always)
+- **Phase B** — `build_strategy_from_reference` when a reference matches (signals + params copied exactly)
+- **Phase C** — custom build with required `kb_search` citation per signal (no library-default params)
+- **Phase D** — `create_strategy_autonomous` only when the user says "pick for me"
+
+Never default to Phase D as the first move.
 
 ## Stage 3 — Review backtest
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -33,6 +33,18 @@
           }
         ]
       }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/block-main-commits.sh",
+            "timeout": 3
+          }
+        ]
+      }
     ]
   }
 }

--- a/.claude/skills/create-strategy/SKILL.md
+++ b/.claude/skills/create-strategy/SKILL.md
@@ -124,17 +124,56 @@ Autonomous is the "I don't care, you decide" escape hatch. It's NOT the primary 
 
 Under no circumstances go straight to Phase D as the first move. Always try Phase A first.
 
-## After Strategy Creation — Hand Off to Backtest
+## Phase E — Backtest
 
 Regardless of which phase built the strategy, hand off to backtesting immediately:
 
 ```
-backtest_strategy(strategy_id, mode="full", lookback_hours|days|months|start/end omitted for timeframe-aware default)
+backtest_strategy(strategy_id, mode="full")
 ```
 
-Let `backtest_service` pick the lookback automatically via `recommended_lookback_months(timeframe)` — 3 months for 5m/15m/30m/1h, 6 months for 4h, 12 months for 1d. Only override when the user explicitly asks for a specific window.
+Omit `lookback_*` and date fields unless the user asked for a specific window — `backtest_service` picks a timeframe-aware default via `recommended_lookback_months(timeframe)`: 3 months for 5m/15m/30m/1h, 6 months for 4h, 12 months for 1d.
 
-Present the result using the `/review-backtest` skill's decision rule (PASS/FAIL against `threshold_spec`).
+Overrides go through the single `config` dict (matches `trading_defaults.json` keys). Example:
+```
+backtest_strategy(strategy_id, mode="full", lookback_hours=24, config={"slippage_pct": 0.002})
+```
+
+## Phase F — Review (PASS/FAIL against threshold_spec)
+
+Evaluate the backtest against 6 fixed thresholds from `server/src/services/data/threshold_spec.json` (copied verbatim from MangroveAI — `git diff` vs upstream is the drift check):
+
+| Metric | Threshold | Direction |
+|---|---|---|
+| `sortino_ratio` | ≥ 1.5 | higher is better |
+| `sharpe_ratio` | ≥ 1.2 | higher is better |
+| `calmar_ratio` | ≥ 1.0 | higher is better |
+| `irr_annualized` | ≥ 0.15 | higher is better |
+| `max_drawdown` | ≤ 0.7 | lower is better |
+| `win_rate` | ≥ 0.25 | higher is better |
+
+**Decision rule:**
+- **PASS** iff ALL six thresholds satisfied
+- **MARGINAL** if 4-5 of 6 satisfied (worth iterating; not ready for live)
+- **FAIL** if ≤ 3 of 6 satisfied (redesign or reject)
+
+### Present the verdict
+
+Always show the user:
+1. The verdict (PASS / MARGINAL / FAIL)
+2. Per-threshold breakdown — actual value vs threshold, ✓ or ✗ per row
+3. Next-step recommendation based on verdict:
+   - **PASS** → "Promote to paper (unrestricted) or live (requires allocation + backup confirmation). Which?"
+   - **MARGINAL** → "Iterate: widen backtest window, tweak params, or try a different reference. Want me to rerun with {specific change}?"
+   - **FAIL** → "This won't work as-is. Options: pick a different reference, change the goal, or accept it's not a viable strategy right now."
+
+### Never fabricate metrics
+
+If the `metrics` dict is missing, empty, or any field is null, **say so explicitly** — do not invent values. Quote the exact SDK response:
+
+> "The backtest response is missing `sharpe_ratio` — I can't verdict against the threshold. This usually means the SDK couldn't compute it (too few trades, or the data provider returned insufficient history). Options: rerun with a longer window, or check `resolved_window` in the response to confirm the window the server actually used."
+
+Likewise: if `total_trades == 0`, every ratio metric is meaningless (division by zero or undefined). Report it as **INSUFFICIENT_TRADES** — not PASS, not FAIL. Suggest widening the window or loosening signal filters.
 
 ## Prohibited
 

--- a/server/src/api/routes/dex.py
+++ b/server/src/api/routes/dex.py
@@ -78,12 +78,17 @@ class SwapRequest(BaseModel):
     wallet_address: str
     slippage_pct: float = Field(
         ...,
+        gt=0,
+        le=0.0025,
         description=(
-            "Slippage tolerance as DECIMAL (0.005 = 0.5%, 0.01 = 1%). "
-            "REQUIRED — no default. Picking a tolerance is a risk "
-            "decision the user must make explicitly for live trades. "
-            "Converted to the upstream percentage convention at the "
-            "dex.prepare_swap() boundary."
+            "Slippage tolerance as DECIMAL. REQUIRED — no default. "
+            "Range: (0, 0.0025] — max 0.25%. Typical values: 0.001 "
+            "(0.1%), 0.002 (0.2%), 0.0025 (0.25% = cap). Anything "
+            "higher is refused to prevent rekt-on-illiquid-pair "
+            "execution. Picking a tolerance is a risk decision the "
+            "user must make explicitly for live trades. Converted "
+            "to the upstream percentage convention (multiplied by "
+            "100) at the dex.prepare_swap() boundary."
         ),
     )
     mev_protection: bool = False

--- a/server/src/mcp/tools.py
+++ b/server/src/mcp/tools.py
@@ -339,12 +339,13 @@ def _register_dex(server: FastMCP) -> None:
 
         Full 6-step flow with client-side signing; SDK never sees keys.
 
-        `slippage_pct` is REQUIRED and specified as a DECIMAL
-        (0.005 = 0.5%, 0.01 = 1%, 0.02 = 2%). No default — picking
-        a slippage tolerance is a risk decision the user must make
-        explicitly for live trades. Converted to the upstream
-        percentage convention (multiplied by 100) at the
-        `dex.prepare_swap()` boundary.
+        `slippage_pct` is REQUIRED and specified as a DECIMAL, capped
+        at 0.0025 (0.25%). Typical values: 0.001 (0.1%), 0.002 (0.2%),
+        0.0025 (0.25% = max). Higher values are refused to prevent
+        rekt-on-illiquid-pair execution. No default — picking a
+        slippage tolerance is a risk decision the user must make
+        explicitly. Converted to the upstream percentage convention
+        (multiplied by 100) at the `dex.prepare_swap()` boundary.
         """
         if not _require(api_key):
             return _auth_error()
@@ -390,7 +391,7 @@ def _register_dex(server: FastMCP) -> None:
             ToolParam(name="amount", type="number", required=True, description="Input amount"),
             ToolParam(name="chain_id", type="integer", required=True, description="EVM chain id"),
             ToolParam(name="wallet_address", type="string", required=True, description="Wallet from local store"),
-            ToolParam(name="slippage_pct", type="number", required=True, description="Slippage tolerance as DECIMAL (0.005 = 0.5%, 0.01 = 1%). No default — user must choose."),
+            ToolParam(name="slippage_pct", type="number", required=True, description="Slippage tolerance as DECIMAL, capped at 0.0025 (0.25%). Typical: 0.001 (0.1%), 0.002 (0.2%), 0.0025 (max). Higher values refused."),
             ToolParam(name="venue_id", type="string", required=False, description="Optional specific venue"),
             ToolParam(name="confirm", type="boolean", required=True, description="Must be true"),
             _APIKEY,

--- a/server/src/models/domain.py
+++ b/server/src/models/domain.py
@@ -113,6 +113,11 @@ class Allocation(BaseModel):
     active: bool
     created_at: datetime
     released_at: datetime | None = None
+    # Per-allocation slippage tolerance (DECIMAL, 0.005 = 0.5%). Capped
+    # at 0.0025 (0.25%) in the Pydantic input layer. Nullable for rows
+    # from pre-migration-004 databases; cron-driven swaps raise on None
+    # rather than silently falling back.
+    slippage_pct: float | None = None
 
 
 def _to_db(value: Any) -> Any:

--- a/server/src/services/allocation_service.py
+++ b/server/src/services/allocation_service.py
@@ -40,6 +40,8 @@ def _row_to_allocation(r) -> Allocation:
         active=bool(r["active"]),
         created_at=datetime.fromisoformat(r["created_at"]),
         released_at=datetime.fromisoformat(r["released_at"]) if r["released_at"] else None,
+        # slippage_pct column added in migration 004; older rows may return None.
+        slippage_pct=(r["slippage_pct"] if "slippage_pct" in r.keys() else None),
     )
 
 
@@ -49,11 +51,18 @@ def record_allocation(
     token_address: str,
     token_symbol: str,
     amount: float,
+    slippage_pct: float | None = None,
 ) -> Allocation:
     """Record a new active allocation for a strategy.
 
     Validates the wallet exists and amount > 0. Does NOT check on-chain
     balance — that's the user's responsibility when they fund the wallet.
+
+    `slippage_pct` is DECIMAL (0.005 = 0.5%). Callers via
+    StrategyAllocationInput enforce the 0.0025 cap + required-ness at the
+    Pydantic layer; we accept None here only so pre-migration test fixtures
+    and legacy call sites don't break compilation. The tick / cron path
+    refuses to execute_many with a None slippage_pct.
     """
     if amount <= 0:
         raise AllocationInsufficient(
@@ -72,11 +81,11 @@ def record_allocation(
     conn.execute(
         """INSERT INTO allocations
            (id, strategy_id, wallet_address, token_address, token_symbol,
-            amount, active, created_at, released_at)
-           VALUES (?,?,?,?,?,?,1,?,NULL)""",
+            amount, active, created_at, released_at, slippage_pct)
+           VALUES (?,?,?,?,?,?,1,?,NULL,?)""",
         (
             alloc_id, strategy_id, wallet_address, token_address,
-            token_symbol, amount, created_at.isoformat(),
+            token_symbol, amount, created_at.isoformat(), slippage_pct,
         ),
     )
     conn.commit()
@@ -88,6 +97,7 @@ def record_allocation(
         wallet_address=wallet_address,
         token_symbol=token_symbol,
         amount=amount,
+        slippage_pct=slippage_pct,
     )
 
     return Allocation(
@@ -100,6 +110,7 @@ def record_allocation(
         active=True,
         created_at=created_at,
         released_at=None,
+        slippage_pct=slippage_pct,
     )
 
 

--- a/server/src/services/data/threshold_spec.json
+++ b/server/src/services/data/threshold_spec.json
@@ -1,0 +1,30 @@
+{
+  "title": "Backtest Thresholds Specification",
+  "version": "2.0",
+  "description": "Performance thresholds for determining backtest pass/fail status. Used by backtest_state.py to evaluate strategy performance.",
+  "thresholds": {
+    "sortino_min": 1.5,
+    "sharpe_min": 1.2,
+    "calmar_min": 1.0,
+    "irr_min": 0.15,
+    "max_drawdown_max": 0.7,
+    "min_win_rate": 0.25
+  },
+  "threshold_descriptions": {
+    "sortino_min": "Minimum Sortino Ratio (downside-adjusted return measure)",
+    "sharpe_min": "Minimum Sharpe Ratio (risk-adjusted return measure)",
+    "calmar_min": "Minimum Calmar Ratio (return over max drawdown)",
+    "irr_min": "Minimum Internal Rate of Return (annualized, as decimal)",
+    "max_drawdown_max": "Maximum allowed drawdown (as decimal, e.g., 0.7 = 70%)",
+    "min_win_rate": "Minimum win rate (as decimal, e.g., 0.25 = 25%)"
+  },
+  "decision_rule": "PASS if sortino >= sortino_min AND sharpe >= sharpe_min AND calmar >= calmar_min AND irr >= irr_min AND max_drawdown <= max_drawdown_max AND win_rate >= min_win_rate",
+  "metrics_mapping": {
+    "sortino": "sortino_ratio",
+    "sharpe": "sharpe_ratio",
+    "calmar": "calmar_ratio",
+    "irr": "irr_annualized (converted from percentage to decimal)",
+    "max_drawdown": "max_drawdown (converted from percentage to decimal)",
+    "win_rate": "win_rate (converted from percentage to decimal)"
+  }
+}

--- a/server/src/services/order_executor.py
+++ b/server/src/services/order_executor.py
@@ -143,11 +143,13 @@ def _live_swap(
     wallet_manager.sign(). The SDK sees unsigned tx payloads + signed tx
     hex strings.
 
-    `slippage_pct` is the user's tolerance as a DECIMAL (0.005 = 0.5%,
-    0.01 = 1%). Converted to the upstream's percentage convention
-    (1.0 = 1%) at the `dex.prepare_swap()` boundary. If None, falls back
-    to 0.01 (1%) with a log warning — cron-driven swaps hit this path
-    until slippage_pct is added to the allocation schema.
+    `slippage_pct` is the user's tolerance as a DECIMAL (0.005 = 0.5%).
+    REQUIRED for live swaps — no fallback. Direct swaps supply it via
+    SwapRequest; cron swaps via the active allocation (migration 004
+    added `slippage_pct` to the allocations table). Capped at 0.0025
+    (0.25%) at the input layer; re-checked here as defense-in-depth.
+    Converted to the upstream's percentage convention (1.0 = 1%) at
+    the `dex.prepare_swap()` boundary.
     """
     if chain_id is None:
         raise SigningError(
@@ -156,13 +158,24 @@ def _live_swap(
         )
 
     if slippage_pct is None:
-        slippage_pct = 0.01
-        _log.warning(
-            "order.slippage_fallback",
-            strategy_id=strategy_id,
-            symbol=intent.symbol,
-            fallback_pct=slippage_pct,
-            note="slippage_pct not supplied; using 1% fallback. Add slippage_pct to the allocation block to silence this.",
+        raise SigningError(
+            "slippage_pct is required for live swaps.",
+            suggestion=(
+                "Direct swap callers pass slippage_pct in the request body "
+                "(decimal, e.g. 0.002 = 0.2%). Cron-driven swaps pull it "
+                "from the active allocation — re-promote the strategy to "
+                "live with an allocation block that includes slippage_pct."
+            ),
+        )
+    if slippage_pct <= 0 or slippage_pct > 0.0025:
+        raise SigningError(
+            f"slippage_pct {slippage_pct} outside allowed range (0, 0.0025].",
+            suggestion=(
+                "Max allowed slippage is 0.25% (0.0025 decimal). Tighter "
+                "values trade off fewer fills for better prices; looser "
+                "values are refused to prevent rekt-on-illiquid-pair "
+                "execution."
+            ),
         )
 
     client = mangrovemarkets_client()

--- a/server/src/services/strategy_service.py
+++ b/server/src/services/strategy_service.py
@@ -88,6 +88,16 @@ class StrategyAllocationInput(BaseModel):
     token: str  # symbol like "USDC"
     token_address: str
     amount: float
+    # Per-allocation slippage tolerance as DECIMAL (0.005 = 0.5%).
+    # REQUIRED — picking a tolerance is a risk decision the user must
+    # make explicitly when committing funds to a live strategy.
+    # Capped at 0.0025 (0.25%); anything higher is rejected at the
+    # API boundary. Matches the decimal convention used for direct
+    # swap slippage_pct (server/src/api/routes/dex.py SwapRequest).
+    slippage_pct: float = Field(..., gt=0, le=0.0025, description=(
+        "Slippage tolerance as DECIMAL (0.005 = 0.5%). Max 0.0025 (0.25%). "
+        "No default — must be set at allocation time."
+    ))
 
 
 class StrategyStatusUpdate(BaseModel):
@@ -408,6 +418,7 @@ def update_status(strategy_id: str, update: StrategyStatusUpdate) -> StrategyDet
             token_address=update.allocation.token_address,
             token_symbol=update.allocation.token,
             amount=update.allocation.amount,
+            slippage_pct=update.allocation.slippage_pct,
         )
 
     # Sync status upstream.
@@ -518,10 +529,12 @@ def tick(strategy_id: str) -> None:
         # Find the wallet + chain_id for live execution (allocation provides it).
         wallet_address = None
         chain_id = None
+        slippage_pct = None
         if mode == "live":
             active_alloc = allocation_service.get_active_allocation(strategy_id)
             if active_alloc:
                 wallet_address = active_alloc.wallet_address
+                slippage_pct = active_alloc.slippage_pct
                 # We don't track chain_id on allocation; pull from wallet row.
                 wrow = get_connection().execute(
                     "SELECT chain_id FROM wallets WHERE address = ?",
@@ -550,6 +563,7 @@ def tick(strategy_id: str) -> None:
                 order_intents, mode=mode, strategy_id=strategy_id,
                 evaluation_id=evaluation_id,
                 wallet_address=wallet_address, chain_id=chain_id,
+                slippage_pct=slippage_pct,
             )
 
         _log.info("strategy.tick.completed",

--- a/server/src/shared/db/migrations/004_allocation_slippage.sql
+++ b/server/src/shared/db/migrations/004_allocation_slippage.sql
@@ -1,0 +1,12 @@
+-- Migration 004: allocation.slippage_pct
+--
+-- Add per-allocation slippage tolerance so cron-driven live swaps use
+-- the user's declared risk tolerance, not a silent fallback.
+--
+-- Units: DECIMAL (0.005 = 0.5%). Capped at 0.0025 (0.25%) in the
+-- Pydantic input layer (src/services/strategy_service.py
+-- StrategyAllocationInput). Nullable in DB so existing allocation rows
+-- from pre-migration states survive — the cron path raises on None
+-- rather than silently falling back.
+
+ALTER TABLE allocations ADD COLUMN slippage_pct REAL;

--- a/server/tests/integration/test_dex_routes.py
+++ b/server/tests/integration/test_dex_routes.py
@@ -127,7 +127,7 @@ def test_swap_requires_confirm(client):
         json={
             "input_token": "USDC", "output_token": "ETH", "amount": 100.0,
             "chain_id": 84532, "wallet_address": "0xabc",
-            "slippage_pct": 0.005, "confirm": False,
+            "slippage_pct": 0.002, "confirm": False,
         },
     )
     assert r.status_code == 400
@@ -152,6 +152,42 @@ def test_swap_requires_explicit_slippage(client):
     assert "slippage_pct" in missing_fields
 
 
+def test_swap_rejects_slippage_above_cap(client):
+    """slippage_pct cap is 0.0025 (0.25%) — anything higher is refused
+    at the API boundary to prevent rekt-on-illiquid-pair execution."""
+    r = client.post(
+        "/api/v1/agent/dex/swap",
+        headers=_auth(),
+        json={
+            "input_token": "USDC", "output_token": "ETH", "amount": 100.0,
+            "chain_id": 84532, "wallet_address": "0xabc",
+            "slippage_pct": 0.01, "confirm": True,  # 1%, over the 0.25% cap
+        },
+    )
+    assert r.status_code == 422
+    body = r.json()
+    errors = body.get("detail", [])
+    assert any(
+        e.get("loc", [None, None])[-1] == "slippage_pct"
+        and e.get("type") in ("less_than_equal", "greater_than")
+        for e in errors
+    ), f"expected cap rejection on slippage_pct; got {errors}"
+
+
+def test_swap_accepts_slippage_at_cap(client):
+    """Boundary: slippage_pct = 0.0025 (exactly the cap) is allowed."""
+    r = client.post(
+        "/api/v1/agent/dex/swap",
+        headers=_auth(),
+        json={
+            "input_token": "USDC", "output_token": "ETH", "amount": 100.0,
+            "chain_id": 84532, "wallet_address": "0xabc",
+            "slippage_pct": 0.0025, "confirm": True,
+        },
+    )
+    assert r.status_code == 200
+
+
 def test_swap_happy_path(client):
     r = client.post(
         "/api/v1/agent/dex/swap",
@@ -159,7 +195,7 @@ def test_swap_happy_path(client):
         json={
             "input_token": "USDC", "output_token": "ETH", "amount": 100.0,
             "chain_id": 84532, "wallet_address": "0xabc",
-            "slippage_pct": 0.005, "confirm": True,
+            "slippage_pct": 0.002, "confirm": True,
         },
     )
     assert r.status_code == 200

--- a/server/tests/integration/test_strategy_routes.py
+++ b/server/tests/integration/test_strategy_routes.py
@@ -157,7 +157,8 @@ def test_patch_status_requires_confirm_for_live(client):
         headers=_auth(),
         json={"status": "live",
               "allocation": {"wallet_address": "0xabc", "token": "USDC",
-                              "token_address": "0xusdc", "amount": 100}},
+                              "token_address": "0xusdc", "amount": 100,
+                              "slippage_pct": 0.002}},
     )
     assert r.status_code == 400
     assert r.json()["code"] == "CONFIRMATION_REQUIRED"

--- a/server/tests/integration/test_strategy_service.py
+++ b/server/tests/integration/test_strategy_service.py
@@ -214,6 +214,7 @@ def test_status_paper_to_live_requires_confirm(temp_db, mock_ai_sdk):
                 allocation=StrategyAllocationInput(
                     wallet_address="0xabc", token="USDC",
                     token_address="0xusdc", amount=100,
+                    slippage_pct=0.002,
                 ),
             ),
         )
@@ -243,6 +244,7 @@ def test_status_to_live_registers_cron_and_allocation(temp_db, mock_ai_sdk):
             allocation=StrategyAllocationInput(
                 wallet_address="0xabc", token="USDC",
                 token_address="0xusdc", amount=100,
+                slippage_pct=0.002,
             ),
         ),
     )
@@ -277,6 +279,7 @@ def test_deactivating_live_releases_allocation_and_cancels_cron(temp_db, mock_ai
             allocation=StrategyAllocationInput(
                 wallet_address="0xabc", token="USDC",
                 token_address="0xusdc", amount=100,
+                slippage_pct=0.002,
             ),
         ),
     )

--- a/server/tests/unit/test_order_executor.py
+++ b/server/tests/unit/test_order_executor.py
@@ -156,6 +156,7 @@ def test_live_skips_approval_when_none(temp_db, mock_mangroveai, mock_markets, s
         strategy_id="s1",
         wallet_address="0xabc",
         chain_id=84532,
+        slippage_pct=0.002,
     )
     assert trade.mode == "live"
     assert trade.status == "confirmed"
@@ -164,6 +165,9 @@ def test_live_skips_approval_when_none(temp_db, mock_mangroveai, mock_markets, s
     assert mock_markets.dex.get_quote.call_count == 1
     assert mock_markets.dex.prepare_swap.call_count == 1
     assert mock_markets.dex.broadcast.call_count == 1
+    # slippage_pct must be converted to percentage (x100) at the prepare_swap boundary.
+    _, kwargs = mock_markets.dex.prepare_swap.call_args
+    assert kwargs["slippage"] == pytest.approx(0.2)
 
 
 def test_live_full_flow_with_approval(temp_db, mock_mangroveai, mock_markets, stub_sign):
@@ -180,6 +184,7 @@ def test_live_full_flow_with_approval(temp_db, mock_mangroveai, mock_markets, st
         strategy_id="s1",
         wallet_address="0xabc",
         chain_id=84532,
+        slippage_pct=0.002,
     )
     assert trade.status == "confirmed"
     # broadcast called twice (approval + swap)
@@ -187,12 +192,37 @@ def test_live_full_flow_with_approval(temp_db, mock_mangroveai, mock_markets, st
     assert trade.fees["approval_tx_hash"] == "0xdeadbeef"
 
 
+def test_live_requires_slippage_pct(temp_db, mock_mangroveai, mock_markets, stub_sign):
+    """slippage_pct has no default in live mode — direct callers must pass
+    it (SwapRequest enforces), cron callers pull it from the active
+    allocation (migration 004)."""
+    from src.services.order_executor import execute_one
+    from src.shared.errors import SigningError
+
+    with pytest.raises(SigningError, match="slippage_pct is required"):
+        execute_one(_intent("buy"), mode="live", strategy_id="s1",
+                    wallet_address="0xabc", chain_id=84532)
+
+
+def test_live_rejects_slippage_above_cap(temp_db, mock_mangroveai, mock_markets, stub_sign):
+    """Defense-in-depth: even if somehow a slippage above 0.25% reaches
+    _live_swap (shouldn't, Pydantic rejects first), refuse to execute."""
+    from src.services.order_executor import execute_one
+    from src.shared.errors import SigningError
+
+    with pytest.raises(SigningError, match="outside allowed range"):
+        execute_one(_intent("buy"), mode="live", strategy_id="s1",
+                    wallet_address="0xabc", chain_id=84532,
+                    slippage_pct=0.01)  # 1%, over the 0.25% cap
+
+
 def test_live_requires_wallet_address(temp_db, mock_mangroveai, mock_markets, stub_sign):
     from src.services.order_executor import execute_one
     from src.shared.errors import SigningError
 
     with pytest.raises(SigningError):
-        execute_one(_intent("buy"), mode="live", strategy_id="s1", chain_id=84532)
+        execute_one(_intent("buy"), mode="live", strategy_id="s1",
+                    chain_id=84532, slippage_pct=0.002)
 
 
 def test_live_requires_chain_id(temp_db, mock_mangroveai, mock_markets, stub_sign):
@@ -200,7 +230,8 @@ def test_live_requires_chain_id(temp_db, mock_mangroveai, mock_markets, stub_sig
     from src.shared.errors import SigningError
 
     with pytest.raises(SigningError):
-        execute_one(_intent("buy"), mode="live", strategy_id="s1", wallet_address="0xabc")
+        execute_one(_intent("buy"), mode="live", strategy_id="s1",
+                    wallet_address="0xabc", slippage_pct=0.002)
 
 
 def test_live_wraps_sdk_failures(temp_db, mock_mangroveai, mock_markets, stub_sign):
@@ -210,7 +241,8 @@ def test_live_wraps_sdk_failures(temp_db, mock_mangroveai, mock_markets, stub_si
     mock_markets.dex.get_quote.side_effect = RuntimeError("upstream 503")
     with pytest.raises(SdkError):
         execute_one(_intent("buy"), mode="live", strategy_id="s1",
-                    wallet_address="0xabc", chain_id=84532)
+                    wallet_address="0xabc", chain_id=84532,
+                    slippage_pct=0.002)
 
 
 # -- Batching --------------------------------------------------------------


### PR DESCRIPTION
Four items from the workshop-hardening plan, one branch, four commits.

## Commits

- `cf0de4b` — **F:** PreToolUse Bash hook blocks `git commit` / `git push origin main`
- `7ebdf7d` — **E:** per-allocation `slippage_pct` (required, decimal, cap 0.25%) threaded end-to-end
- `00faf78` — **A+B:** `threshold_spec.json` + `/create-strategy` Phase E/F (Backtest + Review) + `trading-bot-workflow.md` Stage 4/5 gate rules
- `11064ae` — **D:** Stage 2 trim (delegates to `/create-strategy` skill)

## F — git-workflow hook

`.claude/hooks/block-main-commits.sh` registered as `PreToolUse` with a `Bash` matcher. Blocks (exit 2) when the agent attempts:

- `git commit` / `merge` / `rebase` / `reset --hard` / `reset HEAD~*` while current branch is `main` or `master`
- `git push origin main` / `origin master` / `push --force origin main` (any variant, including `HEAD:main`)

Passes through for non-Bash tools, non-git Bash commands, git read-ops (status/log/diff/show), and git writes on feature branches.

Does NOT block human CLI commits — only sees Claude Code tool calls. For human-side protection enable GitHub branch protection on `main` (one toggle in repo settings).

Unit-tested in a scratch `/tmp` clone: 4 cases on `main` (commit/rebase block, status pass, commit on feature pass) + 2 cases for push-to-main (plain and `--force`). All exit codes correct.

## E — allocation slippage_pct + 0.25% cap

Closes the cron-path gap PR #44 left: allocations now carry their own slippage tolerance so scheduled live swaps use the user's declared value, not a 1% log-warning fallback.

**Schema:**
- Migration `004_allocation_slippage.sql` adds `allocations.slippage_pct REAL NULL`
- `Allocation` domain model gets `slippage_pct: float | None`
- `allocation_service.record_allocation` + `_row_to_allocation` thread the column

**Input validation (the cap):**
- `StrategyAllocationInput.slippage_pct` is REQUIRED: `Field(..., gt=0, le=0.0025)`
- `SwapRequest.slippage_pct` gets the same cap
- MCP `execute_swap` tool description updated: "capped at 0.0025 (0.25%)"
- Decimal throughout the stack; `*100.0` conversion only at the `dex.prepare_swap()` boundary

**Enforcement end-to-end:**
- `strategy_service` tick path pulls `active_alloc.slippage_pct`, passes through `execute_many` → `execute_one` → `_live_swap`
- `_live_swap`: deleted the `order.slippage_fallback` warning. On `None`: raise `SigningError` with remediation. On `slippage_pct > 0.0025`: raise `SigningError` (defense-in-depth).

## A+B — `/create-strategy` Review phase + Stage 4/5 gate rules

**`server/src/services/data/threshold_spec.json`** copied verbatim from MangroveAI (same loader pattern as `trading_defaults.json`).

**`/create-strategy` skill:**
- Renamed "After Strategy Creation" → "Phase E — Backtest" (naming parity with A-D)
- New "Phase F — Review": PASS / MARGINAL / FAIL against 6 thresholds (sortino ≥ 1.5, sharpe ≥ 1.2, calmar ≥ 1.0, irr ≥ 0.15, max_drawdown ≤ 0.7, win_rate ≥ 0.25). Explicit no-fabrication rule — missing metrics → say so, don't invent. `total_trades == 0` reports as INSUFFICIENT_TRADES, not PASS/FAIL.

**`trading-bot-workflow.md` Stages 4/5:**
- Stage 4 (Paper): clarified unrestricted — no allocation, no backup check, no confirm required
- Stage 5 (Live): expanded to four must-be-true gates with explicit call shape:
  1. user explicitly asks
  2. wallet has `backup_confirmed_at` set (redirect to `reveal-secret.sh` + `confirm-backup.sh` otherwise)
  3. allocation block with `slippage_pct` ≤ 0.0025 and first-live amount capped at 10-20% of balance
  4. `confirm=true`

## D — Stage 2 trim

Stage 2 authoring detail delegated to `/create-strategy` skill (Phase A-D).

## Test plan

- [x] **315 passed / 2 skipped** (was 311/2 before F, 315/2 after E, stable through A+B and D)
- [x] ruff clean
- [x] F hook unit-tested across 6 case variations (4 Rule 1 + 2 Rule 2)
- [x] E: new tests — `test_live_requires_slippage_pct`, `test_live_rejects_slippage_above_cap`, `test_swap_rejects_slippage_above_cap`, `test_swap_accepts_slippage_at_cap`. Existing live-mode tests updated.
- [x] E: prepare_swap receives `slippage_pct * 100` (unit conversion verified in test_live_skips_approval_when_none)
- [ ] Reviewer: in a fresh Claude Code session in the repo, try `git commit -m test` on main via Bash — confirm the hook blocks it
- [ ] Reviewer: ask the agent to promote a strategy to live without backing up the wallet — confirm the Stage 5 gate refuses with the remediation CLI commands
- [ ] Reviewer: ask the agent to review a backtest with `total_trades == 0` — confirm it says INSUFFICIENT_TRADES, not PASS/FAIL

## Human-side follow-ups (not automatable from this PR)

- Enable GitHub branch protection on `main` (repo Settings → Branches → Require PR, require status checks). 30-second toggle; complements the Claude Code hook.

## Related

- PR #44 (merged) — left the cron-path slippage gap that item E closes here
- MangroveAI#437 — upstream path to eliminate the remaining `_build_request` kwargs duplication (not blocking)