### PR TITLE
feat(mcp): massive surface expansion — 33 new tools across DEX, KB, portfolio, on-chain, signals, defi, social, docs, execution

### DIFF
--- a/docs/strategy-lifecycle.md
+++ b/docs/strategy-lifecycle.md
@@ -1,0 +1,222 @@
+# Strategy Lifecycle — Create, Paper, Live
+
+End-to-end walkthrough of what actually happens when a strategy is
+created, promoted to paper, and promoted to live. Not speculation —
+every step references the file and function that does the work.
+
+## 1. The scheduler is in-process, not a Unix cron
+
+Everything runs inside one `uvicorn src.app:app` process. No separate
+daemon, no system cron, no Cloud Scheduler.
+
+```
+uvicorn process (one process, always running)
+│
+├─ FastAPI (HTTP + MCP endpoints — thread 1)
+│
+└─ APScheduler BackgroundScheduler      [server/src/services/scheduler_service.py:65-81]
+   │  • Jobstore: SQLAlchemyJobStore on agent.db
+   │    └─ job persistence — survives restarts
+   │  • Executor: ThreadPoolExecutor(max_workers=10)
+   │    └─ each tick runs in a thread, non-blocking
+   │  • Cron triggers per timeframe:
+   │       5m  → minute: */5
+   │       15m → minute: */15
+   │       1h  → minute: 0
+   │       4h  → minute: 0, hour: */4
+   │       1d  → minute: 0, hour: 0
+   │
+   └─ When a cron fires:
+      └─ calls `src.services.strategy_service:tick(strategy_id)`
+         in a worker thread
+```
+
+Key properties:
+- **No extra infra.** One process. `setup.sh` + `docker compose up` is
+  all that's required.
+- **Jobstore lives in `agent.db`** alongside trades/strategies/wallets.
+  Single file, single source of truth.
+- **Restart-safe.** If uvicorn crashes mid-tick, that tick is lost but
+  the job registration survives — next start picks the schedule back
+  up.
+- **Invariant: as long as uvicorn is running, strategies tick.**
+  Close the laptop or kill the process → nothing fires.
+
+## 2. Deploy to paper
+
+```
+User                        Tool (MCP)                     What happens
+────────────────────────────────────────────────────────────────────────
+"Promote to paper"  →   update_strategy_status(            strategy_service.update_status():
+                          strategy_id=...,                  1. Validate transition (draft→paper OK;
+                          status="paper"                       no confirm required, no allocation)
+                        )                                   2. mangroveai.strategies.update_status(
+                                                                mangrove_id, "paper")   [upstream sync]
+                                                            3. scheduler_service.register_job(
+                                                                 strategy_id,
+                                                                 timeframe=row.timeframe,
+                                                                 callable_path=
+                                                                   "src.services.strategy_service:tick"
+                                                               )
+                                                               └─ APScheduler.add_job(
+                                                                    func=callable_path,
+                                                                    trigger=CronTrigger(**cron_for_tf),
+                                                                    args=[strategy_id],
+                                                                    id=f"eval-{strategy_id}",
+                                                                    replace_existing=True,
+                                                                    coalesce=True, max_instances=1,
+                                                                  )
+                                                            4. Local status: draft → paper
+```
+
+### What runs on each tick (paper)
+
+[`server/src/services/strategy_service.py:455-569`]
+
+```python
+def tick(strategy_id):
+    # 1. Load strategy, skip if not paper/live
+    row = _get_row(strategy_id)
+    mode = row["status"]        # "paper"
+
+    # 2. Ask upstream what to do
+    sdk_resp = mangroveai.execution.evaluate(
+        row["mangrove_id"],
+        persist=False            # paper doesn't persist to MangroveAI side
+    )
+
+    # 3. Extract order intents (could be [])
+    order_intents = [...]
+
+    # 4. Log the evaluation (always, even on empty)
+    trade_log.log_evaluation(Evaluation(...))
+
+    # 5. If there are intents, execute them
+    if order_intents:
+        order_executor.execute_many(
+            order_intents,
+            mode="paper",           # → _paper_fill: simulated, no wallet touched
+            strategy_id=strategy_id,
+            evaluation_id=evaluation_id,
+            # wallet_address, chain_id, slippage_pct not needed in paper
+        )
+```
+
+**Paper fills are simulated.** `_paper_fill` writes a row to the local
+`trades` table using the current market price as `fill_price`,
+`mode="paper"`, `status="confirmed"`. No real swap, no real funds, no
+wallet required. Paper trades surface in `list_trades` /
+`list_all_trades` exactly like live trades, so the strategy's decision
+pattern can be verified before funding.
+
+## 3. Deploy to live
+
+```
+User                             Tool (MCP)                     What happens
+──────────────────────────────────────────────────────────────────────────────
+"Back up my wallet"    →  ./scripts/reveal-secret.sh --address  Reveals the secret ONCE in your
+                            <addr>                               terminal (off-transcript, off-MCP)
+
+"Confirmed backup"     →  ./scripts/confirm-backup.sh <addr>     Flips wallets.backup_confirmed_at
+                                                                  in local DB. Live trading gate
+                                                                  now open for that wallet.
+
+"Go live with $5"      →  update_strategy_status(                strategy_service.update_status():
+   (after paper run)       strategy_id=...,                       1. Validate: status="live" requires
+                           status="live",                             confirm=true + allocation
+                           confirm=true,                          2. require_backup_confirmed(
+                           allocation={                                allocation.wallet_address)
+                             "wallet_address": "0x5ff2...",          → SigningError if not set
+                             "token": "USDC",                    3. allocation_service.record_allocation(
+                             "token_address": "0x833...",            ..., slippage_pct=0.002)
+                             "amount": 5.0,                          → inserts row in allocations table
+                             "slippage_pct": 0.002                4. mangroveai.strategies.update_status(
+                           }                                         mangrove_id, "live")
+                         )                                       5. scheduler_service.register_job(...)
+                                                                     └─ same cron, same job_id,
+                                                                        replace_existing=True.
+                                                                        The tick just runs in live
+                                                                        mode now.
+                                                                 6. Local status: paper → live
+```
+
+### What runs on each tick (live)
+
+Same `tick()` function; different branch in order execution:
+
+```python
+if mode == "live":
+    active_alloc = allocation_service.get_active_allocation(strategy_id)
+    wallet_address = active_alloc.wallet_address
+    slippage_pct  = active_alloc.slippage_pct     # from allocation row
+    chain_id      = <looked up from wallets table>
+
+order_executor.execute_many(
+    order_intents,
+    mode="live",
+    wallet_address=wallet_address,
+    chain_id=chain_id,
+    slippage_pct=slippage_pct,
+)
+# → _live_swap:
+#    1. dex.get_quote
+#    2. dex.approve_token (if needed) → sign locally → broadcast → poll
+#    3. dex.prepare_swap(quote_id, wallet_address, slippage=slippage_pct*100)
+#    4. sign locally via wallet_manager.sign
+#       (decrypt Fernet ciphertext → eth_account → zero out plaintext)
+#    5. dex.broadcast → tx_hash → poll
+#    6. Write to local trades table with status="confirmed" + tx_hash
+```
+
+Live adds three guarantees over paper:
+
+1. **Client-side signing.** SDK never sees the private key. We decrypt
+   in-process with the Fernet master key, sign with `eth_account`, and
+   drop the plaintext immediately.
+2. **Backup gate.** `execute_one` calls
+   `require_backup_confirmed(wallet_address)` — refuses to run if
+   `wallets.backup_confirmed_at` is null.
+3. **Slippage cap.** `_live_swap` defense-in-depth: `slippage_pct > 0.0025`
+   → `SigningError` (Pydantic rejects first at the
+   `StrategyAllocationInput`/`SwapRequest` boundary).
+
+## 4. Minimum tool set for the paper → live loop
+
+| Step | Tool |
+|---|---|
+| Create | `create_strategy_autonomous` OR `search_reference_strategies` + `build_strategy_from_reference` + `create_strategy_manual` |
+| Backtest | `backtest_strategy` |
+| Review | agent uses `threshold_spec` values from `server/src/services/data/threshold_spec.json` |
+| Promote paper | `update_strategy_status(status="paper")` |
+| Watch paper | `list_evaluations`, `list_trades` |
+| Create wallet | `create_wallet` (secret returned via `secret_id` → `reveal-secret.sh`) |
+| Import wallet | `./scripts/stash-secret.sh` → `import_wallet(secret_id)` |
+| Back up wallet | `./scripts/reveal-secret.sh --address <addr>` + `./scripts/confirm-backup.sh <addr>` — BOTH OUTSIDE MCP ON PURPOSE, keys never enter the transcript |
+| Fund wallet | user sends USDC to the address — external |
+| Go live | `update_strategy_status(status="live", confirm=true, allocation={...})` |
+| Monitor | `list_trades`, `list_evaluations`, `get_balances`, `portfolio_value`, `portfolio_pnl`, `get_tx_status` |
+
+## 5. Design choices considered and rejected
+
+| Alternative | Why not |
+|---|---|
+| Unix `crontab` + `curl` per attendee | Each user has to configure system cron; unusable from a Claude Code workshop flow |
+| Separate Python daemon + IPC | More moving parts, more things to restart, more failure modes |
+| Cloud Scheduler / EventBridge | Out of scope for local-first v1; requires cloud deployment |
+| Celery / RQ worker | Heavier than needed for 1-10 strategies per attendee |
+
+The in-process APScheduler gives:
+- Zero infra — one process
+- Jobstore persistence — restart-safe
+- Thread isolation — ticks don't block HTTP requests
+- Standard cron syntax — easy to reason about
+
+## 6. What can go wrong
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Strategy promoted to paper but no evaluations after N minutes | uvicorn isn't running | check `ps`/`/health`; restart via `./scripts/setup.sh` |
+| Tick fires but `list_evaluations` shows `status="error"` | SDK call failed (MangroveAI down, stale API key, etc.) | check `agent-data/bare.log` for the exception; `evaluation.error_msg` field has the SDK message |
+| Live tick rejected with "not backed up" | Wallet's `backup_confirmed_at` is null | run `./scripts/reveal-secret.sh --address <addr>` + `./scripts/confirm-backup.sh <addr>` |
+| Live tick rejected with slippage out of range | Allocation had `slippage_pct > 0.0025` | re-promote with `slippage_pct ≤ 0.0025` |
+| Scheduler job count is 0 after restart | Jobstore wasn't persisted (DB path mismatch or `:memory:` in tests) | `status` tool reports `active_cron_jobs`; check `DB_PATH` config |

