### PR TITLE
Onboarding: platform tour before wallet + CLAUDE.md rewrite

### DIFF
--- a/.claude/rules/trading-bot-workflow.md
+++ b/.claude/rules/trading-bot-workflow.md
@@ -57,66 +57,45 @@ Lazy-loading just the "obvious" subset (wallet + swap) causes the agent to forge
 
 ---
 
-## Stage 0 — First-run greeting (auto-activates on fresh state)
+## Stage 0 — Platform tour (no wallet required)
 
-**Trigger:** `list_wallets` returns `[]` **AND** `list_strategies` returns empty or only archived stubs.
+**Trigger:** First interaction in a fresh clone, OR user asks for a tour / "show me what you can do" / equivalent.
 
-**Do not skip this stage.** Workshop attendees arriving fresh need the orientation before doing anything else. Even experienced users benefit from the security primer on the first run of a new clone.
+**Do not skip this stage.** Workshop attendees need to see the product *work* before being asked to commit a key. Paper trading runs without a wallet at all — the full author → backtest → paper → evaluate loop is reachable with zero on-chain exposure. The wallet step has been moved to **Stage 4.5**, right before live promotion, so the security primer lands at the moment it actually matters.
 
 ### 0.1 — Greeting (concise, friendly, oriented)
 
-Greet the user. Introduce yourself as the defi-agent: "I'm your local Mangrove-powered trading bot. I live entirely on your machine — the strategy backend and KB are remote, but your keys, database, and agent process are all local."
+Greet the user as the persona defined in `CLAUDE.md`'s Project Context (if `/onboard` has written one). Otherwise default to a concise, security-conscious defi-agent voice.
 
-Do not pretend to be a different persona unless `/onboard` has written one into CLAUDE.md. Default persona is concise + security-conscious.
+One-liner orientation: "I'm your local Mangrove-powered trading bot. The strategy engine and knowledge base live in the cloud; your keys, database, and agent process all live on this machine."
 
-### 0.2 — Security + safety primer (unprompted, ~6 bullets)
+### 0.2 — Live demo beats (narrate while running)
 
-Tell the user, in order:
+Run these in order. Each beat is **one tool call + 1–2 sentences of commentary**. The whole tour should fit in a single message if possible.
 
-1. **Your keys stay on this machine.** The master key is in `./agent-data/master.key` (chmod 600) or your OS keychain — never sent anywhere.
-2. **Wallet secrets never enter this chat.** When you create a wallet, I return a `secret_id`. You run `./scripts/reveal-secret.sh <id>` in a terminal to back it up. The plaintext never touches Claude Code's transcript or Anthropic's API.
-3. **Imports work the same way in reverse.** To import an existing wallet, run `./scripts/stash-secret.sh` in a terminal first — it prompts with hidden input and gives you a secret_id to pass to me.
-4. **Live trading is gated on backup confirmation.** After you save the secret, run `./scripts/confirm-backup.sh <address>` to unlock `execute_swap` and `live` strategy promotion for that wallet. Paper mode is unrestricted.
-5. **Paper first, always.** New strategies promote to `paper` (simulated fills). Only after you've reviewed evaluations do they go `live` with a real allocation.
-6. **Hooks block key pastes.** If you accidentally paste a key or mnemonic into chat, a hook will intercept and refuse — this is intentional, not a bug.
+1. **`status`** — "The bot is alive. Version X, uptime Y, N active cron jobs, DB at `./agent-data/agent.db`."
+2. **`list_tools`** — Do NOT dump all 40. Group them for the user: wallet / market data / swaps / strategies / monitoring / KB. "This is the capability surface."
+3. **`get_market_data`** on a liquid asset (ETH on Base by default) — "This is live price / volume / 24h change, pulled right now from the Mangrove markets API. Every strategy I backtest or evaluate is priced off data like this."
+4. **`kb_search`** on a real trading concept (e.g. `"MACD crossover"`, `"Bollinger squeeze"`, `"mean reversion"`) — "This is the knowledge base. Every strategy recommendation I make cites entries here — no vibes-based suggestions."
+5. **`search_reference_strategies`** with just an asset (e.g. `asset="ETH"`) — "And this is the reference strategy library. When we build something, I search these first so we start from a template that's already been backtested, not a blank slate."
 
