### PR TITLE
fix: port-9080 dodge, upstream resync, new_orders silent failure

### DIFF
--- a/.mcp.json.example
+++ b/.mcp.json.example
@@ -2,7 +2,7 @@
   "mcpServers": {
     "defi-agent": {
       "transport": "http",
-      "url": "http://localhost:8080/mcp/",
+      "url": "http://localhost:9080/mcp/",
       "headers": {
         "X-API-Key": "dev-key-1"
       }

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ cd defi-agent
 First run takes ~60s (pip install + health wait). Re-runs are idempotent — it detects what's already done and skips.
 
 When it's finished:
-- Agent runs at `http://localhost:8080` (pid in `agent-data/bare.pid`, logs in `agent-data/bare.log`).
+- Agent runs at `http://localhost:9080` (pid in `agent-data/bare.pid`, logs in `agent-data/bare.log`). We bind 9080 externally because `:8080` is commonly squatted by VSCode Helper and other dev tools.
 - `./scripts/verify_quickstart.sh --bare` passed → the tool catalog returned the expected set.
 - Claude Code's MCP registration now knows about `defi-agent`.
 
@@ -174,7 +174,7 @@ Every tool has a mirrored REST endpoint at `/api/v1/agent/*`. Both call the same
 │  Claude Code ─MCP──┐                                        │
 │  Python/curl ─REST─┤                                        │
 │                    ▼                                        │
-│  ┌─ defi-agent (single FastAPI process, port 8080) ──┐     │
+│  ┌─ defi-agent (single FastAPI process, port 9080) ──┐     │
 │  │   • auth middleware (X-API-Key)                   │     │
 │  │   • service layer (one for REST + MCP)            │     │
 │  │   • APScheduler (in-process cron, SQLite jobstore)│     │

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,11 @@ services:
       dockerfile: Dockerfile
     container_name: defi-agent
     ports:
-      - "8080:8080"
+      # Host 9080 -> container 8080. Some host environments (VSCode's
+      # helper, other dev tools) grab :8080 — binding 9080 externally
+      # sidesteps that while keeping the container's internal port
+      # standard.
+      - "9080:8080"
     environment:
       - ENVIRONMENT=local
     volumes:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -473,7 +473,7 @@ Replace the template's `configuration-keys.json` with:
   "AUTH_ENABLED": true,
   "API_KEY": "local-dev-key",
   "MANGROVE_API_KEY": "dev_...",
-  "MANGROVEMARKETS_BASE_URL": "http://localhost:8080",
+  "MANGROVEMARKETS_BASE_URL": "http://localhost:9081",
   "DB_PATH": "./agent.db",
   "KEYRING_SERVICE_NAME": "defi-agent",
   "MASTER_KEY_ENV_FALLBACK": "",

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -4,7 +4,7 @@
 
 **Goal:** Build defi-agent — a local FastAPI + MCP service that wraps `mangroveai` and `mangrovemarkets` SDKs, runs autonomous trading strategies on cron jobs, and logs every evaluation and trade.
 
-**Architecture:** Single-process FastAPI app serves REST (`/api/v1/agent/*`) and MCP (`/mcp`) on port 8080. SQLite for all state including the APScheduler jobstore. Wallet keys encrypted with Fernet, master key in OS Keychain. Strategy evaluation delegated entirely to `mangroveai.execution.evaluate()` — the agent never reimplements signal/risk logic. Single execution path (`order_executor`) for both cron-driven and user-initiated swaps.
+**Architecture:** Single-process FastAPI app serves REST (`/api/v1/agent/*`) and MCP (`/mcp`) on port 9080 (externally; container-internal is still 8080). SQLite for all state including the APScheduler jobstore. Wallet keys encrypted with Fernet, master key in OS Keychain. Strategy evaluation delegated entirely to `mangroveai.execution.evaluate()` — the agent never reimplements signal/risk logic. Single execution path (`order_executor`) for both cron-driven and user-initiated swaps.
 
 **Tech Stack:** Python 3.10+, FastAPI, FastMCP, SQLite, APScheduler, cryptography (Fernet), keyring, mangroveai SDK, mangrovemarkets SDK, pytest.
 
@@ -41,7 +41,7 @@ Goal: turn the app-in-a-box template into a defi-agent shell. After this phase, 
 - [ ] **Step 4:** edit `server/src/api/router.py` — remove imports + includes for deleted routes; add `hello_mangrove` import + include under `x402_router`.
 - [ ] **Step 5:** edit `docker-compose.yml` — delete `postgres` and `redis` services + `volumes` block.
 - [ ] **Step 6:** run the existing test suite: `cd server && pytest`. Expect failures only for removed tests (now deleted) and any test that imported the removed routes — fix any collateral.
-- [ ] **Step 7:** run `docker compose up --build`. Verify the container starts and `curl http://localhost:8080/health` returns 200.
+- [ ] **Step 7:** run `docker compose up --build`. Verify the container starts and `curl http://localhost:9080/health` returns 200.
 - [ ] **Step 8:** commit: `chore(scaffold): rip template demo routes; rename easter_egg → hello_mangrove`.
 
 **Acceptance:** Clean repo with x402 still functional via `hello_mangrove`. App starts. No dead code.
@@ -496,7 +496,7 @@ Goal: every spec endpoint and MCP tool is wired up. After this phase, the agent 
 - [ ] **Step 4:** integration tests for each endpoint.
 - [ ] **Step 5:** commit: `feat(api): discovery routes (status, tools)`.
 
-**Acceptance:** `curl http://localhost:8080/api/v1/agent/status` returns the spec-defined shape.
+**Acceptance:** `curl http://localhost:9080/api/v1/agent/status` returns the spec-defined shape.
 
 ---
 
@@ -765,8 +765,8 @@ Goal: anyone cloning the repo on workshop day can `docker compose up`, hand Clau
   2. `cp server/src/config/local-example-config.json server/src/config/local-config.json`
   3. `sed -i '' 's/MANGROVE_API_KEY_PLACEHOLDER/<your key>/' server/src/config/local-config.json` (or manual edit — document both)
   4. `docker compose up -d --build`
-  5. `curl http://localhost:8080/health` — expect 200
-  6. `curl -H "X-API-Key: local-dev-key" http://localhost:8080/api/v1/agent/status` — expect JSON with `version`, `wallets_count: 0`
+  5. `curl http://localhost:9080/health` — expect 200
+  6. `curl -H "X-API-Key: local-dev-key" http://localhost:9080/api/v1/agent/status` — expect JSON with `version`, `wallets_count: 0`
   7. `cp .mcp.json.example .mcp.json` in any Claude Code project to connect
 - [ ] **Step 2:** explicit scope section in README: "v1 supports EVM chains only (Ethereum, Base, Arbitrum, Polygon, Optimism, BNB, Avalanche, zkSync, Gnosis, Linea). XRPL wallet creation returns a 501 in v1. Solana is not supported."
 - [ ] **Step 3:** link to `docs/testing-testnet.md` (Base Sepolia runbook) and `docs/testing-mainnet.md` (real-funds pre-flight) from the README under a "Testing" section.
@@ -776,7 +776,7 @@ Goal: anyone cloning the repo on workshop day can `docker compose up`, hand Clau
     "mcpServers": {
       "defi-agent": {
         "transport": "http",
-        "url": "http://localhost:8080/mcp",
+        "url": "http://localhost:9080/mcp",
         "headers": {
           "X-API-Key": "local-dev-key"
         }

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -731,7 +731,7 @@ Client-side configuration example (`.mcp.json` in a Claude Code project):
   "mcpServers": {
     "defi-agent": {
       "transport": "http",
-      "url": "http://localhost:8080/mcp",
+      "url": "http://localhost:9080/mcp",
       "headers": {
         "X-API-Key": "<your-configured-api-key>"
       }
@@ -773,7 +773,7 @@ client = MangroveAI()  # reads env
 **Purpose:** DEX swaps, wallet creation, portfolio analytics.
 
 **Config:**
-- `MANGROVEMARKETS_BASE_URL` — defaults to `http://localhost:8080` (MCP server); set to deployed URL in prod
+- `MANGROVEMARKETS_BASE_URL` — defaults to `http://localhost:9081` (self-hosted placeholder; port chosen to dodge the VSCode Helper squat on :8080); set to deployed URL in prod
 - `MANGROVE_API_KEY` — same key as `mangroveai`
 
 **Usage:**
@@ -871,7 +871,7 @@ x402 keys from the template stay required — payment middleware needs them at s
   "AUTH_ENABLED": true,
   "API_KEY": "local-dev-key",
   "MANGROVE_API_KEY": "dev_...",
-  "MANGROVEMARKETS_BASE_URL": "http://localhost:8080",
+  "MANGROVEMARKETS_BASE_URL": "http://localhost:9081",
   "DB_PATH": "./agent.db",
   "KEYRING_SERVICE_NAME": "defi-agent",
   "MASTER_KEY_ENV_FALLBACK": "",

--- a/init.sh
+++ b/init.sh
@@ -61,7 +61,7 @@ echo ""
 echo "Next steps:"
 echo "  1. cp server/src/config/local-example-config.json server/src/config/local-config.json"
 echo "  2. docker compose up -d --build"
-echo "  3. curl http://localhost:8080/health"
+echo "  3. curl http://localhost:9080/health"
 echo ""
 
 # Self-delete

--- a/plugin/.mcp.json
+++ b/plugin/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "app-in-a-box": {
       "type": "streamableHttp",
-      "url": "http://localhost:8080/mcp/"
+      "url": "http://localhost:9080/mcp/"
     }
   }
 }

--- a/scripts/confirm-backup.sh
+++ b/scripts/confirm-backup.sh
@@ -16,7 +16,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$REPO_ROOT"
 
-BASE_URL="${BASE_URL:-http://localhost:8080}"
+BASE_URL="${BASE_URL:-http://localhost:9080}"
 CONFIG_FILE="server/src/config/local-config.json"
 
 GREEN="\033[32m"; RED="\033[31m"; YELLOW="\033[33m"; DIM="\033[2m"; CLR="\033[0m"

--- a/scripts/reveal-secret.sh
+++ b/scripts/reveal-secret.sh
@@ -27,7 +27,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$REPO_ROOT"
 
-BASE_URL="${BASE_URL:-http://localhost:8080}"
+BASE_URL="${BASE_URL:-http://localhost:9080}"
 CONFIG_FILE="server/src/config/local-config.json"
 
 GREEN="\033[32m"; RED="\033[31m"; YELLOW="\033[33m"; DIM="\033[2m"; CLR="\033[0m"

--- a/scripts/run-bare.sh
+++ b/scripts/run-bare.sh
@@ -26,7 +26,7 @@ cd "$REPO_ROOT"
 CONFIG_FILE="server/src/config/local-config.json"
 VENV_DIR=".venv"
 HOST="${BARE_HOST:-0.0.0.0}"
-PORT="${BARE_PORT:-8080}"
+PORT="${BARE_PORT:-9080}"
 
 GREEN="\033[32m"; RED="\033[31m"; YELLOW="\033[33m"; DIM="\033[2m"; CLR="\033[0m"
 step() { printf "${YELLOW}==>${CLR} %s\n" "$1"; }

--- a/scripts/setup-mcp.sh
+++ b/scripts/setup-mcp.sh
@@ -16,7 +16,7 @@
 #   3. server/src/config/local-config.json exists
 #   4. Extract the first value of API_KEYS for the X-API-Key header
 #   5. Remove any existing defi-agent registration (idempotent)
-#   6. Register defi-agent at http://localhost:8080/mcp/ in local scope
+#   6. Register defi-agent at http://localhost:9080/mcp/ in local scope
 #
 # After this: restart Claude Code in the repo directory. Tools load
 # automatically. No approval prompt.
@@ -27,7 +27,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$REPO_ROOT"
 
-BASE_URL="${BASE_URL:-http://localhost:8080}"
+BASE_URL="${BASE_URL:-http://localhost:9080}"
 CONFIG_FILE="server/src/config/local-config.json"
 SERVER_NAME="defi-agent"
 
@@ -49,7 +49,7 @@ ok "claude found: $(command -v claude)"
 
 step "2. defi-agent container healthy at $BASE_URL"
 if ! curl -fsS -m 5 "$BASE_URL/health" >/dev/null 2>&1; then
-  fail "$BASE_URL/health did not respond. Run 'docker compose up -d --build' first."
+  fail "$BASE_URL/health did not respond. Run './scripts/setup.sh --yes' first (bare-metal) or 'docker compose up -d --build' (docker)."
 fi
 ok "/health returned 200"
 
@@ -92,7 +92,7 @@ claude mcp add --transport http --scope local "$SERVER_NAME" "$BASE_URL/mcp/" --
 ok "registered"
 
 echo
-printf "${GREEN}Done.${CLR} Restart Claude Code in this directory to load the 22 defi-agent tools.\n\n"
+printf "${GREEN}Done.${CLR} Restart Claude Code in this directory to load the defi-agent tools (41 total).\n\n"
 echo "  cd $(pwd)"
 echo "  claude"
 echo

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -34,7 +34,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$REPO_ROOT"
 
-BASE_URL="${BASE_URL:-http://localhost:8080}"
+BASE_URL="${BASE_URL:-http://localhost:9080}"
 CONFIG_FILE="server/src/config/local-config.json"
 EXAMPLE_CONFIG="server/src/config/local-example-config.json"
 PID_FILE="agent-data/bare.pid"
@@ -154,12 +154,14 @@ fi
 # Update MANGROVEMARKETS_BASE_URL if still localhost (the example default is
 # localhost, which is wrong for most users who want the hosted server).
 CURRENT_URL="$(python3 -c "import json; print(json.load(open('$CONFIG_FILE')).get('MANGROVEMARKETS_BASE_URL',''))")"
-if [ "$CURRENT_URL" = "http://localhost:8080" ]; then
+if [ "$CURRENT_URL" = "http://localhost:9081" ]; then
   NEW_URL="${MARKETS_URL_ARG:-$MARKETS_URL_DEFAULT}"
   if [ "$ASSUME_YES" != "yes" ] && [ -z "$MARKETS_URL_ARG" ]; then
     echo
-    echo "MANGROVEMARKETS_BASE_URL is currently http://localhost:8080 (self-hosted)."
+    echo "MANGROVEMARKETS_BASE_URL is currently http://localhost:9081 (self-hosted placeholder)."
     echo "Most users want the hosted URL. Accept the default, or paste your own."
+    echo "(Self-host note: 9081 avoids the VSCode Helper :8080 collision — if you run"
+    echo " MangroveMarkets-MCP-Server locally, bind it on 9081 to match this config.)"
     printf "[default: %s] " "$NEW_URL"
     read -r USER_URL
     [ -n "$USER_URL" ] && NEW_URL="$USER_URL"
@@ -214,10 +216,10 @@ else
     if [ "$FOREGROUND" = "yes" ]; then
       info "running in foreground (Ctrl+C to stop)"
       exec env ENVIRONMENT=local PYTHONPATH="$PYTHONPATH" python3 -m uvicorn src.app:app \
-        --host 0.0.0.0 --port 8080 --workers 1 --timeout-keep-alive 120
+        --host 0.0.0.0 --port 9080 --workers 1 --timeout-keep-alive 120
     else
       nohup env ENVIRONMENT=local PYTHONPATH="$PYTHONPATH" python3 -m uvicorn src.app:app \
-        --host 0.0.0.0 --port 8080 --workers 1 --timeout-keep-alive 120 \
+        --host 0.0.0.0 --port 9080 --workers 1 --timeout-keep-alive 120 \
         > "$REPO_ROOT/$LOG_FILE" 2>&1 &
       echo $! > "$REPO_ROOT/$PID_FILE"
       info "uvicorn started in background (pid $(cat "$PID_FILE"))"

--- a/scripts/stash-secret.sh
+++ b/scripts/stash-secret.sh
@@ -24,7 +24,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$REPO_ROOT"
 
-BASE_URL="${BASE_URL:-http://localhost:8080}"
+BASE_URL="${BASE_URL:-http://localhost:9080}"
 CONFIG_FILE="server/src/config/local-config.json"
 
 GREEN="\033[32m"; RED="\033[31m"; YELLOW="\033[33m"; DIM="\033[2m"; CLR="\033[0m"

--- a/scripts/verify_quickstart.sh
+++ b/scripts/verify_quickstart.sh
@@ -21,7 +21,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$REPO_ROOT"
 
-BASE_URL="${BASE_URL:-http://localhost:8080}"
+BASE_URL="${BASE_URL:-http://localhost:9080}"
 HEALTH_TIMEOUT_S=30
 START_TIME=$(date +%s)
 MODE="docker"

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -8,10 +8,17 @@ mcp[cli]>=1.2.0
 google-cloud-secret-manager>=2.20.0
 PyJWT>=2.9.0
 
-# defi-agent SDKs + infra
-mangroveai>=0.1.0
-mangrovemarkets>=0.1.0
-mangrove-kb>=1.0.0
+# defi-agent SDKs + infra.
+# Upper bounds pinned at the next minor: both SDKs are at 0.1.x (Alpha)
+# and minor bumps may carry breaking changes. Revisit pins when either
+# stabilizes to 1.0.
+# Note: there is no `mangrove-kb` package pinned here — all KB access
+# flows through mangroveai.kb.*, which the mangroveai SDK already
+# transitively provides. A previous `mangrove-kb>=1.0.0` pin was
+# impossible to resolve (upstream tops out at 0.5.0) and blocked fresh
+# pip installs.
+mangroveai>=0.1.0,<0.2.0
+mangrovemarkets>=0.1.0,<0.2.0
 apscheduler[sqlalchemy]>=3.10
 cryptography>=42
 keyring>=24

--- a/server/scripts/agent_pay_hello_mangrove.py
+++ b/server/scripts/agent_pay_hello_mangrove.py
@@ -9,7 +9,7 @@ Contrast with pay_hello_mangrove.py, which is an interactive step-through
 for humans learning the protocol.
 
 Requirements:
-    - Server running (default: http://127.0.0.1:8080)
+    - Server running (default: http://127.0.0.1:9080)
     - WALLET_SECRET env var with an EVM private key funded on the active
       network (~$0.05 USDC + a few cents of ETH for gas on Base mainnet)
 
@@ -47,7 +47,7 @@ async def main() -> int:
         print("ERROR: WALLET_SECRET unset. Export an EVM private key.", file=sys.stderr)
         return 1
 
-    base_url = os.environ.get("SERVER_URL", "http://127.0.0.1:8080")
+    base_url = os.environ.get("SERVER_URL", "http://127.0.0.1:9080")
     account = Account.from_key(secret)
     print(f"Payer address: {account.address}")
     print(f"Server:        {base_url}")

--- a/server/scripts/agent_pay_hello_mangrove_mcp.py
+++ b/server/scripts/agent_pay_hello_mangrove_mcp.py
@@ -7,7 +7,7 @@ with the payment attached via MCP _meta — the same ergonomics as
 x402AsyncTransport on the REST side.
 
 Requirements:
-    - Server running (default: http://127.0.0.1:8080) with the hello_mangrove
+    - Server running (default: http://127.0.0.1:9080) with the hello_mangrove
       tool registered via x402.mcp.create_payment_wrapper, so the 402 response
       shape is what x402MCPSession expects
     - WALLET_SECRET env var with an EVM private key funded on the active
@@ -52,7 +52,7 @@ async def main() -> int:
         print("ERROR: WALLET_SECRET unset. Export an EVM private key.", file=sys.stderr)
         return 1
 
-    base_url = os.environ.get("SERVER_URL", "http://127.0.0.1:8080").rstrip("/")
+    base_url = os.environ.get("SERVER_URL", "http://127.0.0.1:9080").rstrip("/")
     mcp_url = f"{base_url}/mcp/"
     network = os.environ.get("X402_NETWORK", "eip155:8453")
 

--- a/server/src/config/dev-config.json
+++ b/server/src/config/dev-config.json
@@ -2,7 +2,7 @@
   "AUTH_ENABLED": true,
   "API_KEYS": "secret:app-config-dev:api_keys",
   "MANGROVE_API_KEY": "secret:app-config-dev:mangrove_api_key",
-  "MANGROVEMARKETS_BASE_URL": "http://localhost:8080",
+  "MANGROVEMARKETS_BASE_URL": "http://localhost:9081",
   "DB_PATH": "./agent-data/agent.db",
   "MASTER_KEY_PATH": "./agent-data/master.key",
   "KEYRING_SERVICE_NAME": "defi-agent",

--- a/server/src/config/local-example-config.json
+++ b/server/src/config/local-example-config.json
@@ -2,7 +2,7 @@
   "AUTH_ENABLED": true,
   "API_KEYS": "dev-key-1",
   "MANGROVE_API_KEY": "REPLACE_WITH_YOUR_DEV_OR_PROD_KEY",
-  "MANGROVEMARKETS_BASE_URL": "http://localhost:8080",
+  "MANGROVEMARKETS_BASE_URL": "http://localhost:9081",
   "DB_PATH": "./agent-data/agent.db",
   "MASTER_KEY_PATH": "./agent-data/master.key",
   "KEYRING_SERVICE_NAME": "defi-agent",

--- a/server/src/config/prod-config.json
+++ b/server/src/config/prod-config.json
@@ -2,7 +2,7 @@
   "AUTH_ENABLED": true,
   "API_KEYS": "secret:app-config-prod:api_keys",
   "MANGROVE_API_KEY": "secret:app-config-prod:mangrove_api_key",
-  "MANGROVEMARKETS_BASE_URL": "http://localhost:8080",
+  "MANGROVEMARKETS_BASE_URL": "http://localhost:9081",
   "DB_PATH": "./agent-data/agent.db",
   "MASTER_KEY_PATH": "./agent-data/master.key",
   "KEYRING_SERVICE_NAME": "defi-agent",

--- a/server/src/config/test-config.json
+++ b/server/src/config/test-config.json
@@ -2,7 +2,7 @@
   "AUTH_ENABLED": true,
   "API_KEYS": "test-key-1,test-key-2",
   "MANGROVE_API_KEY": "test_key_not_used_in_unit_tests",
-  "MANGROVEMARKETS_BASE_URL": "http://localhost:8080",
+  "MANGROVEMARKETS_BASE_URL": "http://localhost:9081",
   "DB_PATH": ":memory:",
   "MASTER_KEY_PATH": "./agent-data-test/master.key",
   "KEYRING_SERVICE_NAME": "defi-agent-test",

--- a/server/src/services/strategy_service.py
+++ b/server/src/services/strategy_service.py
@@ -508,11 +508,20 @@ def tick(strategy_id: str) -> None:
                        exception=str(e), duration_ms=duration_ms)
             return
 
-        # Extract OrderIntents from SDK response. The shape varies: modern
-        # SDKs return EvaluateResult.orders or .actions; be defensive.
+        # Extract OrderIntents from SDK response. The shape varies by SDK
+        # / upstream version — be defensive. Current canonical key is
+        # `new_orders` (MangroveAI SDK `EvaluateResult.new_orders` +
+        # upstream `managers/services.py` response payload). Older
+        # variants used `order_intents` or `orders`; keep both as
+        # fallbacks for cross-version compatibility. Missing this key is
+        # a silent data loss: every tick logs an evaluation but zero
+        # orders, which looks like "strategy didn't fire" when in fact
+        # it did.
         raw_orders = (
-            getattr(sdk_resp, "order_intents", None)
+            getattr(sdk_resp, "new_orders", None)
+            or getattr(sdk_resp, "order_intents", None)
             or getattr(sdk_resp, "orders", None)
+            or (sdk_resp.model_dump().get("new_orders") if hasattr(sdk_resp, "model_dump") else None)
             or (sdk_resp.model_dump().get("order_intents") if hasattr(sdk_resp, "model_dump") else None)
             or []
         )

--- a/server/tests/e2e/test_paper_lifecycle.py
+++ b/server/tests/e2e/test_paper_lifecycle.py
@@ -94,6 +94,7 @@ def client(tmp_path, monkeypatch):
     # The evaluate mock returns an OrderIntent so we exercise the
     # full tick → executor → trade_log path.
     eval_resp = MagicMock()
+    eval_resp.new_orders = None
     eval_resp.order_intents = [
         {"action": "enter", "side": "buy", "symbol": "ETH",
          "amount": 0.01, "reason": "rsi_oversold fired"},

--- a/server/tests/e2e/test_smoke.py
+++ b/server/tests/e2e/test_smoke.py
@@ -78,7 +78,7 @@ def _stub_sdk() -> MagicMock:
 
     # execution
     sdk.execution.evaluate.return_value = MagicMock(
-        order_intents=[], orders=None,
+        new_orders=None, order_intents=[], orders=None,
         model_dump=MagicMock(return_value={"orders": []}),
     )
 

--- a/server/tests/integration/test_strategy_routes.py
+++ b/server/tests/integration/test_strategy_routes.py
@@ -53,6 +53,7 @@ def client(tmp_path, monkeypatch):
     sdk.strategies.update_status.return_value = MagicMock(success=True)
 
     eval_resp = MagicMock()
+    eval_resp.new_orders = None
     eval_resp.order_intents = []
     eval_resp.orders = None
     eval_resp.model_dump.return_value = {"orders": []}

--- a/server/tests/integration/test_strategy_service.py
+++ b/server/tests/integration/test_strategy_service.py
@@ -97,6 +97,7 @@ def mock_ai_sdk(monkeypatch):
 
     # execute.evaluate — empty by default
     eval_resp = MagicMock()
+    eval_resp.new_orders = None
     eval_resp.order_intents = []
     eval_resp.orders = None
     eval_resp.model_dump.return_value = {"orders": []}
@@ -302,6 +303,7 @@ def test_tick_paper_mode_logs_simulated_trade(temp_db, mock_ai_sdk, monkeypatch)
 
     # SDK returns one order intent.
     eval_resp = MagicMock()
+    eval_resp.new_orders = None
     eval_resp.order_intents = [
         {"action": "enter", "side": "buy", "symbol": "ETH",
          "amount": 0.1, "reason": "rsi_oversold fired"},

--- a/tutorials/trading-app/06-building.md
+++ b/tutorials/trading-app/06-building.md
@@ -15,7 +15,7 @@ The product owner agent drives implementation using the agent workforce.
 
 - Review and approve when asked
 - Answer questions if the agents need clarification
-- Test the running app periodically: `docker compose up -d --build && curl http://localhost:8080/health`
+- Test the running app periodically: `docker compose up -d --build && curl http://localhost:9080/health`
 
 ## Expected Output
 

--- a/tutorials/trading-app/08-deployment.md
+++ b/tutorials/trading-app/08-deployment.md
@@ -11,13 +11,13 @@ Deploy the trading app to production.
 docker compose up -d --build
 
 # Verify health
-curl http://localhost:8080/health
+curl http://localhost:9080/health
 
 # Test an endpoint
-curl http://localhost:8080/api/v1/echo -X POST -H "Content-Type: application/json" -d '{"message": "hello"}'
+curl http://localhost:9080/api/v1/echo -X POST -H "Content-Type: application/json" -d '{"message": "hello"}'
 
 # Test auth endpoint
-curl http://localhost:8080/api/v1/marketplace/listings -H "X-API-Key: dev-key-1"
+curl http://localhost:9080/api/v1/marketplace/listings -H "X-API-Key: dev-key-1"
 ```
 
 ## GCP Cloud Run (Optional)


### PR DESCRIPTION
## Summary

Three workshop-critical fixes surfaced during the Apr-23 dry-run against PR #46. All small but each is independently a workshop-day killer if left in.

- **Port-dodge alignment.** VSCode Helper squats :8080 on many dev machines. The defi-agent was already running on 9080 in practice, but nothing downstream knew — MCP registration, `setup-mcp.sh`, `setup.sh`, `run-bare.sh`, `docker-compose`, all docs and tutorials still referenced 8080. Claude Code would connect to VSCode, conclude "server isn't up," and offer `docker compose up`. Aligned every file at 9080 (container-internal port stays 8080; docker maps 9080:8080). Also bumped the `MANGROVEMARKETS_BASE_URL` self-host placeholder 8080 → 9081 + setup.sh detection string + doc defaults.
- **`mangrove-kb>=1.0.0` requirement removed.** Impossible to resolve — upstream tops out at 0.5.0. Would have broken every workshop attendee's first `pip install -r`. Package isn't imported anywhere in `server/src`; all KB access flows through `mangroveai.kb.*`. Also pinned `mangroveai` and `mangrovemarkets` to `<0.2.0` (both Alpha 0.1.x).
- **`strategy_service.tick` silent failure.** The SDK response reader missed `new_orders`, the canonical key used by the current MangroveAI SDK (`EvaluateResult.new_orders`) and the upstream platform. Every paper/live tick was logging an evaluation with zero orders even when the strategy fired. Added `new_orders` at first priority in the defensive `getattr` chain; kept `order_intents` / `orders` as fallbacks. Tests (4 mock sites) updated to set `.new_orders = None` to avoid MagicMock's phantom-attribute short-circuit.

## Heads-up for reviewers

- `CLAUDE.md` and `branding.json` are intentionally not in this PR — those are Tim's local persona/branding edits, stay out of trunk.
- `.mcp.json` (project-scope, user-facing) is gitignored — updated in-place on Tim's machine for the verification session; tracked `.mcp.json.example` is what fresh clones pick up.
- User-scope MCP registration in `~/.claude.json` — Tim re-registered via `claude mcp add` at 9080; no repo file needed.
- If you've been running against this repo, your `.claude/settings.local.json` has stale `curl :8080` approvals. Claude Code will prompt to re-approve `:9080` equivalents on first run.

## Test plan

- [x] `claude mcp list` → `✓ Connected` at `http://localhost:9080/mcp/`
- [x] `pytest tests/ -q` → 328 passed, 2 skipped, 0 failed
- [x] `pip install --dry-run -r server/requirements.txt` → resolves cleanly (was failing on `mangrove-kb>=1.0.0`)
- [x] `curl http://127.0.0.1:9080/health` → healthy; `curl .../api/v1/agent/status` returns expected JSON
- [ ] Fresh clone on reviewer's machine: `./scripts/setup.sh --yes --no-mcp --no-verify && curl localhost:9080/health` should return 200 first try
- [ ] Tim's Sage verification session in `~/Desktop/mangrove/app-in-a-box` loads 41 MCP tools after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)