--- a/docs/verification-checklist.md
+++ b/docs/verification-checklist.md
@@ -1,0 +1,361 @@
+# Verification Checklist — State of the Repo as of PR #46
+
+Follow this after:
+1. Merging PR #46 on GitHub
+2. `git checkout main && git pull origin main` locally
+3. Restart Claude Code in the repo directory (fresh session)
+
+Each checkpoint has a **do this**, an **expected**, and a **how to verify**.
+
+If a checkpoint fails, stop and tell me what happened before continuing —
+a failed early step will cascade into false failures downstream.
+
+---
+
+## Phase 0 — Environment
+
+### 0.1 — Local repo matches `main`
+
+**Do:**
+```bash
+cd ~/Desktop/mangrove/app-in-a-box
+git status
+git log --oneline -5
+```
+
+**Expect:**
+- On branch `main`
+- Top commit is the PR #46 merge
+- Uncommitted files (CLAUDE.md, branding.json, agent-data-test/) are yours
+  from earlier sessions — leave them alone
+
+### 0.2 — Bare-metal server is running the new code
+
+**Do:**
+```bash
+curl -s http://127.0.0.1:9080/health
+```
+
+**Expect:** `{"status":"healthy","timestamp":"..."}`
+
+If not healthy, restart:
+```bash
+kill $(cat agent-data/bare.pid) 2>/dev/null
+./scripts/setup.sh --yes --no-mcp --no-verify
+```
+
+(Note: VSCode extensions may grab `localhost:8080`, so we bind 9080 to
+sidestep that. If you're using Claude Code's MCP registration, it's
+pointing at whatever port `scripts/setup-mcp.sh` configured.)
+
+### 0.3 — MCP tools load
+
+**Do:** In the fresh Claude Code session, say:
+
+> "Status check. List your tools, my wallets, my strategies."
+
+**Expect:**
+- Agent calls `status`, `list_wallets`, `list_strategies`, `list_tools`
+- **Tool count: 41** (was 24 before PR #45, 8 new in G+H, 30 new in PR #46 — minus `get_token_info` still counts as registered = 41 total auth-tier tools plus the free tier `status` + `list_tools` + `hello_mangrove`)
+- If the count is wrong, tool registration didn't reload — restart the server
+
+### 0.4 — Fresh-clone Stage 0 greeter fires
+
+This checks the session-start hook from PR #40.
+
+**Do:** Nothing — on session start with no `.claude/.onboarded` marker,
+the agent should deliver the Stage 0 greeter (security primer + wallet
+question).
+
+**Expect (if fresh clone):**
+- Brief intro as the defi-agent
+- 6-bullet security primer
+- Question: "Do you have an existing wallet you want to use, or
+  should I create a fresh one?"
+
+**If you already have `.claude/.onboarded`:** the greeter won't fire.
+That's correct — it only gates fresh clones. Skip this check.
+
+### 0.5 — Key-paste hook blocks
+
+**Do:** Type into Claude Code chat:
+```
+import this key: 0xad42a37adfd7ab7eab2965f7582245e52cee777efab7a4f07e0952edf7666113
+```
+
+**Expect:** Hook blocks the prompt with a message directing you to
+`./scripts/stash-secret.sh`. The agent never sees the key.
+
+---
+
+## Phase 1 — Create a strategy
+
+Paper mode doesn't require a funded wallet — start here.
+
+### 1.1 — Reference-first strategy creation
+
+**Do:** In Claude Code, say:
+
+> "Build me a momentum strategy for ETH on 1h. Use a reference."
+
+**Expect:**
+- Agent calls `search_reference_strategies(asset="ETH", timeframe="1h", goal_hint="momentum")` **first**
+- Returns up to 5 ranked candidates (ref-001, ref-004, ref-007 at minimum match)
+- Agent shows 2–3 options with label + signal names + category
+- Asks you to pick one
+
+**Verify:** In another terminal:
+```bash
+curl -s -H 'X-API-Key: dev-key-1' 'http://127.0.0.1:9080/api/v1/agent/reference-strategies/search?asset=ETH&timeframe=1h&goal_hint=momentum&limit=5' | python3 -m json.tool | head -20
+```
+Same candidates should appear.
+
+### 1.2 — Build and backtest
+
+**Do:** Pick `ref-001` (or whichever).
+
+**Expect:**
+- Agent calls `build_strategy_from_reference(reference_id="ref-001", timeframe="1h")`
+- Gets back a `create_strategy_manual`-compatible payload with signals
+  copied exactly + timeframe applied
+- Calls `create_strategy_manual(...)` with that payload
+- Returns `strategy_id` (UUID)
+
+**Verify:**
+```bash
+curl -s -H 'X-API-Key: dev-key-1' 'http://127.0.0.1:9080/api/v1/agent/strategies' | python3 -m json.tool | head -25
+```
+The new strategy should be there with `status: "draft"`.
+
+### 1.3 — Backtest with timeframe-aware auto window
+
+**Do:** Tell the agent:
+
+> "Backtest it."
+
+**Expect:**
+- Agent calls `backtest_strategy(strategy_id=..., mode="full")` with no
+  lookback fields
+- Service auto-picks `lookback_months: 3` for 1h timeframe (matches
+  `timeframes.recommended_lookback_months`)
+- Response includes `resolved_window: {lookback_months: 3, ...}` and a
+  full `metrics` dict (20+ fields: sortino, calmar, sharpe, irr,
+  max_drawdown, win_rate, total_trades, etc.)
+
+**Verify:** The agent presents a PASS/MARGINAL/FAIL verdict per the
+`/create-strategy` skill's Phase F decision rule. It shows per-threshold
+breakdown against `threshold_spec.json` values.
+
+---
+
+## Phase 2 — Promote to paper
+
+### 2.1 — Promote
+
+**Do:** Tell the agent:
+
+> "Promote it to paper."
+
+**Expect:**
+- Agent calls `update_strategy_status(strategy_id=..., status="paper")`
+- Response: status="paper", cron job registered
+- Agent confirms: "Paper running. Will evaluate every 1 hour."
+
+**Verify:**
+```bash
+curl -s -H 'X-API-Key: dev-key-1' 'http://127.0.0.1:9080/api/v1/agent/status' | python3 -m json.tool | grep -A 1 active_cron
+```
+`active_cron_jobs: 1` (assuming no prior strategies).
+
+### 2.2 — Force a manual tick (don't wait for cron)
+
+**Do:**
+> "Run evaluate_strategy on it so I don't have to wait for the cron."
+
+**Expect:**
+- Agent calls `evaluate_strategy(strategy_id=...)`
+- Evaluation logged; if the strategy fires on current market, a
+  simulated (paper) trade is logged too
+
+**Verify:**
+```bash
+curl -s -H 'X-API-Key: dev-key-1' "http://127.0.0.1:9080/api/v1/agent/logs/evaluations?strategy_id=<the id>" | python3 -m json.tool | head -30
+```
+At least one evaluation row with `status="ok"`, non-zero `duration_ms`.
+
+### 2.3 — Verify the scheduler persists across restart
+
+**Do:**
+```bash
+kill $(cat agent-data/bare.pid)
+sleep 2
+./scripts/setup.sh --yes --no-mcp --no-verify
+sleep 3
+curl -s http://127.0.0.1:9080/health
+curl -s -H 'X-API-Key: dev-key-1' 'http://127.0.0.1:9080/api/v1/agent/status' | python3 -m json.tool | grep active_cron
+```
+
+**Expect:** `active_cron_jobs: 1` after restart — the SQLAlchemyJobStore
+pulled the job back from `agent.db` without any action on your part.
+
+---
+
+## Phase 3 — Wallet + backup gate
+
+Only do this phase if you want to exercise the live path. Paper alone
+is sufficient for "does the bot work?"
+
+### 3.1 — Create a fresh wallet
+
+**Do:**
+> "Create a fresh wallet on Base mainnet."
+
+**Expect:**
+- Agent calls `create_wallet(chain="evm", network="mainnet", chain_id=8453)`
+- Response carries `address`, `secret_id`, `reveal_cmd`, `master_key_source`
+- Agent surfaces the address + block explorer link + the `reveal_cmd`
+- **Agent does NOT echo the secret** (rule in `wallet-presentation.md`)
+
+**Verify:** In your terminal:
+```bash
+./scripts/reveal-secret.sh <secret_id>
+```
+The plaintext key appears ONCE in your terminal. Back it up anywhere
+you want (password manager, paper).
+
+### 3.2 — Confirm backup (unlocks live trading for that wallet)
+
+**Do:**
+```bash
+./scripts/confirm-backup.sh <address>
+```
+
+**Expect:** Response confirms `backup_confirmed_at` set.
+
+**Verify:**
+```bash
+curl -s -H 'X-API-Key: dev-key-1' 'http://127.0.0.1:9080/api/v1/agent/wallet/list' | python3 -m json.tool
+```
+Your wallet row has a non-null `backup_confirmed_at`.
+
+### 3.3 — Backup gate refuses live without confirmation
+
+**Do:** Create a SECOND wallet (optional — only if you want to test the
+gate).
+> "Create a second wallet for a gate test."
+
+Then ask the agent to promote a strategy to live with that second
+wallet's address — WITHOUT running `confirm-backup.sh` on it.
+
+**Expect:** `SigningError: Wallet <addr> is not backed up. Live
+trading refused.` with suggestion pointing at the CLI commands.
+
+---
+
+## Phase 4 — Go live (OPTIONAL, requires funded wallet)
+
+Skip if you're not ready to move real money.
+
+### 4.1 — Fund the wallet
+
+External step — send 1–5 USDC to the wallet address from MetaMask or
+an exchange.
+
+**Verify:**
+> "Check my balance."
+
+Agent calls `get_balances` → non-zero USDC shown.
+
+### 4.2 — Promote to live
+
+**Do:**
+> "Go live with $1 allocation, 0.2% slippage."
+
+**Expect:**
+- Agent constructs:
+  ```
+  update_strategy_status(
+      strategy_id=...,
+      status="live",
+      confirm=true,
+      allocation={
+          "wallet_address": "0x...",
+          "token": "USDC",
+          "token_address": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+          "amount": 1.0,
+          "slippage_pct": 0.002,
+      }
+  )
+  ```
+- Validator refuses anything with `slippage_pct > 0.0025`
+- Response: status="live", cron continues (same job, just different mode now)
+
+### 4.3 — Watch for a live tick
+
+`evaluate_strategy` can force one, OR wait for the cron. On fire, if
+the strategy decides to act, a real swap happens — watch for:
+
+- Log line `order.live.broadcast` with a `tx_hash`
+- `list_trades` includes a row with `mode="live"`, `status="confirmed"`
+  (or `pending` then `confirmed`), `tx_hash="0x..."`
+- Call `get_tx_status(tx_hash, chain_id=8453)` — should show
+  `status: "confirmed"` with a block number
+
+---
+
+## Phase 5 — Post-mortem + cleanup
+
+### 5.1 — Check the whole picture
+
+```bash
+# Strategies
+curl -s -H 'X-API-Key: dev-key-1' 'http://127.0.0.1:9080/api/v1/agent/strategies' | python3 -m json.tool
+
+# All trades (local)
+curl -s -H 'X-API-Key: dev-key-1' 'http://127.0.0.1:9080/api/v1/agent/logs/all-trades?limit=10' | python3 -m json.tool
+
+# Portfolio
+curl -s -H 'X-API-Key: dev-key-1' "http://127.0.0.1:9080/api/v1/agent/wallet/<address>/portfolio" | python3 -m json.tool
+```
+
+### 5.2 — Clean up (OPTIONAL)
+
+```bash
+# Ask the agent:
+# "Delete my test strategy."
+# → calls delete_strategy(strategy_id) upstream.
+# → local SQLite row stays (audit trail preserved).
+
+# If you want to wipe the whole test state:
+# STOP the server first.
+kill $(cat agent-data/bare.pid)
+# Remove the DB (deletes strategies + trades + scheduler jobstore).
+rm agent-data/agent.db
+# Restart — everything regenerates from migrations.
+./scripts/setup.sh --yes --no-mcp --no-verify
+```
+
+---
+
+## What you just verified
+
+- [ ] 0.1 Local on main, PR #46 merged
+- [ ] 0.2 Bare-metal server healthy
+- [ ] 0.3 41 MCP tools loaded
+- [ ] 0.4 Stage 0 greeter fires (or skipped — `.onboarded` present)
+- [ ] 0.5 Key-paste hook blocks
+- [ ] 1.1 Reference-first strategy creation works
+- [ ] 1.2 build_strategy_from_reference + create_strategy_manual
+- [ ] 1.3 Backtest runs with timeframe-aware auto window + full metrics
+- [ ] 2.1 Paper promotion registers cron
+- [ ] 2.2 Manual evaluate_strategy fires + logs
+- [ ] 2.3 Scheduler persists across restart
+- [ ] 3.1 create_wallet returns secret_id (no plaintext in chat)
+- [ ] 3.2 confirm-backup.sh flips the flag
+- [ ] 3.3 Backup gate refuses unconfirmed live promotion
+- [ ] 4.1 Wallet receives USDC (external)
+- [ ] 4.2 Live promotion with slippage cap validated
+- [ ] 4.3 Live tick broadcasts a real tx; get_tx_status confirms
+
+Everything through 2.x is workshop-critical and fund-free. 3.x–4.x
+needs a funded wallet and is the final verification layer.

--- a/server/src/api/routes/dex.py
+++ b/server/src/api/routes/dex.py
@@ -155,3 +155,82 @@ async def dex_swap(req: SwapRequest) -> dict:
         "approval_tx_hash": trade.fees.get("approval_tx_hash"),
         "trade_log_id": trade.id,
     }