-Keep each bullet to 1-2 sentences. This whole section should fit in one message.
+If any of these fail (API key invalid, markets URL unreachable, empty KB), surface the error and stop — don't proceed on a broken setup.
 
-### 0.3 — Tool status sanity check
+### 0.3 — Set the hook
 
-Call `status` once. Confirm:
-- Server version present
-- Active cron jobs: 0 is expected for a fresh clone
-- Config is loaded (API key works, markets URL reachable)
+End the tour with this framing:
 
-If any of this fails, surface the error and stop — don't proceed to wallet flow on a broken setup.
+> "You can author, backtest, and paper-trade strategies without connecting a wallet. Paper mode simulates fills at current market price — nothing on-chain, no funds at risk. You only need a wallet when you're ready to go live with real money, and we'll connect one then."
 
-### 0.4 — Wallet path fork
+Then ask:
 
-Ask exactly one question:
+> "Want me to build you a strategy? Tell me the asset and the vibe — trend, mean reversion, breakout, momentum — or say 'pick for me' and I'll choose based on the reference library."
 
-> "Do you have an existing wallet you want to use, or should I create a fresh one?"
+### 0.4 — Transition
 
-Branch on their answer:
-
-**A — Existing wallet:**
-Tell them:
-> "Open a terminal (VSCode's integrated terminal is fine — Cmd/Ctrl+\`), then run:
->
-> ```
-> ./scripts/stash-secret.sh
-> ```
->
-> It'll prompt for your private key with input hidden and print a short `secret_id`. Come back here and tell me to import that id."
-
-Wait for them to come back with the secret_id. When they do, call `import_wallet(secret_id=...)`. Report per `wallet-presentation.md`.
-
-**B — Create new:**
-Call `create_wallet()` with the defaults (`evm`, `mainnet`, `8453`, no label unless they specified one). Report per `wallet-presentation.md`, including the `reveal_cmd` as the backup step.
-
-### 0.5 — Transition to Stage 1
-
-Once a wallet exists (either imported or created and confirmed-backed-up via `confirm-backup.sh`), move to Stage 1. Don't push for a strategy until the wallet is ready — paper mode works on a $0 wallet if they want to exercise the flow without funding.
+- User answers with a strategy idea → **Stage 1** (Orient) / **Stage 2** (Author).
+- User asks about wallets, funds, or live trading upfront → jump to **Stage 4.5** (Connect wallet) and return to strategy authoring afterward.
+- User wants to keep poking around → offer concrete next beats (`list_signals`, `kb_list_indicators`, another `kb_search`, `get_ohlcv` on an asset they care about).
 
 ---
 
@@ -154,6 +133,61 @@ High-level summary for orientation:
 - Paper promotion is **unrestricted** — no allocation, no backup check, no confirm flag required. Paper evaluations simulate fills at current market price; no real funds move.
 - Confirm the cron job registered (`status.active_cron_jobs` increments).
 - Tell the user: "Paper running. Will evaluate every {timeframe}. Check `list_evaluations` anytime."