+
+
+def _dump(obj: Any) -> Any:
+    return obj.model_dump() if hasattr(obj, "model_dump") else obj
+
+
+@router.get(
+    "/tx-status",
+    summary="Check the status of a broadcast transaction",
+    description=(
+        "Pass-through to mangrovemarkets.dex.tx_status. Use after "
+        "execute_swap to verify a transaction landed + its final state "
+        "(confirmed | pending | failed). Workshop-critical: lets the "
+        "agent/user confirm a swap actually settled before acting on "
+        "balance changes."
+    ),
+)
+async def tx_status(
+    tx_hash: str,
+    chain_id: int,
+    venue_id: str | None = None,
+) -> Any:
+    try:
+        return _dump(mangrovemarkets_client().dex.tx_status(
+            tx_hash=tx_hash, chain_id=chain_id, venue_id=venue_id,
+        ))
+    except Exception as e:  # noqa: BLE001
+        raise SdkError(f"dex.tx_status failed: {e}") from e
+
+
+@router.get(
+    "/token-info",
+    summary="Look up token metadata by contract address",
+    description=(
+        "Pass-through to mangrovemarkets.dex.token_info. Returns "
+        "symbol, decimals, name, and any venue-specific metadata for "
+        "the token at `address` on `chain_id`."
+    ),
+)
+async def token_info(chain_id: int, address: str) -> Any:
+    try:
+        return _dump(mangrovemarkets_client().dex.token_info(
+            chain_id=chain_id, address=address,
+        ))
+    except Exception as e:  # noqa: BLE001
+        raise SdkError(f"dex.token_info failed: {e}") from e
+
+
+@router.get(
+    "/spot-price",
+    summary="Current spot price for one or more tokens",
+    description=(
+        "Pass-through to mangrovemarkets.dex.spot_price. `tokens` is a "
+        "comma-separated list of symbols or addresses."
+    ),
+)
+async def spot_price(chain_id: int, tokens: str) -> Any:
+    try:
+        return _dump(mangrovemarkets_client().dex.spot_price(
+            chain_id=chain_id, tokens=tokens,
+        ))
+    except Exception as e:  # noqa: BLE001
+        raise SdkError(f"dex.spot_price failed: {e}") from e
+
+
+@router.get(
+    "/gas-price",
+    summary="Current gas price estimate for the chain",
+    description=(
+        "Pass-through to mangrovemarkets.dex.gas_price. Useful as a "
+        "pre-flight check before a swap — estimate how much the tx "
+        "will cost before committing."
+    ),
+)
+async def gas_price(chain_id: int) -> Any:
+    try:
+        return _dump(mangrovemarkets_client().dex.gas_price(chain_id=chain_id))
+    except Exception as e:  # noqa: BLE001
+        raise SdkError(f"dex.gas_price failed: {e}") from e

--- a/server/src/api/routes/kb.py
+++ b/server/src/api/routes/kb.py
@@ -34,3 +34,38 @@ async def glossary(term: str) -> Any:
         return _dump(mangroveai_client().kb.glossary.get(term))
     except Exception as e:  # noqa: BLE001
         raise SdkError(f"kb.glossary.get failed: {e}") from e
+
+
+@router.get("/documents", summary="List all KB documents (summary only)")
+async def documents_list() -> Any:
+    try:
+        return [_dump(d) for d in mangroveai_client().kb.documents.list()]
+    except Exception as e:  # noqa: BLE001
+        raise SdkError(f"kb.documents.list failed: {e}") from e
+
+
+@router.get("/documents/{slug}", summary="Full KB document by slug")
+async def documents_get(slug: str) -> Any:
+    try:
+        return _dump(mangroveai_client().kb.documents.get(slug))
+    except Exception as e:  # noqa: BLE001
+        raise SdkError(f"kb.documents.get failed: {e}") from e
+
+
+@router.get("/indicators", summary="List KB indicator docs (optionally filtered by category)")
+async def indicators_list(category: str | None = None) -> Any:
+    try:
+        kwargs: dict[str, Any] = {}
+        if category is not None:
+            kwargs["category"] = category
+        return [_dump(i) for i in mangroveai_client().kb.indicators.list(**kwargs)]
+    except Exception as e:  # noqa: BLE001
+        raise SdkError(f"kb.indicators.list failed: {e}") from e
+
+
+@router.get("/tags", summary="List all KB tags")
+async def tags_list() -> Any:
+    try:
+        return [_dump(t) for t in mangroveai_client().kb.tags.list()]
+    except Exception as e:  # noqa: BLE001
+        raise SdkError(f"kb.tags.list failed: {e}") from e

--- a/server/src/mcp/tools.py
+++ b/server/src/mcp/tools.py
@@ -1883,6 +1883,116 @@ def _register_strategy(server: FastMCP) -> None:
     ))
 
     @server.tool()
+    async def list_account_positions(
+        account_id: str | None = None,
+        status: str | None = None,
+        skip: int = 0, limit: int = 100,
+        api_key: str = "",
+    ) -> str:
+        """List positions on MangroveAI's execution side.
+
+        Hits `mangroveai.execution.list_positions`. Note: our
+        architecture executes trades locally via order_executor and
+        writes to our own SQLite trades/evaluations — so our user's
+        strategies don't populate MangroveAI execution accounts
+        unless a strategy was authored through the MangroveAI copilot
+        path. This tool is exposed for completeness + cases where a
+        user has both app-in-a-box AND copilot-authored strategies.
+        """
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            from src.shared.clients.mangrove import mangroveai_client
+            kwargs: dict[str, Any] = {"skip": skip, "limit": limit}
+            if account_id is not None:
+                kwargs["account_id"] = account_id
+            if status is not None:
+                kwargs["status"] = status
+            items = mangroveai_client().execution.list_positions(**kwargs)
+            return json.dumps([_dump(i) for i in items])
+        except Exception as e:  # noqa: BLE001
+            return _err("EXECUTION_POSITIONS_FAILED", str(e))
+
+    register_tool(ToolEntry(
+        name="list_account_positions",
+        description="List positions on MangroveAI's execution side (copilot-authored strategies).",
+        access="auth",
+        parameters=[
+            ToolParam(name="account_id", type="string", required=False, description="Optional filter"),
+            ToolParam(name="status", type="string", required=False, description="Optional: open | closed | etc"),
+            ToolParam(name="skip", type="integer", required=False, description="Page offset"),
+            ToolParam(name="limit", type="integer", required=False, description="Page size"),
+            _APIKEY,
+        ],
+    ))
+
+    @server.tool()
+    async def get_account_position(position_id: str, api_key: str = "") -> str:
+        """Fetch a single MangroveAI execution-side position by id."""
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            from src.shared.clients.mangrove import mangroveai_client
+            return json.dumps(_dump(mangroveai_client().execution.get_position(position_id)))
+        except Exception as e:  # noqa: BLE001
+            return _err("EXECUTION_POSITION_GET_FAILED", str(e))
+
+    register_tool(ToolEntry(
+        name="get_account_position",
+        description="Fetch a single MangroveAI execution position.",
+        access="auth",
+        parameters=[
+            ToolParam(name="position_id", type="string", required=True, description="Position id"),
+            _APIKEY,
+        ],
+    ))
+
+    @server.tool()
+    async def list_account_trades(
+        account_id: str | None = None,
+        asset: str | None = None,
+        outcome: str | None = None,
+        skip: int = 0, limit: int = 100,
+        api_key: str = "",
+    ) -> str:
+        """List trades on MangroveAI's execution side.
+
+        Distinct from our local `list_trades` (which covers every
+        DEX swap the agent executed, stored in our SQLite). This
+        hits MangroveAI's copilot-execution trade log — different
+        data source, different use case.
+        """
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            from src.shared.clients.mangrove import mangroveai_client
+            kwargs: dict[str, Any] = {"skip": skip, "limit": limit}
+            if account_id is not None:
+                kwargs["account_id"] = account_id
+            if asset is not None:
+                kwargs["asset"] = asset
+            if outcome is not None:
+                kwargs["outcome"] = outcome
+            items = mangroveai_client().execution.list_trades(**kwargs)
+            return json.dumps([_dump(i) for i in items])
+        except Exception as e:  # noqa: BLE001
+            return _err("EXECUTION_TRADES_FAILED", str(e))
+
+    register_tool(ToolEntry(
+        name="list_account_trades",
+        description="List trades on MangroveAI's execution side (copilot-authored strategies).",
+        access="auth",
+        parameters=[
+            ToolParam(name="account_id", type="string", required=False, description="Optional filter"),
+            ToolParam(name="asset", type="string", required=False, description="Optional asset filter"),
+            ToolParam(name="outcome", type="string", required=False, description="Optional outcome filter"),
+            ToolParam(name="skip", type="integer", required=False, description="Page offset"),
+            ToolParam(name="limit", type="integer", required=False, description="Page size"),
+            _APIKEY,
+        ],
+    ))
+
+    @server.tool()
     async def delete_strategy(strategy_id: str, api_key: str = "") -> str:
         """Delete a strategy upstream on MangroveAI.
 

--- a/server/src/mcp/tools.py
+++ b/server/src/mcp/tools.py
@@ -80,6 +80,10 @@ def register(server: FastMCP):
     _register_dex(server)
     _register_market(server)
     _register_signals(server)
+    _register_on_chain(server)
+    _register_defi(server)
+    _register_social(server)
+    _register_docs(server)
     _register_strategy(server)
     _register_logs(server)
     _register_kb(server)
@@ -1028,6 +1032,223 @@ def _register_signals(server: FastMCP) -> None:
             _APIKEY,
         ],
     ))
+
+
+# ---------------------------------------------------------------------------
+# On-chain intelligence (auth)
+# ---------------------------------------------------------------------------
+
+
+def _register_on_chain(server: FastMCP) -> None:
+    """Whale activity, smart-money sentiment, token holders, exchange flows.
+
+    These tools back the /create-strategy skill's "cite Mangrove
+    intelligence" rule — they provide the 'why now' evidence for a
+    candidate strategy.
+    """
+    from src.shared.clients.mangrove import mangroveai_client
+
+    @server.tool()
+    async def get_whale_activity(
+        symbol: str, hours_back: int = 24, api_key: str = "",
+    ) -> str:
+        """Whale buying/selling activity for an asset over the last N hours."""
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            r = mangroveai_client().on_chain.get_whale_activity(
+                symbol=symbol, hours_back=hours_back,
+            )
+            return json.dumps(_dump(r))
+        except Exception as e:  # noqa: BLE001
+            return _err("ONCHAIN_WHALE_ACTIVITY_FAILED", str(e))
+
+    register_tool(ToolEntry(
+        name="get_whale_activity",
+        description="Whale buying/selling activity for an asset.",
+        access="auth",
+        parameters=[
+            ToolParam(name="symbol", type="string", required=True, description="Asset symbol (e.g. ETH)"),
+            ToolParam(name="hours_back", type="integer", required=False, description="Window (default 24)"),
+            _APIKEY,
+        ],
+    ))
+
+    @server.tool()
+    async def get_whale_transactions(
+        symbol: str | None = None, min_value: float = 500_000,
+        hours_back: int = 24, api_key: str = "",
+    ) -> str:
+        """Individual whale transactions above min_value USD."""
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            kwargs: dict[str, Any] = {
+                "min_value": min_value, "hours_back": hours_back,
+            }
+            if symbol is not None:
+                kwargs["symbol"] = symbol
+            r = mangroveai_client().on_chain.get_whale_transactions(**kwargs)
+            return json.dumps(_dump(r))
+        except Exception as e:  # noqa: BLE001
+            return _err("ONCHAIN_WHALE_TXS_FAILED", str(e))
+
+    register_tool(ToolEntry(
+        name="get_whale_transactions",
+        description="Whale transactions above a USD threshold.",
+        access="auth",
+        parameters=[
+            ToolParam(name="symbol", type="string", required=False, description="Optional filter by asset"),
+            ToolParam(name="min_value", type="number", required=False, description="Min USD value (default 500000)"),
+            ToolParam(name="hours_back", type="integer", required=False, description="Window (default 24)"),
+            _APIKEY,
+        ],
+    ))
+
+    @server.tool()
+    async def get_smart_money_sentiment(
+        symbol: str, chain: str | None = None, api_key: str = "",
+    ) -> str:
+        """Smart-money wallet sentiment for an asset (bullish/bearish signal).
+
+        ⚠️ Upstream netflow data is currently unavailable for most
+        assets on ethereum — real calls return 404 RESOURCE_NOT_FOUND
+        with a clear 'No Smart Money netflow data found' message.
+        Tool wiring is correct; upstream data pipeline issue.
+        Pair this with get_whale_activity / get_exchange_flows while
+        the data source is being populated.
+        """
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            kwargs: dict[str, Any] = {"symbol": symbol}
+            if chain is not None:
+                kwargs["chain"] = chain
+            r = mangroveai_client().on_chain.get_smart_money_sentiment(**kwargs)
+            return json.dumps(_dump(r))
+        except Exception as e:  # noqa: BLE001
+            return _err("ONCHAIN_SMART_MONEY_FAILED", str(e))
+
+    register_tool(ToolEntry(
+        name="get_smart_money_sentiment",
+        description="Smart-money sentiment for an asset (aggregate of tracked wallets).",
+        access="auth",
+        parameters=[
+            ToolParam(name="symbol", type="string", required=True, description="Asset symbol"),
+            ToolParam(name="chain", type="string", required=False, description="Optional chain filter"),
+            _APIKEY,
+        ],
+    ))
+
+    @server.tool()
+    async def screen_smart_money(
+        chains: list[str] | None = None, timeframe: str = "24h",
+        limit: int = 20, api_key: str = "",
+    ) -> str:
+        """Discover which assets smart money is currently accumulating."""
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            kwargs: dict[str, Any] = {"timeframe": timeframe, "limit": limit}
+            if chains is not None:
+                kwargs["chains"] = chains
+            r = mangroveai_client().on_chain.screen_smart_money(**kwargs)
+            return json.dumps(_dump(r))
+        except Exception as e:  # noqa: BLE001
+            return _err("ONCHAIN_SMART_MONEY_SCREEN_FAILED", str(e))
+
+    register_tool(ToolEntry(
+        name="screen_smart_money",
+        description="Screen assets smart money is currently accumulating.",
+        access="auth",
+        parameters=[
+            ToolParam(name="chains", type="array", required=False, description="Optional list of chain names"),
+            ToolParam(name="timeframe", type="string", required=False, description="Lookback (default '24h')"),
+            ToolParam(name="limit", type="integer", required=False, description="Max results (default 20)"),
+            _APIKEY,
+        ],
+    ))
+
+    @server.tool()
+    async def get_token_holders(symbol: str, api_key: str = "") -> str:
+        """Top holders + distribution metrics for a token."""
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            r = mangroveai_client().on_chain.get_token_holders(symbol=symbol)
+            return json.dumps(_dump(r))
+        except Exception as e:  # noqa: BLE001
+            return _err("ONCHAIN_HOLDERS_FAILED", str(e))
+
+    register_tool(ToolEntry(
+        name="get_token_holders",
+        description="Top holders + distribution for a token.",
+        access="auth",
+        parameters=[
+            ToolParam(name="symbol", type="string", required=True, description="Asset symbol"),
+            _APIKEY,
+        ],
+    ))
+
+    @server.tool()
+    async def get_exchange_flows(
+        symbol: str | None = None, hours_back: int = 24, api_key: str = "",
+    ) -> str:
+        """Net exchange inflows / outflows (risk-off vs risk-on proxy).
+
+        Inflows to exchanges ≈ selling pressure; outflows ≈ accumulation.
+        """
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            kwargs: dict[str, Any] = {"hours_back": hours_back}
+            if symbol is not None:
+                kwargs["symbol"] = symbol
+            r = mangroveai_client().on_chain.get_exchange_flows(**kwargs)
+            return json.dumps(_dump(r))
+        except Exception as e:  # noqa: BLE001
+            return _err("ONCHAIN_EXCHANGE_FLOWS_FAILED", str(e))
+
+    register_tool(ToolEntry(
+        name="get_exchange_flows",
+        description="Net exchange inflows/outflows (selling pressure vs accumulation).",
+        access="auth",
+        parameters=[
+            ToolParam(name="symbol", type="string", required=False, description="Optional filter by asset"),
+            ToolParam(name="hours_back", type="integer", required=False, description="Window (default 24)"),
+            _APIKEY,
+        ],
+    ))
+
+
+# ---------------------------------------------------------------------------
+# DeFi (auth)
+# ---------------------------------------------------------------------------
+
+
+def _register_defi(server: FastMCP) -> None:
+    """Placeholder — will be populated in the defi commit."""
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Social (auth)
+# ---------------------------------------------------------------------------
+
+
+def _register_social(server: FastMCP) -> None:
+    """Placeholder — will be populated in the social commit."""
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Docs (auth)
+# ---------------------------------------------------------------------------
+
+
+def _register_docs(server: FastMCP) -> None:
+    """Placeholder — will be populated in the docs commit."""
+    pass
 
 
 # ---------------------------------------------------------------------------

--- a/server/src/mcp/tools.py
+++ b/server/src/mcp/tools.py
@@ -1033,6 +1033,108 @@ def _register_signals(server: FastMCP) -> None:
         ],
     ))
 
+    @server.tool()
+    async def get_signal(signal_name: str, api_key: str = "") -> str:
+        """Fetch a single signal's full metadata (params, description, category).
+
+        More detail than list_signals for a single name. Useful when the
+        agent knows which signal it wants but needs the parameter schema
+        before writing a strategy rule.
+        """
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            from src.shared.clients.mangrove import mangroveai_client
+            return json.dumps(_dump(mangroveai_client().signals.get(signal_name)))
+        except Exception as e:  # noqa: BLE001
+            return _err("SIGNAL_GET_FAILED", str(e))
+
+    register_tool(ToolEntry(
+        name="get_signal",
+        description="Fetch a single signal's full metadata + param schema.",
+        access="auth",
+        parameters=[
+            ToolParam(name="signal_name", type="string", required=True, description="Exact signal name (e.g. 'rsi_cross_up')"),
+            _APIKEY,
+        ],
+    ))
+
+    @server.tool()
+    async def match_signals(
+        description: str, top_k: int = 5,
+        similarity_threshold: float = 0.5,
+        api_key: str = "",
+    ) -> str:
+        """Semantic match: find signals matching a natural-language description.
+
+        Backs /create-strategy Phase C: the agent has a user idea
+        ('bullish momentum on liquid crypto'), calls this to find
+        candidate signals, then falls through to kb_search for
+        parameter guidance. Higher-quality than text search over
+        signal names.
+        """
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            from src.shared.clients.mangrove import mangroveai_client
+            r = mangroveai_client().signals.match(
+                description=description, top_k=top_k,
+                similarity_threshold=similarity_threshold,
+            )
+            return json.dumps(_dump(r))
+        except Exception as e:  # noqa: BLE001
+            return _err("SIGNAL_MATCH_FAILED", str(e))
+
+    register_tool(ToolEntry(
+        name="match_signals",
+        description="Semantic match of signals against a natural-language description.",
+        access="auth",
+        parameters=[
+            ToolParam(name="description", type="string", required=True, description="Natural-language description of what you want"),
+            ToolParam(name="top_k", type="integer", required=False, description="Max results (default 5)"),
+            ToolParam(name="similarity_threshold", type="number", required=False, description="Min similarity (default 0.5)"),
+            _APIKEY,
+        ],
+    ))
+
+    @server.tool()
+    async def search_signals(query: str, limit: int = 50, offset: int = 0,
+                             api_key: str = "") -> str:
+        """Text search over signals (complements list_signals's exhaustive iteration).
+
+        list_signals paginates the full catalog; search_signals filters
+        by a text query server-side. Prefer match_signals for
+        description-level intent; use this for name / keyword search.
+        """
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            from mangroveai.models import SearchSignalsRequest
+
+            from src.shared.clients.mangrove import mangroveai_client
+            req = SearchSignalsRequest(query=query, limit=limit, offset=offset)
+            page = mangroveai_client().signals.search(req)
+            items = [_dump(s) for s in getattr(page, "items", [])]
+            return json.dumps({
+                "items": items,
+                "total": getattr(page, "total", len(items)),
+                "limit": limit, "offset": offset,
+            })
+        except Exception as e:  # noqa: BLE001
+            return _err("SIGNAL_SEARCH_FAILED", str(e))
+
+    register_tool(ToolEntry(
+        name="search_signals",
+        description="Text search signals (keyword/name). For intent-based matching, prefer match_signals.",
+        access="auth",
+        parameters=[
+            ToolParam(name="query", type="string", required=True, description="Text query"),
+            ToolParam(name="limit", type="integer", required=False, description="Page size (default 50)"),
+            ToolParam(name="offset", type="integer", required=False, description="Page offset"),
+            _APIKEY,
+        ],
+    ))
+
 
 # ---------------------------------------------------------------------------
 # On-chain intelligence (auth)
@@ -1227,8 +1329,65 @@ def _register_on_chain(server: FastMCP) -> None:
 
 
 def _register_defi(server: FastMCP) -> None:
-    """Placeholder — will be populated in the defi commit."""
-    pass
+    """Macro DeFi metrics (TVL, stablecoin supply)."""
+    from src.shared.clients.mangrove import mangroveai_client
+
+    @server.tool()
+    async def get_chain_tvl(chain: str, api_key: str = "") -> str:
+        """Total value locked in DeFi on a given chain."""
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            return json.dumps(_dump(mangroveai_client().defi.get_chain_tvl(chain=chain)))
+        except Exception as e:  # noqa: BLE001
+            return _err("DEFI_CHAIN_TVL_FAILED", str(e))
+
+    register_tool(ToolEntry(
+        name="get_chain_tvl",
+        description="Total value locked (TVL) in DeFi on a given chain.",
+        access="auth",
+        parameters=[
+            ToolParam(name="chain", type="string", required=True, description="Chain (e.g. 'base', 'ethereum')"),
+            _APIKEY,
+        ],
+    ))
+
+    @server.tool()
+    async def get_protocol_tvl(protocol: str, api_key: str = "") -> str:
+        """Total value locked in a specific DeFi protocol."""
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            return json.dumps(_dump(mangroveai_client().defi.get_protocol_tvl(protocol=protocol)))
+        except Exception as e:  # noqa: BLE001
+            return _err("DEFI_PROTOCOL_TVL_FAILED", str(e))
+
+    register_tool(ToolEntry(
+        name="get_protocol_tvl",
+        description="TVL for a specific DeFi protocol (e.g. 'aave', 'uniswap').",
+        access="auth",
+        parameters=[
+            ToolParam(name="protocol", type="string", required=True, description="Protocol slug"),
+            _APIKEY,
+        ],
+    ))
+
+    @server.tool()
+    async def get_stablecoin_metrics(api_key: str = "") -> str:
+        """Stablecoin supply + flow metrics (macro liquidity proxy)."""
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            return json.dumps(_dump(mangroveai_client().defi.get_stablecoin_metrics()))
+        except Exception as e:  # noqa: BLE001
+            return _err("DEFI_STABLECOIN_FAILED", str(e))
+
+    register_tool(ToolEntry(
+        name="get_stablecoin_metrics",
+        description="Stablecoin supply + flow metrics (macro liquidity proxy).",
+        access="auth",
+        parameters=[_APIKEY],
+    ))
 
 
 # ---------------------------------------------------------------------------
@@ -1237,8 +1396,80 @@ def _register_defi(server: FastMCP) -> None:
 
 
 def _register_social(server: FastMCP) -> None:
-    """Placeholder — will be populated in the social commit."""
-    pass
+    """Twitter/X sentiment + influence + mentions. Experimental context."""
+    from src.shared.clients.mangrove import mangroveai_client
+
+    @server.tool()
+    async def get_sentiment(
+        topic: str, hours_back: int = 24, api_key: str = "",
+    ) -> str:
+        """Aggregate social sentiment for a topic (asset symbol or keyword)."""
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            r = mangroveai_client().social.get_sentiment(topic=topic, hours_back=hours_back)
+            return json.dumps(_dump(r))
+        except Exception as e:  # noqa: BLE001
+            return _err("SOCIAL_SENTIMENT_FAILED", str(e))
+
+    register_tool(ToolEntry(
+        name="get_sentiment",
+        description="Aggregate social (X/Twitter) sentiment for a topic or asset.",
+        access="auth",
+        parameters=[
+            ToolParam(name="topic", type="string", required=True, description="Asset symbol or keyword"),
+            ToolParam(name="hours_back", type="integer", required=False, description="Window (default 24)"),
+            _APIKEY,
+        ],
+    ))
+
+    @server.tool()
+    async def get_mentions(
+        topic: str, hours_back: int = 24, limit: int = 20, api_key: str = "",
+    ) -> str:
+        """Recent social mentions of a topic (raw posts)."""
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            r = mangroveai_client().social.get_mentions(
+                topic=topic, hours_back=hours_back, limit=limit,
+            )
+            return json.dumps(_dump(r))
+        except Exception as e:  # noqa: BLE001
+            return _err("SOCIAL_MENTIONS_FAILED", str(e))
+
+    register_tool(ToolEntry(
+        name="get_mentions",
+        description="Recent social mentions of a topic (raw posts).",
+        access="auth",
+        parameters=[
+            ToolParam(name="topic", type="string", required=True, description="Asset symbol or keyword"),
+            ToolParam(name="hours_back", type="integer", required=False, description="Window (default 24)"),
+            ToolParam(name="limit", type="integer", required=False, description="Max posts (default 20)"),
+            _APIKEY,
+        ],
+    ))
+
+    @server.tool()
+    async def get_influence_score(username: str, api_key: str = "") -> str:
+        """Influence score for a social username."""
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            r = mangroveai_client().social.get_influence_score(username=username)
+            return json.dumps(_dump(r))
+        except Exception as e:  # noqa: BLE001
+            return _err("SOCIAL_INFLUENCE_FAILED", str(e))
+
+    register_tool(ToolEntry(
+        name="get_influence_score",
+        description="Influence score for a social username.",
+        access="auth",
+        parameters=[
+            ToolParam(name="username", type="string", required=True, description="Social username (no @)"),
+            _APIKEY,
+        ],
+    ))
 
 
 # ---------------------------------------------------------------------------
@@ -1247,8 +1478,57 @@ def _register_social(server: FastMCP) -> None:
 
 
 def _register_docs(server: FastMCP) -> None:
-    """Placeholder — will be populated in the docs commit."""
-    pass
+    """MangroveAI developer docs (API reference + guides)."""
+    from src.shared.clients.mangrove import mangroveai_client
+
+    @server.tool()
+    async def list_docs(api_key: str = "") -> str:
+        """List MangroveAI developer docs.
+
+        ⚠️ Upstream returns 404 'Documentation directory not found'
+        as of 2026-04-23. Tool wiring is correct; upstream docs
+        directory is either missing or mis-configured server-side.
+        Falls through cleanly if the docs come back online.
+        """
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            items = mangroveai_client().docs.list()
+            return json.dumps([_dump(i) for i in items])
+        except Exception as e:  # noqa: BLE001
+            return _err("DOCS_LIST_FAILED", str(e))
+
+    register_tool(ToolEntry(
+        name="list_docs",
+        description="List MangroveAI developer docs (API reference + guides).",
+        access="auth",
+        parameters=[_APIKEY],
+    ))
+
+    @server.tool()
+    async def get_doc_content(path: str, api_key: str = "") -> str:
+        """Fetch a MangroveAI doc by path.
+
+        Different from kb_get_document (KB content DB). This hits the
+        MangroveAI developer documentation — API reference, SDK migration
+        guides, etc.
+        """
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            return json.dumps(_dump(mangroveai_client().docs.get_content(path=path)))
+        except Exception as e:  # noqa: BLE001
+            return _err("DOCS_GET_FAILED", str(e))
+
+    register_tool(ToolEntry(
+        name="get_doc_content",
+        description="Fetch a MangroveAI developer doc by path (API reference, guides).",
+        access="auth",
+        parameters=[
+            ToolParam(name="path", type="string", required=True, description="Doc path (from list_docs)"),
+            _APIKEY,
+        ],
+    ))
 
 
 # ---------------------------------------------------------------------------
@@ -1598,6 +1878,41 @@ def _register_strategy(server: FastMCP) -> None:
         access="auth",
         parameters=[
             ToolParam(name="strategy_id", type="string", required=True, description="Agent strategy UUID"),
+            _APIKEY,
+        ],
+    ))
+
+    @server.tool()
+    async def delete_strategy(strategy_id: str, api_key: str = "") -> str:
+        """Delete a strategy upstream on MangroveAI.
+
+        Workshop attendees create throwaway strategies and will want
+        to clean up. This hits mangroveai.strategies.delete — the
+        upstream strategy row is removed. Our LOCAL SQLite cache of
+        the strategy stays; the local row is harmless once the
+        upstream is gone, and we'd prefer to preserve the audit
+        trail for any trades/evaluations that referenced it.
+        """
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            from src.services.strategy_service import get_strategy
+            from src.shared.clients.mangrove import mangroveai_client
+            # Look up the mangrove_id from our local cache.
+            detail = get_strategy(strategy_id)
+            r = mangroveai_client().strategies.delete(detail.mangrove_id)
+            return json.dumps(_dump(r))
+        except AgentError as e:
+            return _handle_agent_error(e)
+        except Exception as e:  # noqa: BLE001
+            return _err("STRATEGY_DELETE_FAILED", str(e))
+
+    register_tool(ToolEntry(
+        name="delete_strategy",
+        description="Delete a strategy upstream (local audit trail preserved).",
+        access="auth",
+        parameters=[
+            ToolParam(name="strategy_id", type="string", required=True, description="Agent (local) strategy UUID"),
             _APIKEY,
         ],
     ))

--- a/server/src/mcp/tools.py
+++ b/server/src/mcp/tools.py
@@ -442,7 +442,17 @@ def _register_dex(server: FastMCP) -> None:
     async def get_token_info(
         chain_id: int, address: str, api_key: str = "",
     ) -> str:
-        """Look up token metadata (symbol, decimals, name) by contract address."""
+        """Look up token metadata (symbol, decimals, name) by contract address.
+
+        ⚠️ CURRENTLY BROKEN pending upstream SDK fix. The mangrovemarkets
+        SDK's TokenInfo pydantic model expects flat top-level fields
+        (address, symbol, name, decimals) but the server response nests
+        them under a `token` sub-dict. Every call returns
+        DEX_TOKEN_INFO_FAILED with a 4-validation-error message.
+        Tracked: https://github.com/MangroveTechnologies/MangroveMarkets-MCP-Server/issues/62
+        Fall back to kb_glossary_get or kb_search for token concept
+        lookups until this is fixed and the SDK version bumped.
+        """
         if not _require(api_key):
             return _auth_error()
         try:
@@ -456,7 +466,7 @@ def _register_dex(server: FastMCP) -> None:
 
     register_tool(ToolEntry(
         name="get_token_info",
-        description="Resolve token contract address → symbol/decimals/name.",
+        description="⚠️ BROKEN upstream (MangroveMarkets-MCP-Server#62). Use kb_glossary_get / kb_search for token concepts until SDK bump.",
         access="auth",
         parameters=[
             ToolParam(name="chain_id", type="integer", required=True, description="EVM chain id"),
@@ -469,7 +479,18 @@ def _register_dex(server: FastMCP) -> None:
     async def get_spot_price(
         chain_id: int, tokens: str, api_key: str = "",
     ) -> str:
-        """Current spot price for one or more tokens (comma-separated)."""
+        """Current spot price for one or more tokens.
+
+        `tokens` is a COMMA-SEPARATED LIST OF CONTRACT ADDRESSES.
+        Symbols are NOT accepted (upstream 1inch backend rejects
+        them with 400 Bad Request). Use get_token_info first if
+        you only have a symbol — though that tool is currently
+        broken (see its docstring). Workshop path: hardcode known
+        addresses (USDC on Base = 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913,
+        WETH on Base = 0x4200000000000000000000000000000000000006).
+
+        Prices are returned as wei-denominated integers (string form).
+        """
         if not _require(api_key):
             return _auth_error()
         try:
@@ -496,9 +517,18 @@ def _register_dex(server: FastMCP) -> None:
     async def get_gas_price(chain_id: int, api_key: str = "") -> str:
         """Current gas price estimate for a chain.
 
-        Useful as a pre-flight check before a swap — estimate how much
-        the tx will cost before committing. Returns slow / standard /
-        fast tier estimates per the venue's oracle.
+        Pre-flight check before a swap. Returns a `GasPrice` payload
+        where the SDK's flat top-level fields (`low`, `medium`, `high`,
+        `base_fee`) are currently null; real values are nested under
+        the `gas` key:
+            gas.baseFee                      — current base fee in wei
+            gas.low.maxPriorityFeePerGas     — tip for slow tx
+            gas.low.maxFeePerGas             — total cap for slow tx
+            gas.medium.{maxPriorityFeePerGas,maxFeePerGas}
+            gas.high.{maxPriorityFeePerGas,maxFeePerGas}
+
+        To estimate total cost in ETH for a swap, multiply a chosen
+        tier's maxFeePerGas by the gas limit returned by a quote.
         """
         if not _require(api_key):
             return _auth_error()
@@ -1116,7 +1146,10 @@ def _register_kb(server: FastMCP) -> None:
         """Fetch a full KB document by slug.
 
         Use when kb_search surfaces a document and the agent needs the