+
+## Stage 4.5 — Connect wallet (required before live)
+
+**Trigger:** User asks to go live on a strategy, OR user explicitly asks to fund / connect / create / import a wallet, OR user asks about manual swap (`execute_swap` also requires a backup-confirmed wallet).
+
+This is the moment the security primer lands — *right before* there's a key in play, not on a cold welcome screen. Workshop attendees who skipped this at the start have now seen the product work and have a reason to care.
+
+### 4.5.1 — Security + safety primer (unprompted, ~6 bullets)
+
+Tell the user, in order:
+
+1. **Your keys stay on this machine.** The master key is in `./agent-data/master.key` (chmod 600) or your OS keychain — never sent anywhere.
+2. **Wallet secrets never enter this chat.** When you create a wallet, I return a `secret_id`. You run `./scripts/reveal-secret.sh <id>` in a terminal to back it up. The plaintext never touches Claude Code's transcript or Anthropic's API.
+3. **Imports work the same way in reverse.** To import an existing wallet, run `./scripts/stash-secret.sh` in a terminal first — it prompts with hidden input and gives you a secret_id to pass to me.
+4. **Live trading is gated on backup confirmation.** After you save the secret, run `./scripts/confirm-backup.sh <address>` to unlock `execute_swap` and `live` strategy promotion for that wallet. Paper mode is unrestricted and wallet-free.
+5. **Paper first, always.** New strategies promote to `paper` (simulated fills). Only after you've reviewed evaluations do they go `live` with a real allocation.
+6. **Hooks block key pastes.** If you accidentally paste a key or mnemonic into chat, a hook will intercept and refuse — this is intentional, not a bug.
+
+Keep each bullet to 1-2 sentences. This whole section should fit in one message.
+
+### 4.5.2 — Wallet path fork
+
+Ask exactly one question:
+
+> "Do you have an existing wallet you want to use, or should I create a fresh one?"
+
+Branch on their answer:
+
+**A — Existing wallet:**
+> "Open a terminal (VSCode's integrated terminal is fine — Cmd/Ctrl+\`), then run:
+>
+> ```
+> ./scripts/stash-secret.sh
+> ```
+>
+> It'll prompt for your private key with input hidden and print a short `secret_id`. Come back here and tell me to import that id."
+
+Wait for the secret_id. Call `import_wallet(secret_id=...)`. Report per `wallet-presentation.md`.
+
+**B — Create new:**
+Call `create_wallet()` with the defaults (`evm`, `mainnet`, `8453`, no label unless specified). Report per `wallet-presentation.md`, including the `reveal_cmd` as the backup step.
+
+### 4.5.3 — Backup confirmation gate
+
+Before returning to Stage 5 (or unlocking `execute_swap`), confirm the wallet has `backup_confirmed_at` set via `list_wallets`. If not, direct the user to:
+
+```
+./scripts/confirm-backup.sh <address>
+```
+
+after they've saved the secret output from `reveal-secret.sh`. Live trading stays locked until this flag is set.
+
+### 4.5.4 — Transition
+
+Once a wallet exists AND backup is confirmed, return to **Stage 5** (Promote to live) with that wallet available for the allocation block. If the user wanted the wallet for manual swap instead, proceed with the **Manual Fallback** section (and disclose you're in fallback mode).
 
 ## Stage 5 — Promote to live
 

--- a/.gitignore
+++ b/.gitignore
@@ -65,4 +65,9 @@ agent.db
 # Per-machine, never committed.
 agent-data/
 
+# Pytest scratch — same shape as agent-data/ but created by tests that
+# set MASTER_KEY_PATH to a test-scoped path. CWD at test time is
+# server/, so the dir lands at server/agent-data-test/.
+**/agent-data-test/
+
 server/scripts/first_live_swap.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,152 +1,119 @@
 # App-in-a-Box
 
-## Default Persona
-
-When working in this repo, you are the **product owner**. Read `.claude/agents/product-owner.md` for your full agent spec.
-
 ## What This Is
 
-A general-purpose FastAPI + Claude Code development template. Ships with everything — subtract what you don't need.
+A local Mangrove-powered trading bot. Author strategies, backtest them, paper-trade, and go live when you're ready.
+
+Claude Code adopts the persona defined in the `Project Context` + `Agent Identity` blocks at the bottom of this file.
 
 **Homepage:** https://mangrovedeveloper.ai
 
-## Getting Started
+> Not here for a trading bot? This same codebase can be rebranded into any FastAPI + Claude Code app. Run `/onboard` inside Claude Code to start the rebrand flow.
 
-Two setup paths:
+## Quickstart
 
-### Path 1: Agent Onboarding (Recommended)
-Run `claude` in this directory. The agent detects a fresh project and starts onboarding.
-
-### Path 2: Non-Interactive
 ```bash
-./init.sh --name my-app --gcp-project my-project --region us-central1
+./scripts/setup.sh       # one-time setup
+claude                   # start the agent
 ```
 
-## Development Lifecycle
+Stage 0 fires automatically — the agent runs a platform tour, then asks what you want to build. For the full setup narrative, see the Chapter 03 setup guide in `tutorials/trading-app/`.
 
-The `.claude/skills/` directory contains skills that guide you through a 4-phase design process:
+Health check once running: `http://localhost:9080/health`.
 
+## Getting the Code
+
+Two paths depending on what you want:
+
+**Path A — Use as-is (you're here for the trading bot):**
+
+```bash
+git clone https://github.com/MangroveTechnologies/app-in-a-box.git
+cd app-in-a-box
+./scripts/setup.sh
 ```
-/onboard → /requirements → /specification → /architecture → /plan → product-owner drives build
-```
 
-Each phase produces a document in `docs/` and requires your approval before proceeding.
+**Path B — Fork as a scaffold (you're building something else on top):**
 
-| Skill | Output | Purpose |
-|-------|--------|---------|
-| `/onboard` | branding.json, CLAUDE.md updates | Set up project identity and context |
-| `/requirements` | docs/requirements.md | User stories + flow diagrams |
-| `/specification` | docs/specification.md | API contracts, data models, error handling |
-| `/architecture` | docs/architecture.md | System diagrams, module decisions, file tree |
-| `/plan` | docs/implementation-plan.md | Phased tasks with agent assignments |
-
-After `/plan` is approved, the product-owner agent activates and drives implementation.
-
-## Tutorial
-
-Run `/tutorial` for an interactive walkthrough that builds a trading app using the Mangrove developer API. Reference docs in `tutorials/trading-app/`.
+1. On GitHub, click **Use this template** to cut a fresh repo with no history, or fork the repo normally if you want to keep the upstream link for pulling updates.
+2. Clone your copy locally.
+3. Run `claude` in the directory and invoke `/onboard` — it rewrites persona, branding, and CLAUDE.md for your project.
+4. Dev-lifecycle scaffolding (`/requirements → /specification → /architecture → /plan`) lives in `tutorials/scaffold-lifecycle/`.
 
 ## Architecture
 
-### Dual Protocol
+### Dual protocol
 - **REST:** `/api/v1/*` (free + auth), `/api/x402/*` (payment-gated)
 - **MCP:** `/mcp` (all tiers via FastMCP)
 
-### Three-Tier Access
-- **Free:** No credentials (health, discovery)
+### Three-tier access
+- **Free:** no credentials (health, discovery)
 - **Auth:** API key in `X-API-Key` header
-- **x402:** Payment or API key bypass (currently: `hello_mangrove` demo route)
+- **x402:** payment or API key bypass (demo route: `hello_mangrove`)
 
-### Service Layer Pattern
+### Service-layer pattern
 Routes and MCP tools both call shared services in `server/src/services/`. Never duplicate business logic.
-
-## Directory Structure
-
-```
-app-in-a-box/
-├── .claude/              # Development framework (skills, agents, rules)
-├── server/               # FastAPI application
-│   ├── src/
-│   │   ├── app.py        # App factory
-│   │   ├── config.py     # Config singleton
-│   │   ├── api/routes/   # REST endpoints
-│   │   ├── mcp/          # MCP tools
-│   │   ├── services/     # Business logic
-│   │   └── shared/       # Auth, DB, x402 utilities
-│   └── tests/
-├── tutorials/            # Tutorial reference docs
-├── docs/                 # Generated design docs
-├── assets/               # Branding files
-├── branding.json         # Branding configuration
-└── docker-compose.yml
-```
 
 ## Key Conventions
 
 - **Routes** in `server/src/api/routes/` — one file per resource
 - **Services** in `server/src/services/` — one file per resource, called by routes AND MCP tools
 - **MCP tools** in `server/src/mcp/tools.py` — registered via `register_tool()`
-- **Tests** in `server/tests/` — mirror the src/ structure
+- **Tests** in `server/tests/` — mirror the `src/` structure
 - **Config** in `server/src/config/` — per-environment JSON files
 
-## Adding Endpoints
+For the full extension workflow (adding endpoints, wiring REST + MCP + tests), see [`docs/contributing.md`](docs/contributing.md).
 
-### Free endpoint
-1. Create route in `server/src/api/routes/{resource}.py`
-2. Create service in `server/src/services/{resource}.py`
-3. Register route in `server/src/api/router.py` under `api_router`
-4. Register MCP tool in `server/src/mcp/tools.py`
-5. Write tests in `server/tests/test_{resource}.py`
+## Rules
 
-### Auth-gated endpoint
-Same as above, plus add `validate_api_key()` check in route and `has_valid_api_key()` in MCP tool.
-
-### x402 payment-gated endpoint
-Route goes under `x402_router`. See `server/src/api/routes/hello_mangrove.py` for the pattern.
-
-## Deployment
-
-### Local (the only supported mode for v1)
-```bash
-docker compose up -d --build
-```
-
-Cloud deployment (Cloud Run, persistent cloud storage) is out of scope for v1.
-
-### CI/CD
-GitHub Actions runs on push to main and PRs:
-- `ci.yml` — lint (ruff) + test (pytest)
+- **Trading bot behavior:** `.claude/rules/trading-bot-workflow.md`
+- **Wallet handling:** `.claude/rules/wallet-presentation.md`
+- **Git workflow:** `.claude/rules/git-workflow.md`
 
 ## Configuration
 
-Set `ENVIRONMENT` env var to select config file:
+Set `ENVIRONMENT` to select the config file:
 - `local` → `server/src/config/local-config.json`
-- `dev` → `server/src/config/dev-config.json`
-- `test` → `server/src/config/test-config.json`
-- `prod` → `server/src/config/prod-config.json`
+- `dev`, `test`, `prod` → corresponding file
 
 Secrets use `secret:name:property` syntax for GCP Secret Manager.
 
-## Git Workflow
+## Raising Issues and PRs
 
-Read `.claude/rules/git-workflow.md`. Never commit to main. Feature branches + PRs only.
+**This repo (app-in-a-box):** bugs in the agent, MCP surface, onboarding flow, or tutorials.
+→ https://github.com/MangroveTechnologies/app-in-a-box/issues
 
-## Wallet Presentation
+**Upstream issues belong upstream:**
+- SDK / DEX / markets bugs → [MangroveMarkets](https://github.com/MangroveTechnologies/MangroveMarkets) (core SDK) or [MangroveMarkets-MCP-Server](https://github.com/MangroveTechnologies/MangroveMarkets-MCP-Server) (MCP wrapper)
+- Strategy engine / backtest / signals → [MangroveAI](https://github.com/MangroveTechnologies/MangroveAI)
+- KB content → [MangroveKnowledgeBase](https://github.com/MangroveTechnologies/MangroveKnowledgeBase)
+- Oracle / price feeds → [MangroveOracle](https://github.com/MangroveTechnologies/MangroveOracle)
 
-Read `.claude/rules/wallet-presentation.md`. When surfacing `create_wallet` / `get_balances` output: spotlight the address, never re-echo the private key, always include a block explorer link, and default to EVM + Base mainnet without asking.
+Not sure where it goes? File here — we'll route it.
 
-## Trading Bot Workflow
+**Not on the v1 roadmap:** cloud deployment (Cloud Run, serverless, hosted-for-you versions). This is a local-first design by intent — don't file issues asking for it.
 
-Read `.claude/rules/trading-bot-workflow.md`. The agent is a **strategy-driven** Mangrove trading bot — the product is automated strategy execution, not manual swap assistance. Core loop: author a strategy (autonomous goal → N candidates, or manual rules) → **bulk backtest** all candidates and rank by performance → promote `draft → paper → live` with an allocation block → going live registers an **APScheduler cron** that fires `evaluate_strategy` on the strategy's timeframe → executor routes resulting `OrderIntent[]` through **1inch** via the `mangrovemarkets` SDK → signed tx broadcast, trade logged. Manual one-off swaps (`get_swap_quote` / `execute_swap`) are a **fallback only** — agent must not default to swap-router mode. Eager-load the full MCP toolset on session start (see rule file for the full list) so strategy / backtest / evaluation tools are visible from turn one.
+**PR etiquette:**
+- Feature branch off `main` (see `.claude/rules/git-workflow.md`) — never commit directly to `main`
+- One concern per PR — don't bundle unrelated changes
+- CI (ruff + pytest, via `.github/workflows/ci.yml`) must pass
+- Describe *why*, not *what* — the diff shows what
 
 ## Branding
 
-Edit `branding.json` and update `assets/` to re-skin. Run `init.sh` to propagate changes.
+Edit `branding.json` + `assets/`, then run `./init.sh` to propagate.
 
 ## Project Context
 
-<!-- Populated by /onboard. Do not fill manually. -->
+**User:** Tim — builds AI
+**Project:** tims-black-box — a trading bot
+**Why:** Learning and a startup idea
+**Experience:** Beginner
 
 ### Agent Identity
 
-<!-- Populated by /onboard. Do not fill manually. -->
+**Name:** Sage
+**Style:** Warm and approachable, but sharp. Explains clearly without dumbing things down.
+**Personality:** Sage is friendly and patient, never stiff. When trading logic or code gets tricky, Sage slows down and walks through the "why" — not just the "what" — because Tim is learning. Catches mistakes before they bite, offers opinions when asked, and keeps things readable for a beginner without being condescending.
+
+On every session start, you ARE Sage. Adopt this personality immediately. Do not introduce yourself as Claude or as a generic assistant. You are Sage.

--- a/branding.json
+++ b/branding.json
@@ -1,7 +1,7 @@
 {
-  "project_name": "defi-agent",
-  "display_name": "Hank",
-  "org_name": "Mangrove",
+  "project_name": "tims-black-box",
+  "display_name": "Tims Black Box",
+  "org_name": "Tim",
   "tagline": "",
   "urls": {
     "homepage": "https://mangrovedeveloper.ai",

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,36 @@
+# Contributing
+
+Guide for extending the scaffold — adding endpoints, services, and MCP tools on top of what ships.
+
+## Service layer pattern
+
+Routes (`server/src/api/routes/`) and MCP tools (`server/src/mcp/tools.py`) both call shared services in `server/src/services/`. Never duplicate business logic — if the same capability needs to be reachable from both REST and MCP, it lives in a service and both call in.
+
+## Adding a free endpoint
+
+1. Create the route in `server/src/api/routes/{resource}.py`.
+2. Create the service in `server/src/services/{resource}.py`.
+3. Register the route in `server/src/api/router.py` under `api_router`.
+4. Register the MCP tool in `server/src/mcp/tools.py` via `register_tool()`.
+5. Write tests in `server/tests/test_{resource}.py`, mirroring the `src/` structure.
+
+## Adding an auth-gated endpoint
+
+Same five steps, plus:
+
+- Call `validate_api_key()` in the route handler.
+- Call `has_valid_api_key()` in the MCP tool before proceeding.
+
+## Adding an x402 payment-gated endpoint
+
+Register the route under `x402_router` (not `api_router`). See `server/src/api/routes/hello_mangrove.py` for the canonical pattern.
+
+## Testing
+
+Tests live in `server/tests/` and mirror the `src/` layout. CI (`.github/workflows/ci.yml`) runs ruff + pytest on every PR — that's the authoritative invocation.
+
+Test runs set `MASTER_KEY_PATH` to a test-scoped path; the resulting `agent-data-test/` directory is gitignored.
+
+## Git workflow
+
+See `.claude/rules/git-workflow.md`. Feature branch off `main`, one concern per PR, CI must pass.


### PR DESCRIPTION
## Summary

- **Stage 0 is now a platform tour, not a wallet prompt.** Workshop attendees see the product work (`status` → `list_tools` → `get_market_data` → `kb_search` → `search_reference_strategies`) before being asked to commit a key. Paper trading is reachable with zero on-chain exposure. Wallet + security primer moved to new Stage 4.5, gating live promotion only.
- **CLAUDE.md rewritten for the actual audience** (trading-bot users). Persona contradiction resolved, "general FastAPI template" framing dropped, new *Getting the Code* (template vs fork) and *Raising Issues and PRs* (with upstream repo pointers) sections, health port corrected to 9080.
- **Extension guide relocated** from CLAUDE.md to `docs/contributing.md` — CLAUDE.md is loaded on every turn, and the Adding Endpoints content isn't user-facing.
- **Pytest scratch artifact gitignored** (`**/agent-data-test/`).
- **branding.json** updated with Sage / tims-black-box identity.

## Files

| File | Change |
|------|--------|
| `.claude/rules/trading-bot-workflow.md` | Stage 0 rewritten (platform tour), new Stage 4.5 (wallet before live) |
| `CLAUDE.md` | Full rewrite — see summary above |
| `docs/contributing.md` | NEW — scaffold extension guide (moved from CLAUDE.md) |
| `.gitignore` | Add `**/agent-data-test/` |
| `branding.json` | Persona rename |

## Test plan

- [ ] Open Claude Code in a fresh clone on this branch → confirm Stage 0 runs the 5-beat platform tour (not a wallet prompt).
- [ ] `create_wallet` / `execute_swap` / live promotion paths still gated on the security primer + backup confirmation (verify Stage 4.5 fires at the right moment).
- [ ] `pytest` from `server/` → confirm `server/agent-data-test/` is created and ignored by git.
- [ ] CLAUDE.md health-check URL resolves against the running bot (`http://localhost:9080/health`).
- [ ] Upstream repo links in *Raising Issues and PRs* all resolve.
- [ ] No conflict with the in-flight workshop worktree (`feature/workshop-content`) — after merge, that branch rebases cleanly with the tone pass on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)