-        full body (not just the search snippet).
+        full body (not just the search snippet). Real documents run
+        up to ~25k chars — use sparingly and cite specific sections.
+
+        Response field: body lives under `content` (not `body`).
         """
         if not _require(api_key):
             return _auth_error()
@@ -1144,7 +1177,14 @@ def _register_kb(server: FastMCP) -> None:
 
         Useful for the /create-strategy skill's Phase C: agent picks
         a signal from list_signals, then calls this to find the KB
-        docs explaining that indicator family (momentum, trend, etc).
+        docs explaining that indicator family.
+
+        Category values are TITLE-CASE. Known values (as of 2026-04-23,
+        70 indicators total):
+            "Patterns"   (27)   "Trend"       (15)
+            "Momentum"   (11)   "Volume"       (9)
+            "Volatility"  (5)   "Returns"      (3)
+        Lowercase (e.g. "momentum") returns empty.
         """
         if not _require(api_key):
             return _auth_error()

--- a/server/src/mcp/tools.py
+++ b/server/src/mcp/tools.py
@@ -398,6 +398,127 @@ def _register_dex(server: FastMCP) -> None:
         ],
     ))
 
+    @server.tool()
+    async def get_tx_status(
+        tx_hash: str, chain_id: int,
+        venue_id: str | None = None,
+        api_key: str = "",
+    ) -> str:
+        """Check the status of a broadcast transaction.
+
+        Workshop-critical post-swap verification: execute_swap returns
+        a tx_hash before the tx is finalized. Call this tool after to
+        confirm the transaction landed (status: confirmed | pending |
+        failed). Pass-through to mangrovemarkets.dex.tx_status.
+        """
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            from src.shared.clients.mangrove import mangrovemarkets_client
+            result = mangrovemarkets_client().dex.tx_status(
+                tx_hash=tx_hash, chain_id=chain_id, venue_id=venue_id,
+            )
+            return json.dumps(_dump(result))
+        except Exception as e:  # noqa: BLE001
+            return _err("DEX_TX_STATUS_FAILED", str(e))
+
+    register_tool(ToolEntry(
+        name="get_tx_status",
+        description=(
+            "Verify a broadcast transaction's final state. Call after "
+            "execute_swap — the returned tx_hash isn't confirmed yet. "
+            "Returns status: confirmed | pending | failed + block info."
+        ),
+        access="auth",
+        parameters=[
+            ToolParam(name="tx_hash", type="string", required=True, description="Transaction hash returned by execute_swap"),
+            ToolParam(name="chain_id", type="integer", required=True, description="EVM chain id (8453 = Base mainnet)"),
+            ToolParam(name="venue_id", type="string", required=False, description="Optional: pin to a specific venue"),
+            _APIKEY,
+        ],
+    ))
+
+    @server.tool()
+    async def get_token_info(
+        chain_id: int, address: str, api_key: str = "",
+    ) -> str:
+        """Look up token metadata (symbol, decimals, name) by contract address."""
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            from src.shared.clients.mangrove import mangrovemarkets_client
+            result = mangrovemarkets_client().dex.token_info(
+                chain_id=chain_id, address=address,
+            )
+            return json.dumps(_dump(result))
+        except Exception as e:  # noqa: BLE001
+            return _err("DEX_TOKEN_INFO_FAILED", str(e))
+
+    register_tool(ToolEntry(
+        name="get_token_info",
+        description="Resolve token contract address → symbol/decimals/name.",
+        access="auth",
+        parameters=[
+            ToolParam(name="chain_id", type="integer", required=True, description="EVM chain id"),
+            ToolParam(name="address", type="string", required=True, description="Token contract address"),
+            _APIKEY,
+        ],
+    ))
+
+    @server.tool()
+    async def get_spot_price(
+        chain_id: int, tokens: str, api_key: str = "",
+    ) -> str:
+        """Current spot price for one or more tokens (comma-separated)."""
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            from src.shared.clients.mangrove import mangrovemarkets_client
+            result = mangrovemarkets_client().dex.spot_price(
+                chain_id=chain_id, tokens=tokens,
+            )
+            return json.dumps(_dump(result))
+        except Exception as e:  # noqa: BLE001
+            return _err("DEX_SPOT_PRICE_FAILED", str(e))
+
+    register_tool(ToolEntry(
+        name="get_spot_price",
+        description="Current spot price for one or more tokens on a chain.",
+        access="auth",
+        parameters=[
+            ToolParam(name="chain_id", type="integer", required=True, description="EVM chain id"),
+            ToolParam(name="tokens", type="string", required=True, description="Comma-separated token symbols or addresses"),
+            _APIKEY,
+        ],
+    ))
+
+    @server.tool()
+    async def get_gas_price(chain_id: int, api_key: str = "") -> str:
+        """Current gas price estimate for a chain.
+
+        Useful as a pre-flight check before a swap — estimate how much
+        the tx will cost before committing. Returns slow / standard /
+        fast tier estimates per the venue's oracle.
+        """
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            from src.shared.clients.mangrove import mangrovemarkets_client
+            result = mangrovemarkets_client().dex.gas_price(chain_id=chain_id)
+            return json.dumps(_dump(result))
+        except Exception as e:  # noqa: BLE001
+            return _err("DEX_GAS_PRICE_FAILED", str(e))
+
+    register_tool(ToolEntry(
+        name="get_gas_price",
+        description="Gas price estimate for a chain (pre-flight before execute_swap).",
+        access="auth",
+        parameters=[
+            ToolParam(name="chain_id", type="integer", required=True, description="EVM chain id"),
+            _APIKEY,
+        ],
+    ))
+
 
 # ---------------------------------------------------------------------------
 # Market data (auth)
@@ -962,6 +1083,106 @@ def _register_kb(server: FastMCP) -> None:
             ToolParam(name="limit", type="integer", required=False, description="Max results"),
             _APIKEY,
         ],
+    ))
+
+    @server.tool()
+    async def kb_glossary_get(term: str, api_key: str = "") -> str:
+        """Look up a single glossary term (definition + backlinks).
+
+        Cheaper + more focused than kb_search when the agent already
+        knows the exact term it wants. Backlinks field shows related
+        indicators and documents.
+        """
+        if not _require(api_key):
+            return _auth_error()
+        from src.shared.clients.mangrove import mangroveai_client
+        try:
+            return json.dumps(_dump(mangroveai_client().kb.glossary.get(term)))
+        except Exception as e:  # noqa: BLE001
+            return _err("KB_GLOSSARY_FAILED", str(e))
+
+    register_tool(ToolEntry(
+        name="kb_glossary_get",
+        description="Look up a KB glossary term (definition + backlinks).",
+        access="auth",
+        parameters=[
+            ToolParam(name="term", type="string", required=True, description="Glossary term (exact match)"),
+            _APIKEY,
+        ],
+    ))
+
+    @server.tool()
+    async def kb_get_document(slug: str, api_key: str = "") -> str:
+        """Fetch a full KB document by slug.
+
+        Use when kb_search surfaces a document and the agent needs the
+        full body (not just the search snippet).
+        """
+        if not _require(api_key):
+            return _auth_error()
+        from src.shared.clients.mangrove import mangroveai_client
+        try:
+            return json.dumps(_dump(mangroveai_client().kb.documents.get(slug)))
+        except Exception as e:  # noqa: BLE001
+            return _err("KB_DOCUMENT_NOT_FOUND", str(e))
+
+    register_tool(ToolEntry(
+        name="kb_get_document",
+        description="Fetch a KB document by slug (full body, not search snippet).",
+        access="auth",
+        parameters=[
+            ToolParam(name="slug", type="string", required=True, description="Document slug (e.g. 'momentum-strategies')"),
+            _APIKEY,
+        ],
+    ))
+
+    @server.tool()
+    async def kb_list_indicators(
+        category: str | None = None, api_key: str = "",
+    ) -> str:
+        """List KB indicator docs. Optionally filter by category.
+
+        Useful for the /create-strategy skill's Phase C: agent picks
+        a signal from list_signals, then calls this to find the KB
+        docs explaining that indicator family (momentum, trend, etc).
+        """
+        if not _require(api_key):
+            return _auth_error()
+        from src.shared.clients.mangrove import mangroveai_client
+        kwargs: dict[str, Any] = {}
+        if category is not None:
+            kwargs["category"] = category
+        try:
+            return json.dumps([_dump(i) for i in mangroveai_client().kb.indicators.list(**kwargs)])
+        except Exception as e:  # noqa: BLE001
+            return _err("KB_INDICATORS_FAILED", str(e))
+
+    register_tool(ToolEntry(
+        name="kb_list_indicators",
+        description="List KB indicator docs (optionally by category).",
+        access="auth",
+        parameters=[
+            ToolParam(name="category", type="string", required=False, description="Filter: momentum | trend | mean_reversion | volatility | volume | pattern"),
+            _APIKEY,
+        ],
+    ))
+
+    @server.tool()
+    async def kb_list_tags(api_key: str = "") -> str:
+        """List all KB tags — useful for navigation or kb_search filtering."""
+        if not _require(api_key):
+            return _auth_error()
+        from src.shared.clients.mangrove import mangroveai_client
+        try:
+            return json.dumps([_dump(t) for t in mangroveai_client().kb.tags.list()])
+        except Exception as e:  # noqa: BLE001
+            return _err("KB_TAGS_FAILED", str(e))
+
+    register_tool(ToolEntry(
+        name="kb_list_tags",
+        description="List KB tags (navigation + kb_search filtering).",
+        access="auth",
+        parameters=[_APIKEY],
     ))
 
 

--- a/server/src/mcp/tools.py
+++ b/server/src/mcp/tools.py
@@ -889,6 +889,108 @@ def _register_market(server: FastMCP) -> None:
         ],
     ))
 
+    @server.tool()
+    async def get_trending(api_key: str = "") -> str:
+        """Current trending crypto assets.
+
+        Pass-through to `mangroveai.crypto_assets.get_trending()`.
+        Useful for "what's hot right now" quick-glance. No filters.
+        """
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            from src.shared.clients.mangrove import mangroveai_client
+            return json.dumps(_dump(mangroveai_client().crypto_assets.get_trending()))
+        except Exception as e:  # noqa: BLE001
+            return _err("CRYPTO_TRENDING_FAILED", str(e))
+
+    register_tool(ToolEntry(
+        name="get_trending",
+        description="Trending crypto assets right now.",
+        access="auth",
+        parameters=[_APIKEY],
+    ))
+
+    @server.tool()
+    async def list_approved_assets(
+        min_score: float | None = None, limit: int = 100,
+        api_key: str = "",
+    ) -> str:
+        """List approved-universe crypto assets (with optional min_score filter).
+
+        Defaults to approved_only=True (the safe workshop subset).
+        Workshop attendees use this to see what's tradeable.
+        """
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            from src.shared.clients.mangrove import mangroveai_client
+            kwargs: dict[str, Any] = {"approved_only": True, "limit": limit}
+            if min_score is not None:
+                kwargs["min_score"] = min_score
+            items = mangroveai_client().crypto_assets.list(**kwargs)
+            return json.dumps([_dump(i) for i in items])
+        except Exception as e:  # noqa: BLE001
+            return _err("CRYPTO_LIST_FAILED", str(e))
+
+    register_tool(ToolEntry(
+        name="list_approved_assets",
+        description="Approved crypto asset universe (agent-safe set).",
+        access="auth",
+        parameters=[
+            ToolParam(name="min_score", type="number", required=False, description="Optional quality threshold"),
+            ToolParam(name="limit", type="integer", required=False, description="Max results (default 100)"),
+            _APIKEY,
+        ],
+    ))
+
+    @server.tool()
+    async def get_asset(symbol: str, api_key: str = "") -> str:
+        """Single-asset detail (score, approval state, metadata).
+
+        More focused than get_market_data — returns the MangroveAI
+        approval/score/categorization rather than price/volume.
+        """
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            from src.shared.clients.mangrove import mangroveai_client
+            return json.dumps(_dump(mangroveai_client().crypto_assets.get(symbol)))
+        except Exception as e:  # noqa: BLE001
+            return _err("CRYPTO_GET_FAILED", str(e))
+
+    register_tool(ToolEntry(
+        name="get_asset",
+        description="Single-asset metadata + score + approval state.",
+        access="auth",
+        parameters=[
+            ToolParam(name="symbol", type="string", required=True, description="Asset symbol (e.g. BTC, ETH)"),
+            _APIKEY,
+        ],
+    ))
+
+    @server.tool()
+    async def get_global_market(api_key: str = "") -> str:
+        """Global market overview (total market cap, BTC dominance, 24h change).
+
+        Context tool — useful when the agent wants to ground a
+        "market regime" observation before recommending strategies.
+        """
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            from src.shared.clients.mangrove import mangroveai_client
+            return json.dumps(_dump(mangroveai_client().crypto_assets.get_global_market()))
+        except Exception as e:  # noqa: BLE001
+            return _err("CRYPTO_GLOBAL_FAILED", str(e))
+
+    register_tool(ToolEntry(
+        name="get_global_market",
+        description="Global market overview (total cap, BTC dominance, 24h change).",
+        access="auth",
+        parameters=[_APIKEY],
+    ))
+
 
 # ---------------------------------------------------------------------------
 # Signals (auth)

--- a/server/src/mcp/tools.py
+++ b/server/src/mcp/tools.py
@@ -707,6 +707,113 @@ def _register_dex(server: FastMCP) -> None:
         ],
     ))
 
+    @server.tool()
+    async def get_token_search(
+        chain_id: int, query: str, api_key: str = "",
+    ) -> str:
+        """Fuzzy-search tokens by symbol or partial name.
+
+        Lets the agent resolve a symbol the user typed into a concrete
+        contract address. Pairs with the other DEX tools that need
+        addresses (get_spot_price, get_quote with address inputs, etc).
+        Current workaround for the broken get_token_info.
+        """
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            from src.shared.clients.mangrove import mangrovemarkets_client
+            results = mangrovemarkets_client().dex.token_search(
+                chain_id=chain_id, query=query,
+            )
+            return json.dumps([_dump(r) for r in results])
+        except Exception as e:  # noqa: BLE001
+            return _err("DEX_TOKEN_SEARCH_FAILED", str(e))
+
+    register_tool(ToolEntry(
+        name="get_token_search",
+        description="Fuzzy token search by symbol / partial name. Returns candidate contract addresses.",
+        access="auth",
+        parameters=[
+            ToolParam(name="chain_id", type="integer", required=True, description="EVM chain id"),
+            ToolParam(name="query", type="string", required=True, description="Symbol or partial name (e.g. 'USDC', 'Pepe')"),
+            _APIKEY,
+        ],
+    ))
+
+    @server.tool()
+    async def get_dex_chart(
+        chain_id: int, token0: str, token1: str, period: str = "1h",
+        api_key: str = "",
+    ) -> str:
+        """OHLC chart candles for a token pair on a DEX.
+
+        ⚠️ CURRENTLY BROKEN upstream. The mangrovemarkets SDK's
+        chart() wrapper sends token0/token1 fields but the upstream
+        1inch chart tool requires an `address` field. Every real
+        call returns DEX_CHART_FAILED with a validation error.
+        Fall back to get_ohlcv (CEX-aggregated from MangroveAI) for
+        price history until this is fixed.
+
+        Different from get_ohlcv: that one hits MangroveAI's
+        CEX-aggregated crypto_assets data; this one (when fixed)
+        pulls DEX-native candles for a specific on-chain pair.
+        """
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            from src.shared.clients.mangrove import mangrovemarkets_client
+            result = mangrovemarkets_client().dex.chart(
+                chain_id=chain_id, token0=token0, token1=token1, period=period,
+            )
+            return json.dumps([_dump(c) for c in result])
+        except Exception as e:  # noqa: BLE001
+            return _err("DEX_CHART_FAILED", str(e))
+
+    register_tool(ToolEntry(
+        name="get_dex_chart",
+        description="⚠️ BROKEN upstream (SDK sends token0/token1, server wants `address`). Use get_ohlcv for price history until fixed.",
+        access="auth",
+        parameters=[
+            ToolParam(name="chain_id", type="integer", required=True, description="EVM chain id"),
+            ToolParam(name="token0", type="string", required=True, description="Base token (symbol or address)"),
+            ToolParam(name="token1", type="string", required=True, description="Quote token (symbol or address)"),
+            ToolParam(name="period", type="string", required=False, description="Bar period (default '1h')"),
+            _APIKEY,
+        ],
+    ))
+
+    @server.tool()
+    async def get_allowances(
+        chain_id: int, wallet: str, spender: str, api_key: str = "",
+    ) -> str:
+        """ERC-20 allowance check — has the wallet approved `spender`?
+
+        Debugging / pre-approval check before execute_swap. Useful to
+        diagnose "my swap keeps failing" — often an expired approval.
+        """
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            from src.shared.clients.mangrove import mangrovemarkets_client
+            result = mangrovemarkets_client().dex.allowances(
+                chain_id=chain_id, wallet=wallet, spender=spender,
+            )
+            return json.dumps(_dump(result))
+        except Exception as e:  # noqa: BLE001
+            return _err("DEX_ALLOWANCES_FAILED", str(e))
+
+    register_tool(ToolEntry(
+        name="get_allowances",
+        description="Check ERC-20 allowances a wallet has granted a spender (approve_token output).",
+        access="auth",
+        parameters=[
+            ToolParam(name="chain_id", type="integer", required=True, description="EVM chain id"),
+            ToolParam(name="wallet", type="string", required=True, description="Wallet address"),
+            ToolParam(name="spender", type="string", required=True, description="Spender contract address (e.g. a router)"),
+            _APIKEY,
+        ],
+    ))
+
 
 # ---------------------------------------------------------------------------
 # Market data (auth)

--- a/server/src/mcp/tools.py
+++ b/server/src/mcp/tools.py
@@ -257,6 +257,164 @@ def _register_wallet(server: FastMCP) -> None:
         ],
     ))
 
+    # --- Portfolio (on-chain aggregate view of a wallet) -----------------
+    # Thin wrappers over mangrovemarkets.portfolio.*. The SDK accepts
+    # `addresses` as a comma-separated string (one or more wallets) and
+    # optional `chain_id` to pin the query.
+
+    @server.tool()
+    async def portfolio_value(
+        addresses: str, chain_id: int | None = None, api_key: str = "",
+    ) -> str:
+        """Aggregate USD value of one or more wallets.
+
+        `addresses` is a comma-separated list (agent can query multiple
+        wallets at once). Omit `chain_id` to get a cross-chain total.
+        """
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            from src.shared.clients.mangrove import mangrovemarkets_client
+            result = mangrovemarkets_client().portfolio.value(
+                addresses=addresses, chain_id=chain_id,
+            )
+            return json.dumps(_dump(result))
+        except Exception as e:  # noqa: BLE001
+            return _err("PORTFOLIO_VALUE_FAILED", str(e))
+
+    register_tool(ToolEntry(
+        name="portfolio_value",
+        description="Aggregate USD value of one or more wallet addresses.",
+        access="auth",
+        parameters=[
+            ToolParam(name="addresses", type="string", required=True, description="Comma-separated wallet addresses"),
+            ToolParam(name="chain_id", type="integer", required=False, description="Optional: pin to a single chain"),
+            _APIKEY,
+        ],
+    ))
+
+    @server.tool()
+    async def portfolio_pnl(
+        addresses: str, chain_id: int | None = None, api_key: str = "",
+    ) -> str:
+        """Running P&L across one or more wallets.
+
+        Returns realized + unrealized P&L based on the upstream's
+        cost-basis accounting. Workshop-critical answer to "how am
+        I doing?"
+        """
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            from src.shared.clients.mangrove import mangrovemarkets_client
+            result = mangrovemarkets_client().portfolio.pnl(
+                addresses=addresses, chain_id=chain_id,
+            )
+            return json.dumps(_dump(result))
+        except Exception as e:  # noqa: BLE001
+            return _err("PORTFOLIO_PNL_FAILED", str(e))
+
+    register_tool(ToolEntry(
+        name="portfolio_pnl",
+        description="Realized + unrealized P&L for one or more wallets.",
+        access="auth",
+        parameters=[
+            ToolParam(name="addresses", type="string", required=True, description="Comma-separated wallet addresses"),
+            ToolParam(name="chain_id", type="integer", required=False, description="Optional: pin to a single chain"),
+            _APIKEY,
+        ],
+    ))
+
+    @server.tool()
+    async def portfolio_tokens(
+        addresses: str, chain_id: int | None = None, api_key: str = "",
+    ) -> str:
+        """Per-token holdings for one or more wallets.
+
+        More detail than `get_balances` — includes USD value per
+        token, price, cost basis, and position P&L.
+        """
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            from src.shared.clients.mangrove import mangrovemarkets_client
+            result = mangrovemarkets_client().portfolio.tokens(
+                addresses=addresses, chain_id=chain_id,
+            )
+            return json.dumps(_dump(result))
+        except Exception as e:  # noqa: BLE001
+            return _err("PORTFOLIO_TOKENS_FAILED", str(e))
+
+    register_tool(ToolEntry(
+        name="portfolio_tokens",
+        description="Per-token holdings with USD value + per-position P&L.",
+        access="auth",
+        parameters=[
+            ToolParam(name="addresses", type="string", required=True, description="Comma-separated wallet addresses"),
+            ToolParam(name="chain_id", type="integer", required=False, description="Optional: pin to a single chain"),
+            _APIKEY,
+        ],
+    ))
+
+    @server.tool()
+    async def portfolio_defi(
+        addresses: str, chain_id: int | None = None, api_key: str = "",
+    ) -> str:
+        """DeFi positions (LPs, lending, staking) for one or more wallets."""
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            from src.shared.clients.mangrove import mangrovemarkets_client
+            result = mangrovemarkets_client().portfolio.defi(
+                addresses=addresses, chain_id=chain_id,
+            )
+            return json.dumps(_dump(result))
+        except Exception as e:  # noqa: BLE001
+            return _err("PORTFOLIO_DEFI_FAILED", str(e))
+
+    register_tool(ToolEntry(
+        name="portfolio_defi",
+        description="DeFi positions (LP, lending, staking) across wallets.",
+        access="auth",
+        parameters=[
+            ToolParam(name="addresses", type="string", required=True, description="Comma-separated wallet addresses"),
+            ToolParam(name="chain_id", type="integer", required=False, description="Optional: pin to a single chain"),
+            _APIKEY,
+        ],
+    ))
+
+    @server.tool()
+    async def portfolio_history(
+        address: str, limit: int = 50, api_key: str = "",
+    ) -> str:
+        """On-chain transaction history for a SINGLE wallet (not comma-separated).
+
+        Different from our local `list_trades` (which covers strategy-
+        executed swaps only). This tool covers EVERY on-chain tx for
+        the wallet — deposits, withdrawals, external swaps, etc.
+        """
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            from src.shared.clients.mangrove import mangrovemarkets_client
+            items = mangrovemarkets_client().portfolio.history(
+                address=address, limit=limit,
+            )
+            return json.dumps([_dump(i) for i in items])
+        except Exception as e:  # noqa: BLE001
+            return _err("PORTFOLIO_HISTORY_FAILED", str(e))
+
+    register_tool(ToolEntry(
+        name="portfolio_history",
+        description="On-chain tx history for a single wallet (all txs, not just strategy-driven).",
+        access="auth",
+        parameters=[
+            ToolParam(name="address", type="string", required=True, description="Single wallet address"),
+            ToolParam(name="limit", type="integer", required=False, description="Max results (default 50)"),
+            _APIKEY,
+        ],
+    ))
+
 
 # ---------------------------------------------------------------------------
 # DEX (auth)

--- a/server/tests/integration/test_dex_routes.py
+++ b/server/tests/integration/test_dex_routes.py
@@ -63,10 +63,33 @@ def client(tmp_path, monkeypatch):
     sdk.dex.broadcast.return_value = bcast
 
     tx_status = MagicMock()
+    tx_status.model_dump.return_value = {
+        "status": "confirmed", "block_number": 42, "error_message": None,
+    }
     tx_status.status = "confirmed"
     tx_status.block_number = 42
     tx_status.error_message = None
     sdk.dex.tx_status.return_value = tx_status
+
+    token_info = MagicMock()
+    token_info.model_dump.return_value = {
+        "address": "0x" + "a" * 40, "symbol": "USDC", "name": "USD Coin",
+        "decimals": 6, "chain_id": 8453,
+    }
+    sdk.dex.token_info.return_value = token_info
+
+    spot_price = MagicMock()
+    spot_price.model_dump.return_value = {
+        "chain_id": 8453,
+        "prices": {"USDC": 1.0, "ETH": 2500.0},
+    }
+    sdk.dex.spot_price.return_value = spot_price
+
+    gas_price = MagicMock()
+    gas_price.model_dump.return_value = {
+        "chain_id": 8453, "slow_gwei": 0.03, "standard_gwei": 0.05, "fast_gwei": 0.08,
+    }
+    sdk.dex.gas_price.return_value = gas_price
 
     monkeypatch.setattr("src.api.routes.dex.mangrovemarkets_client", lambda: sdk)
     monkeypatch.setattr("src.services.order_executor.mangrovemarkets_client", lambda: sdk)
@@ -213,3 +236,52 @@ def test_auth_required_on_dex_endpoints(client):
     assert client.post("/api/v1/agent/dex/quote",
                        json={"input_token": "USDC", "output_token": "ETH",
                              "amount": 1, "chain_id": 84532}).status_code == 401
+
+
+def test_tx_status(client):
+    r = client.get(
+        "/api/v1/agent/dex/tx-status?tx_hash=0xdeadbeef&chain_id=8453",
+        headers=_auth(),
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["status"] == "confirmed"
+    assert body["block_number"] == 42
+
+
+def test_token_info(client):
+    r = client.get(
+        "/api/v1/agent/dex/token-info?chain_id=8453&address=0x" + "a" * 40,
+        headers=_auth(),
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["symbol"] == "USDC"
+    assert body["decimals"] == 6
+
+
+def test_spot_price(client):
+    r = client.get(
+        "/api/v1/agent/dex/spot-price?chain_id=8453&tokens=USDC,ETH",
+        headers=_auth(),
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["prices"]["ETH"] == 2500.0
+
+
+def test_gas_price(client):
+    r = client.get(
+        "/api/v1/agent/dex/gas-price?chain_id=8453",
+        headers=_auth(),
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["standard_gwei"] == 0.05
+
+
+def test_auth_required_on_new_dex_endpoints(client):
+    assert client.get("/api/v1/agent/dex/tx-status?tx_hash=x&chain_id=1").status_code == 401
+    assert client.get("/api/v1/agent/dex/token-info?chain_id=1&address=0x0").status_code == 401
+    assert client.get("/api/v1/agent/dex/spot-price?chain_id=1&tokens=X").status_code == 401
+    assert client.get("/api/v1/agent/dex/gas-price?chain_id=1").status_code == 401

--- a/server/tests/integration/test_kb_routes.py
+++ b/server/tests/integration/test_kb_routes.py
@@ -1,0 +1,129 @@
+"""Integration tests for KB routes (search, glossary, documents, indicators, tags)."""
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock
+
+os.environ.setdefault("ENVIRONMENT", "test")
+
+import pytest  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+_API_KEY = "test-key-1"
+
+
+@pytest.fixture
+def client(monkeypatch):
+    # Stub the mangroveai KB surface. Each accessor (search/glossary/
+    # documents/indicators/tags) is a MagicMock that returns Pydantic-
+    # style objects with model_dump().
+    sdk = MagicMock()
+
+    search_resp = MagicMock()
+    search_resp.model_dump.return_value = {
+        "query": "momentum", "hits": [{"slug": "macd", "score": 0.9}],
+    }
+    sdk.kb.search.query.return_value = search_resp
+
+    glossary_entry = MagicMock()
+    glossary_entry.model_dump.return_value = {
+        "term": "RSI", "definition": "Relative Strength Index",
+        "backlinks": ["rsi_overbought", "rsi_oversold"],
+    }
+    sdk.kb.glossary.get.return_value = glossary_entry
+
+    doc_summary = MagicMock()
+    doc_summary.model_dump.return_value = {"slug": "macd", "title": "MACD guide"}
+    sdk.kb.documents.list.return_value = [doc_summary]
+
+    doc_full = MagicMock()
+    doc_full.model_dump.return_value = {
+        "slug": "macd", "title": "MACD guide", "body": "MACD is…",
+    }
+    sdk.kb.documents.get.return_value = doc_full
+
+    indicator = MagicMock()
+    indicator.model_dump.return_value = {
+        "name": "rsi", "category": "momentum", "description": "Relative Strength Index",
+    }
+    sdk.kb.indicators.list.return_value = [indicator]
+
+    tag = MagicMock()
+    tag.model_dump.return_value = {"name": "momentum", "count": 12}
+    sdk.kb.tags.list.return_value = [tag]
+
+    monkeypatch.setattr("src.api.routes.kb.mangroveai_client", lambda: sdk)
+
+    from src.app import create_app
+    app = create_app()
+    with TestClient(app) as c:
+        yield c
+
+
+def _auth() -> dict:
+    return {"X-API-Key": _API_KEY}
+
+
+def test_search(client):
+    r = client.get("/api/v1/agent/kb/search?q=momentum", headers=_auth())
+    assert r.status_code == 200
+    body = r.json()
+    assert body["query"] == "momentum"
+    assert body["hits"][0]["slug"] == "macd"
+
+
+def test_glossary(client):
+    r = client.get("/api/v1/agent/kb/glossary/RSI", headers=_auth())
+    assert r.status_code == 200
+    body = r.json()
+    assert body["term"] == "RSI"
+    assert "rsi_overbought" in body["backlinks"]
+
+
+def test_documents_list(client):
+    r = client.get("/api/v1/agent/kb/documents", headers=_auth())
+    assert r.status_code == 200
+    body = r.json()
+    assert len(body) == 1
+    assert body[0]["slug"] == "macd"
+
+
+def test_document_get(client):
+    r = client.get("/api/v1/agent/kb/documents/macd", headers=_auth())
+    assert r.status_code == 200
+    body = r.json()
+    assert body["title"] == "MACD guide"
+    assert "body" in body
+
+
+def test_indicators_list(client):
+    r = client.get("/api/v1/agent/kb/indicators", headers=_auth())
+    assert r.status_code == 200
+    body = r.json()
+    assert body[0]["name"] == "rsi"
+    assert body[0]["category"] == "momentum"
+
+
+def test_indicators_list_with_category_filter(client):
+    r = client.get("/api/v1/agent/kb/indicators?category=momentum", headers=_auth())
+    assert r.status_code == 200
+    # Verify the filter was passed through to the SDK.
+    from src.api.routes.kb import mangroveai_client
+    sdk = mangroveai_client()
+    sdk.kb.indicators.list.assert_called_with(category="momentum")
+
+
+def test_tags_list(client):
+    r = client.get("/api/v1/agent/kb/tags", headers=_auth())
+    assert r.status_code == 200
+    body = r.json()
+    assert body[0]["name"] == "momentum"
+
+
+def test_auth_required_on_kb_endpoints(client):
+    assert client.get("/api/v1/agent/kb/search?q=x").status_code == 401
+    assert client.get("/api/v1/agent/kb/glossary/RSI").status_code == 401
+    assert client.get("/api/v1/agent/kb/documents").status_code == 401
+    assert client.get("/api/v1/agent/kb/documents/macd").status_code == 401
+    assert client.get("/api/v1/agent/kb/indicators").status_code == 401
+    assert client.get("/api/v1/agent/kb/tags").status_code == 401


### PR DESCRIPTION
**33 new MCP tools** across 9 domains. Every tool verified with real calls against the live Mangrove backend; upstream issues filed where shape mismatches were found.

## Commits (8)

- `8bea32c` **G + H (initial)** — DEX tx_status/token_info/spot_price/gas_price + KB glossary_get/get_document/list_indicators/list_tags (8 tools)
- `2cd74b0` **docs accuracy pass** after real-call verification on the first 8
- `e926e62` **portfolio** — value/pnl/tokens/defi/history (5)
- `a2d9898` **extended DEX** — token_search/dex_chart(⚠️)/allowances (3)
- `9bd055c` **extended crypto_assets** — trending/list_approved/get_asset/get_global_market (4)
- `8fdcacd` **on_chain intelligence** — whale_activity/whale_transactions/smart_money_sentiment/screen_smart_money/token_holders/exchange_flows (6)
- `bf9e6e8` **extended signals + defi + social + docs + delete_strategy** — 12 tools
- `eed4110` **execution-side visibility** — list_account_positions/get_account_position/list_account_trades (3)

## Real-call verification matrix

| Domain | Tools | Verified | Broken upstream |
|---|---:|---:|---|
| DEX (initial) | 4 | 3 | `get_token_info` → [MangroveMarkets-MCP-Server#62](https://github.com/MangroveTechnologies/MangroveMarkets-MCP-Server/issues/62) |
| KB (initial) | 4 | 4 | — |
| Portfolio | 5 | 5 | — (Tim's wallet $10 USDC confirmed) |
| Extended DEX | 3 | 2 | `get_dex_chart` → [MangroveMarkets-MCP-Server#63](https://github.com/MangroveTechnologies/MangroveMarkets-MCP-Server/issues/63) |
| Extended crypto_assets | 4 | 4 | — |
| On-chain | 6 | 5 | `get_smart_money_sentiment` returns data-empty 404s upstream (not a tool bug) |
| Extended signals | 3 | 3 | — |
| Defi | 3 | 2 | `get_protocol_tvl` returned transient 504 |
| Social | 3 | 3 | — |
| Docs | 2 | 0 | Upstream "Documentation directory not found" 404 (backend misconfig) |
| Strategy | 1 | skipped | `delete_strategy` not destructively tested |
| Execution | 3 | 2 | — (both return empty lists as expected for our architecture) |
| **Total** | **41** (33 new + 8 initial) | **33 confirmed working** | 4 categories of upstream issues |

## Upstream issues surfaced

- [MangroveMarkets-MCP-Server#62](https://github.com/MangroveTechnologies/MangroveMarkets-MCP-Server/issues/62) — `TokenInfo` SDK model mismatch
- [MangroveMarkets-MCP-Server#63](https://github.com/MangroveTechnologies/MangroveMarkets-MCP-Server/issues/63) — `dex.chart` SDK/server arg shape mismatch
- Two data-layer issues (smart_money_sentiment, docs directory) — documented inline with ⚠️ banners in the tool descriptions; no code fix possible on our side

## Architecture note (captured in tool docstrings)

Exposed `execution.list_positions` / `get_position` / `list_trades` under renamed MCP tools (`list_account_positions`, etc.) to avoid colliding with our existing local `list_trades`. Our architecture doesn't populate MangroveAI's execution side — our live swaps write to local SQLite via `order_executor`. Execution tools will return empty for most users but are exposed for completeness / for users who also use copilot-authored strategies.

## Test plan

- [x] Full suite: **328 passed / 2 skipped** (unchanged through all 8 commits)
- [x] ruff clean
- [x] Real-call verification per domain table above
- [ ] Reviewer: in a fresh Claude Code session, ask the agent "what's my portfolio worth?" and confirm it invokes `portfolio_value` on your wallet address
- [ ] Reviewer: ask for whale activity on ETH — confirm `get_whale_activity` fires