### PR TITLE
Rename secret_id to vault_token + fix build_from_reference payload

### DIFF
--- a/.claude/hooks/block-wallet-secrets.sh
+++ b/.claude/hooks/block-wallet-secrets.sh
@@ -104,8 +104,8 @@ If this was you pasting a key, use the out-of-band flow instead:
   2. Run:  ./scripts/stash-secret.sh
   3. The script prompts for your key with input hidden (no echo).
      It stashes the key in an in-process vault on the agent and
-     prints a short secret_id.
-  4. Come back to this chat and tell me:  "import wallet secret_id <ID>"
+     prints a short vault_token.
+  4. Come back to this chat and tell me:  "import wallet vault_token <ID>"
      I'll call the import_wallet MCP tool with that id — the plaintext
      never touches this conversation.
 
@@ -113,7 +113,7 @@ To create a fresh wallet, just ask me to — no key needs to be typed.
 
 If this was a tool response that matched the pattern (defense-in-depth
 trip), inspect the tool's code and make sure it's not returning
-plaintext key material. Tool responses should carry a secret_id only;
+plaintext key material. Tool responses should carry a vault_token only;
 the plaintext should go through the SecretVault + reveal-secret.sh CLI.
 
 If this was a false positive (not a real key/mnemonic), rephrase to

--- a/.claude/rules/trading-bot-workflow.md
+++ b/.claude/rules/trading-bot-workflow.md
@@ -145,8 +145,8 @@ This is the moment the security primer lands — *right before* there's a key in
 Tell the user, in order:
 
 1. **Your keys stay on this machine.** The master key is in `./agent-data/master.key` (chmod 600) or your OS keychain — never sent anywhere.
-2. **Wallet secrets never enter this chat.** When you create a wallet, I return a `secret_id`. You run `./scripts/reveal-secret.sh <id>` in a terminal to back it up. The plaintext never touches Claude Code's transcript or Anthropic's API.
-3. **Imports work the same way in reverse.** To import an existing wallet, run `./scripts/stash-secret.sh` in a terminal first — it prompts with hidden input and gives you a secret_id to pass to me.
+2. **Wallet secrets never enter this chat.** When you create a wallet, I return a `vault_token`. You run `./scripts/reveal-secret.sh <id>` in a terminal to back it up. The plaintext never touches Claude Code's transcript or Anthropic's API.
+3. **Imports work the same way in reverse.** To import an existing wallet, run `./scripts/stash-secret.sh` in a terminal first — it prompts with hidden input and gives you a vault_token to pass to me.
 4. **Live trading is gated on backup confirmation.** After you save the secret, run `./scripts/confirm-backup.sh <address>` to unlock `execute_swap` and `live` strategy promotion for that wallet. Paper mode is unrestricted and wallet-free.
 5. **Paper first, always.** New strategies promote to `paper` (simulated fills). Only after you've reviewed evaluations do they go `live` with a real allocation.
 6. **Hooks block key pastes.** If you accidentally paste a key or mnemonic into chat, a hook will intercept and refuse — this is intentional, not a bug.
@@ -168,9 +168,9 @@ Branch on their answer:
 > ./scripts/stash-secret.sh
 > ```
 >
-> It'll prompt for your private key with input hidden and print a short `secret_id`. Come back here and tell me to import that id."
+> It'll prompt for your private key with input hidden and print a short `vault_token`. Come back here and tell me to import that id."
 
-Wait for the secret_id. Call `import_wallet(secret_id=...)`. Report per `wallet-presentation.md`.
+Wait for the vault_token. Call `import_wallet(vault_token=...)`. Report per `wallet-presentation.md`.
 
 **B — Create new:**
 Call `create_wallet()` with the defaults (`evm`, `mainnet`, `8453`, no label unless specified). Report per `wallet-presentation.md`, including the `reveal_cmd` as the backup step.
@@ -245,7 +245,7 @@ In that case: `get_swap_quote` → user confirm → `execute_swap`. The execute_
 
 - Never default to `get_swap_quote` / `execute_swap` without first attempting the strategy-driven flow.
 - Never call `update_strategy_status` to `live` without explicit user confirmation AND an allocation block AND `backup_confirmed_at` on the wallet.
-- Never accept a raw private key or mnemonic as an argument to any tool. `import_wallet` takes `secret_id` only.
+- Never accept a raw private key or mnemonic as an argument to any tool. `import_wallet` takes `vault_token` only.
 - Never ask the user to paste a private key into chat.
 - Never claim a signal is "firing" based on the signal-catalog listing alone; firing requires an actual `evaluate_strategy` call against current OHLCV.
 - Never recommend a strategy without showing backtest metrics from a real `backtest_strategy` or `create_strategy_autonomous` run.

--- a/.claude/rules/wallet-presentation.md
+++ b/.claude/rules/wallet-presentation.md
@@ -6,8 +6,8 @@ These rules govern how the agent presents wallet operations. They apply to `crea
 
 After the phase-2 security rework, wallet secrets flow **out-of-band**. They never enter MCP tool responses, so they never enter Claude Code's conversation context.
 
-- `create_wallet` returns a `secret_id` (opaque, TTL-bound, single-read). The user runs `./scripts/reveal-secret.sh <secret_id>` in a terminal to see the plaintext.
-- `import_wallet` accepts a `secret_id` (obtained by the user running `./scripts/stash-secret.sh` first). It never accepts a raw key as an argument.
+- `create_wallet` returns a `vault_token` (opaque, TTL-bound, single-read). The user runs `./scripts/reveal-secret.sh <vault_token>` in a terminal to see the plaintext.
+- `import_wallet` accepts a `vault_token` (obtained by the user running `./scripts/stash-secret.sh` first). It never accepts a raw key as an argument.
 - Reveal-on-demand for existing wallets is via `./scripts/reveal-secret.sh --address <addr>`, also out-of-band.
 
 **If a user pastes a private key or mnemonic into chat**, `.claude/hooks/block-wallet-secrets.sh` will intercept and refuse the prompt. The hook returns a message directing them to `stash-secret.sh`. Do not try to work around this.
@@ -28,9 +28,9 @@ If the user asks for an alternative, proceed with the default but mention:
 
 ### NEVER
 
-- **Never** echo `secret_id` or any wallet secret in prose more than the one time you present the tool's response.
+- **Never** echo `vault_token` or any wallet secret in prose more than the one time you present the tool's response.
 - **Never** ask the user to paste a private key. If they want to import an existing wallet, direct them to `./scripts/stash-secret.sh`.
-- **Never** quote, screenshot, or "save" the secret_id after the user has run `reveal-secret.sh` — the vault entry is consumed on reveal; the id is useless afterward.
+- **Never** quote, screenshot, or "save" the vault_token after the user has run `reveal-secret.sh` — the vault entry is consumed on reveal; the id is useless afterward.
 
 ### ALWAYS
 
@@ -80,7 +80,7 @@ Where `{PLAIN_ENGLISH_MASTER_KEY_SOURCE}` maps from the tool's `master_key_sourc
 
 ## Presenting `import_wallet` output
 
-Only call `import_wallet` with a `secret_id` the user obtained from `stash-secret.sh`. If they paste a raw key, DO NOT CALL the tool with the key — the hook will block upstream, but also refuse semantically.
+Only call `import_wallet` with a `vault_token` the user obtained from `stash-secret.sh`. If they paste a raw key, DO NOT CALL the tool with the key — the hook will block upstream, but also refuse semantically.
 
 ### Template for `import_wallet`
 
@@ -93,7 +93,7 @@ Address:
 Block explorer: https://basescan.org/address/{ADDRESS}
 
 Your secret is already backed up (you just typed it into stash-secret.sh —
-that's what gave you the secret_id). The agent auto-confirmed the backup,
+that's what gave you the vault_token). The agent auto-confirmed the backup,
 so live trading is already unlocked for this wallet.
 
 Run get_balances to verify it's the wallet you expected.
@@ -115,7 +115,7 @@ integrated terminal works — Cmd+` / Ctrl+`) and run:
   ./scripts/stash-secret.sh
 
 It prompts for the key with input hidden (no echo) and prints a short
-secret_id. Come back here, tell me "import wallet secret_id <ID>", and
+vault_token. Come back here, tell me "import wallet vault_token <ID>", and
 I'll call the import_wallet tool with that id. Your key will never
 touch this conversation.
 ```

--- a/README.md
+++ b/README.md
@@ -99,10 +99,10 @@ Start Claude Code in the repo directory. The agent auto-runs its first-run greet
 
 ### If you want a fresh wallet
 
-Just say "create a new wallet." The agent calls `create_wallet` with sane defaults (Base mainnet). The response carries a `secret_id` — NOT the plaintext key. The agent will tell you to run the backup command in your VSCode terminal:
+Just say "create a new wallet." The agent calls `create_wallet` with sane defaults (Base mainnet). The response carries a `vault_token` — NOT the plaintext key. The agent will tell you to run the backup command in your VSCode terminal:
 
 ```bash
-./scripts/reveal-secret.sh <secret_id>
+./scripts/reveal-secret.sh <vault_token>
 ```
 
 That prints your private key to **the terminal only** (never into the chat). Save it in a password manager / hardware wallet / paper, then tell the agent you've backed it up. The agent will run:
@@ -121,7 +121,7 @@ The agent will tell you to open your terminal and run:
 ./scripts/stash-secret.sh
 ```
 
-It prompts for your key with input hidden (no echo) and prints a short `secret_id`. Come back to Claude Code and say "import wallet secret_id X" — the agent calls `import_wallet` with that id. Your key never passes through the chat, the transcript, or Anthropic's API.
+It prompts for your key with input hidden (no echo) and prints a short `vault_token`. Come back to Claude Code and say "import wallet vault_token X" — the agent calls `import_wallet` with that id. Your key never passes through the chat, the transcript, or Anthropic's API.
 
 ### From there
 
@@ -139,7 +139,7 @@ Requires `backup_confirmed_at` on the wallet — the agent will refuse otherwise
 
 ## Safety model at a glance
 
-- **Your private keys never touch this chat.** `create_wallet` returns a `secret_id`, not the plaintext. Revealing is a separate CLI (`reveal-secret.sh`) that prints to your terminal only.
+- **Your private keys never touch this chat.** `create_wallet` returns a `vault_token`, not the plaintext. Revealing is a separate CLI (`reveal-secret.sh`) that prints to your terminal only.
 - **Harness hooks block key pastes.** If you try to paste a key into Claude Code, `.claude/hooks/block-wallet-secrets.sh` refuses the prompt with an educational message. The hook is in `.claude/settings.json` — disabling it requires a commit.
 - **Live trading is gated on explicit backup confirmation.** After you save a wallet's secret off-agent, `./scripts/confirm-backup.sh <addr>` flips a flag. `execute_swap` and `update_strategy_status → live` refuse on wallets without it.
 - **Master key stays local.** Bare-metal: OS keychain. Docker: `./agent-data/master.key` (chmod 600, gitignored).

--- a/docs/strategy-lifecycle.md
+++ b/docs/strategy-lifecycle.md
@@ -189,8 +189,8 @@ Live adds three guarantees over paper:
 | Review | agent uses `threshold_spec` values from `server/src/services/data/threshold_spec.json` |
 | Promote paper | `update_strategy_status(status="paper")` |
 | Watch paper | `list_evaluations`, `list_trades` |
-| Create wallet | `create_wallet` (secret returned via `secret_id` → `reveal-secret.sh`) |
-| Import wallet | `./scripts/stash-secret.sh` → `import_wallet(secret_id)` |
+| Create wallet | `create_wallet` (secret returned via `vault_token` → `reveal-secret.sh`) |
+| Import wallet | `./scripts/stash-secret.sh` → `import_wallet(vault_token)` |
 | Back up wallet | `./scripts/reveal-secret.sh --address <addr>` + `./scripts/confirm-backup.sh <addr>` — BOTH OUTSIDE MCP ON PURPOSE, keys never enter the transcript |
 | Fund wallet | user sends USDC to the address — external |
 | Go live | `update_strategy_status(status="live", confirm=true, allocation={...})` |

--- a/docs/verification-checklist.md
+++ b/docs/verification-checklist.md
@@ -212,13 +212,13 @@ is sufficient for "does the bot work?"
 
 **Expect:**
 - Agent calls `create_wallet(chain="evm", network="mainnet", chain_id=8453)`
-- Response carries `address`, `secret_id`, `reveal_cmd`, `master_key_source`
+- Response carries `address`, `vault_token`, `reveal_cmd`, `master_key_source`
 - Agent surfaces the address + block explorer link + the `reveal_cmd`
 - **Agent does NOT echo the secret** (rule in `wallet-presentation.md`)
 
 **Verify:** In your terminal:
 ```bash
-./scripts/reveal-secret.sh <secret_id>
+./scripts/reveal-secret.sh <vault_token>
 ```
 The plaintext key appears ONCE in your terminal. Back it up anywhere
 you want (password manager, paper).
@@ -350,7 +350,7 @@ rm agent-data/agent.db
 - [ ] 2.1 Paper promotion registers cron
 - [ ] 2.2 Manual evaluate_strategy fires + logs
 - [ ] 2.3 Scheduler persists across restart
-- [ ] 3.1 create_wallet returns secret_id (no plaintext in chat)
+- [ ] 3.1 create_wallet returns vault_token (no plaintext in chat)
 - [ ] 3.2 confirm-backup.sh flips the flag
 - [ ] 3.3 Backup gate refuses unconfirmed live promotion
 - [ ] 4.1 Wallet receives USDC (external)

--- a/scripts/reveal-secret.sh
+++ b/scripts/reveal-secret.sh
@@ -2,10 +2,10 @@
 # reveal-secret.sh — retrieve a wallet's plaintext secret OUT-OF-BAND.
 #
 # Two modes:
-#   1. By secret_id (freshly-created wallets):
-#        ./scripts/reveal-secret.sh <secret_id>
+#   1. By vault_token (freshly-created wallets):
+#        ./scripts/reveal-secret.sh <vault_token>
 #      Consumes the vault entry (single-read, TTL-bound). Use this right
-#      after `create_wallet` returns a secret_id.
+#      after `create_wallet` returns a vault_token.
 #
 #   2. By address (already-stored wallets):
 #        ./scripts/reveal-secret.sh --address <wallet-address>
@@ -15,7 +15,7 @@
 #
 # The secret is printed to THIS terminal only. It does not pass through
 # Claude Code or get logged anywhere beyond structured event logs
-# (which record only the address / secret_id, not the plaintext).
+# (which record only the address / vault_token, not the plaintext).
 #
 # After you copy it into a password manager / hardware wallet / paper,
 # clear your terminal scrollback if you care. The agent keeps no record
@@ -36,7 +36,7 @@ fail() { printf "${RED}  ✗${CLR} %s\n" "$1" >&2; exit 1; }
 usage() {
   cat >&2 <<EOF
 Usage:
-  $0 <secret_id>                  # reveal a stashed secret (single-read)
+  $0 <vault_token>                  # reveal a stashed secret (single-read)
   $0 --address <wallet-address>   # reveal an already-stored wallet secret
 EOF
   exit 2

--- a/scripts/stash-secret.sh
+++ b/scripts/stash-secret.sh
@@ -7,7 +7,7 @@
 #   2. It prompts for the key via `read -s` — no echo to the terminal.
 #   3. It POSTs the key to the agent's localhost REST endpoint.
 #   4. The agent stashes the key in an in-process vault (TTL ~300s,
-#      single-read) and returns an opaque `secret_id`.
+#      single-read) and returns an opaque `vault_token`.
 #   5. You tell the agent (in Claude Code) to import that id.
 #      The agent calls the `import_wallet` MCP tool, which consumes the
 #      id and stores the wallet.
@@ -101,17 +101,17 @@ PY
 SECRET=""
 unset SECRET
 
-SECRET_ID="$(printf '%s' "$RESPONSE" | python3 -c "import json, sys; print(json.loads(sys.stdin.read())['secret_id'])")"
+VAULT_TOKEN="$(printf '%s' "$RESPONSE" | python3 -c "import json, sys; print(json.loads(sys.stdin.read())['vault_token'])")"
 TTL="$(printf '%s' "$RESPONSE" | python3 -c "import json, sys; print(json.loads(sys.stdin.read())['secret_ttl_seconds'])")"
 
 ok "stashed"
-info "secret_id: $SECRET_ID"
+info "vault_token: $VAULT_TOKEN"
 info "expires in: ${TTL}s (single-read)"
 
 echo
 printf "${GREEN}Next:${CLR} in Claude Code, say:\n\n"
-echo "    Import my wallet with secret_id $SECRET_ID"
+echo "    Import my wallet with vault_token $VAULT_TOKEN"
 echo
-echo "The agent will call import_wallet(secret_id=$SECRET_ID). Your key"
+echo "The agent will call import_wallet(vault_token=$VAULT_TOKEN). Your key"
 echo "never enters the conversation or the transcript."
 echo

--- a/server/src/api/routes/wallet.py
+++ b/server/src/api/routes/wallet.py
@@ -1,13 +1,13 @@
 """Wallet routes — auth-gated.
 
 - POST /api/v1/agent/wallet/create
-      Create + encrypt a wallet. Response carries secret_id (no plaintext).
+      Create + encrypt a wallet. Response carries vault_token (no plaintext).
 - POST /api/v1/agent/wallet/import
-      Import an existing wallet by secret_id (from a prior stash).
+      Import an existing wallet by vault_token (from a prior stash).
 - POST /api/v1/agent/wallet/stash-secret
       Accept a raw plaintext secret from the localhost CLI (not MCP).
-      Returns secret_id. Called by scripts/stash-secret.sh.
-- GET  /api/v1/agent/wallet/reveal-secret/{secret_id}
+      Returns vault_token. Called by scripts/stash-secret.sh.
+- GET  /api/v1/agent/wallet/reveal-secret/{vault_token}
       Reveal + consume a stashed secret. Called by scripts/reveal-secret.sh.
 - GET  /api/v1/agent/wallet/{address}/reveal
       Reveal-on-demand: decrypt a stored wallet's secret. Called by
@@ -65,7 +65,7 @@ class WalletCreateRequest(BaseModel):
 
 
 class WalletImportRequest(BaseModel):
-    secret_id: str = Field(..., description="From POST /wallet/stash-secret")
+    vault_token: str = Field(..., description="From POST /wallet/stash-secret")
     chain: str = "evm"
     network: str = "mainnet"
     chain_id: int | None = 8453
@@ -92,7 +92,7 @@ class ConfirmBackupResponse(BaseModel):
     summary="Create a new wallet (secret stashed, not returned)",
     description=(
         "Creates + encrypts a wallet locally. Response carries only a "
-        "secret_id pointing at the in-process vault — run the reveal_cmd "
+        "vault_token pointing at the in-process vault — run the reveal_cmd "
         "out-of-band to back up the plaintext. The MCP transport never "
         "sees the key."
     ),
@@ -110,7 +110,7 @@ async def wallet_create(req: WalletCreateRequest) -> WalletCreateResponse:
 @router.post(
     "/import",
     response_model=WalletImportResponse,
-    summary="Import an existing wallet by secret_id",
+    summary="Import an existing wallet by vault_token",
     description=(
         "Expects the secret to already be in the vault via a prior call to "
         "POST /wallet/stash-secret. This endpoint consumes the vault entry, "
@@ -120,7 +120,7 @@ async def wallet_create(req: WalletCreateRequest) -> WalletCreateResponse:
 )
 async def wallet_import(req: WalletImportRequest) -> WalletImportResponse:
     return import_wallet(
-        secret_id=req.secret_id,
+        vault_token=req.vault_token,
         chain=req.chain,
         network=req.network,
         chain_id=req.chain_id,
@@ -144,13 +144,13 @@ async def wallet_stash_secret(req: StashSecretRequest) -> StashSecretResponse:
     from src.config import app_config
     sid = stash_external_secret(req.secret, address_hint=req.address_hint)
     return StashSecretResponse(
-        secret_id=sid,
+        vault_token=sid,
         secret_ttl_seconds=int(getattr(app_config, "SECRET_VAULT_TTL_SECONDS", 300)),
     )
 
 
 @router.get(
-    "/reveal-secret/{secret_id}",
+    "/reveal-secret/{vault_token}",
     response_model=RevealSecretResponse,
     summary="Reveal + consume a stashed secret (single-read)",
     description=(
@@ -159,12 +159,12 @@ async def wallet_stash_secret(req: StashSecretRequest) -> StashSecretResponse:
         "called from an MCP tool."
     ),
 )
-async def wallet_reveal_secret(secret_id: str) -> RevealSecretResponse:
+async def wallet_reveal_secret(vault_token: str) -> RevealSecretResponse:
     try:
-        secret = vault.reveal(secret_id)
+        secret = vault.reveal(vault_token)
     except KeyError as e:
         raise SigningError(
-            "secret_id unknown or expired.",
+            "vault_token unknown or expired.",
             suggestion="Re-create or re-stash the secret to get a fresh id.",
         ) from e
     return RevealSecretResponse(secret=secret, address=None)

--- a/server/src/mcp/tools.py
+++ b/server/src/mcp/tools.py
@@ -141,7 +141,7 @@ def _register_wallet(server: FastMCP) -> None:
 
         The plaintext secret is NEVER returned in this response — it would
         land in the Claude Code transcript and get sent to Anthropic. Instead
-        the response carries a `secret_id` referencing an in-process vault.
+        the response carries a `vault_token` referencing an in-process vault.
         Tell the user to run the `reveal_cmd` in a terminal to back up the
         secret. The id is TTL-bound (default 300s) and single-read.
         EVM only in v1. Base mainnet (chain_id 8453) is the default.
@@ -158,7 +158,7 @@ def _register_wallet(server: FastMCP) -> None:
     register_tool(ToolEntry(
         name="create_wallet",
         description=(
-            "Create + encrypt a wallet. Response carries only secret_id + "
+            "Create + encrypt a wallet. Response carries only vault_token + "
             "reveal_cmd — plaintext never enters the Claude Code transcript. "
             "EVM only in v1."
         ),
@@ -174,7 +174,7 @@ def _register_wallet(server: FastMCP) -> None:
 
     @server.tool()
     async def import_wallet(
-        secret_id: str,
+        vault_token: str,
         chain: str = "evm", network: str = "mainnet",
         chain_id: int | None = 8453, label: str | None = None,
         api_key: str = "",
@@ -183,7 +183,7 @@ def _register_wallet(server: FastMCP) -> None:
 
         The user's flow: run `./scripts/stash-secret.sh` in a terminal (it
         prompts for the private key via `read -s` so it isn't echoed, posts
-        to /internal/stash-secret, prints the returned secret_id). Then
+        to /internal/stash-secret, prints the returned vault_token). Then
         tell the agent to import that id. The private key NEVER enters
         Claude Code's conversation context — this tool only handles the id.
 
@@ -197,7 +197,7 @@ def _register_wallet(server: FastMCP) -> None:
         try:
             from src.services.wallet_manager import import_wallet as svc
             result = svc(
-                secret_id=secret_id,
+                vault_token=vault_token,
                 chain=chain, network=network,
                 chain_id=chain_id, label=label,
             )
@@ -208,13 +208,13 @@ def _register_wallet(server: FastMCP) -> None:
     register_tool(ToolEntry(
         name="import_wallet",
         description=(
-            "Import an existing wallet from a stashed secret_id. The user "
+            "Import an existing wallet from a stashed vault_token. The user "
             "must obtain the id by running scripts/stash-secret.sh in a "
             "terminal FIRST — this tool refuses raw keys by design."
         ),
         access="auth",
         parameters=[
-            ToolParam(name="secret_id", type="string", required=True, description="From scripts/stash-secret.sh output"),
+            ToolParam(name="vault_token", type="string", required=True, description="From scripts/stash-secret.sh output"),
             ToolParam(name="chain", type="string", required=False, description="evm (default)"),
             ToolParam(name="network", type="string", required=False, description="mainnet (default) | testnet"),
             ToolParam(name="chain_id", type="integer", required=False, description="Default 8453 (Base mainnet)"),

--- a/server/src/services/reference_strategies_service.py
+++ b/server/src/services/reference_strategies_service.py
@@ -27,6 +27,7 @@ from src.shared.logging import get_logger
 _log = get_logger(__name__)
 
 _DATA_PATH = Path(__file__).parent / "data" / "reference_strategies.json"
+_DEFAULTS_PATH = Path(__file__).parent / "data" / "trading_defaults.json"
 
 
 class ReferenceSignal(BaseModel):
@@ -47,6 +48,34 @@ class ReferenceStrategy(BaseModel):
     execution_config: dict[str, Any]
     source: str
     notes: str = ""
+
+
+@lru_cache(maxsize=1)
+def _load_execution_defaults() -> dict[str, Any]:
+    """Flat execution_config defaults, merged from every group in trading_defaults.json.
+
+    Reference strategies in the seed JSON store only per-strategy *overrides*
+    (e.g. max_risk_per_trade=0.008). The upstream SDK's strategies.create
+    endpoint requires a full flat execution_config including fields like
+    initial_balance, reward_factor, atr_period, etc. This loader produces
+    that flat dict once per process.
+
+    Mechanism note: before this existed, build_from_reference returned only
+    the reference's override dict, and downstream create_strategy_manual
+    hit a 500 on the missing initial_balance key. The reference data is
+    intentionally sparse — the merge responsibility lives here.
+    """
+    if not _DEFAULTS_PATH.is_file():
+        _log.warning("trading_defaults.missing", path=str(_DEFAULTS_PATH))
+        return {}
+    raw = json.loads(_DEFAULTS_PATH.read_text())
+    flat: dict[str, Any] = {}
+    for key, group in raw.items():
+        if key == "description":
+            continue
+        if isinstance(group, dict):
+            flat.update(group)
+    return flat
 
 
 @lru_cache(maxsize=1)
@@ -184,12 +213,18 @@ def build_from_reference(
     entry = [_to_rule(s) for s in ref.entry_signals]
     exit_rules = [_to_rule(s) for s in ref.exit_signals]
 
+    # Flatten trading_defaults.json, then let the reference's overrides win.
+    # Keeps the reference data sparse (overrides only) while producing a
+    # payload the SDK will accept without extra patching by the caller.
+    exec_cfg = dict(_load_execution_defaults())
+    exec_cfg.update(dict(ref.execution_config))
+
     return {
         "name": name or f"{ref.label} [from {ref.id}]",
         "asset": ref.asset,
         "timeframe": tf,
         "entry": entry,
         "exit": exit_rules,
-        "execution_config": dict(ref.execution_config),
+        "execution_config": exec_cfg,
         "source_reference_id": ref.id,
     }

--- a/server/src/services/secret_vault.py
+++ b/server/src/services/secret_vault.py
@@ -9,14 +9,14 @@ Why this exists:
     leaks to both transport and disk.
 
     SecretVault breaks that coupling: on wallet creation or import, the
-    agent stashes the plaintext in memory keyed by a random `secret_id` and
+    agent stashes the plaintext in memory keyed by a random `vault_token` and
     the MCP response carries ONLY the id. The user retrieves the plaintext
     out-of-band via a local bash/curl script that hits the localhost REST
     API — this subprocess never touches Claude's conversation context.
 
 Semantics:
-    - `stash(secret) -> secret_id`: store plaintext, return opaque id.
-    - `reveal(secret_id) -> secret`: return AND immediately evict. Single-read.
+    - `stash(secret) -> vault_token`: store plaintext, return opaque id.
+    - `reveal(vault_token) -> secret`: return AND immediately evict. Single-read.
     - TTL-bound: entries expire after `SECRET_VAULT_TTL_SECONDS` regardless
       of read. Sweep runs lazily on every stash/reveal + via a background
       task (started by the FastAPI lifespan hook).
@@ -92,10 +92,10 @@ class _Vault:
                 expires_at=now + _ttl(),
                 address=address,
             )
-        _log.info("secret_vault.stashed", secret_id=sid[:8] + "...", has_address=address is not None)
+        _log.info("secret_vault.stashed", vault_token=sid[:8] + "...", has_address=address is not None)
         return sid
 
-    def reveal(self, secret_id: str) -> str:
+    def reveal(self, vault_token: str) -> str:
         """Return the secret and evict the entry (single-read).
 
         Raises KeyError if the id is unknown or expired.
@@ -103,10 +103,10 @@ class _Vault:
         now = time.monotonic()
         with self._lock:
             self._sweep_locked(now)
-            entry = self._entries.pop(secret_id, None)
+            entry = self._entries.pop(vault_token, None)
         if entry is None:
-            raise KeyError(f"secret_id unknown or expired: {secret_id[:8]}...")
-        _log.info("secret_vault.revealed", secret_id=secret_id[:8] + "...")
+            raise KeyError(f"vault_token unknown or expired: {vault_token[:8]}...")
+        _log.info("secret_vault.revealed", vault_token=vault_token[:8] + "...")
         return entry.secret
 
     def stash_for_address(self, secret: str, address: str) -> str:

--- a/server/src/services/wallet_manager.py
+++ b/server/src/services/wallet_manager.py
@@ -3,12 +3,12 @@
 Responsibilities:
 - Create wallets via mangrovemarkets.wallet.create(). Encrypt the returned
   seed/private_key with Fernet, persist the ciphertext in SQLite. Stash
-  the plaintext in the in-process SecretVault and return only a secret_id
+  the plaintext in the in-process SecretVault and return only a vault_token
   in the MCP response — the plaintext never enters the Claude Code
   conversation context.
 - Import externally-generated private keys via the stash-and-consume
   pattern: user's bash CLI posts the raw key to /internal/stash-secret
-  and gets back a secret_id, then calls import_wallet with that id.
+  and gets back a vault_token, then calls import_wallet with that id.
 - List stored wallets (addresses + metadata only; never returns secrets).
 - Sign arbitrary EVM transactions locally. The SDK never sees the key.
 - Gate live trading on explicit user backup confirmation (backup_confirmed_at).
@@ -16,7 +16,7 @@ Responsibilities:
 
 Security:
 - The plaintext key NEVER appears in an MCP tool response. Responses carry
-  only the opaque secret_id, which is useful only via the localhost reveal
+  only the opaque vault_token, which is useful only via the localhost reveal
   CLI (out-of-band, never through Claude Code).
 - sign() decrypts into a local bytes variable, derives the signing account,
   signs, discards the variable. Plaintext lifetime is <10ms per op.
@@ -62,7 +62,7 @@ SecretType = Literal["private_key", "mnemonic"]
 class WalletCreateResponse(BaseModel):
     """Response for POST /wallet/create.
 
-    The plaintext secret is NEVER included. The caller receives a secret_id
+    The plaintext secret is NEVER included. The caller receives a vault_token
     pointing at an in-process vault entry (TTL-bound, single-read) and a
     reveal_cmd describing how to retrieve the plaintext out-of-band.
     """
@@ -73,7 +73,7 @@ class WalletCreateResponse(BaseModel):
     chain_id: int | None = None
     label: str | None = None
     created_at: datetime
-    secret_id: str
+    vault_token: str
     secret_type: SecretType
     master_key_source: str
     reveal_cmd: str
@@ -100,7 +100,7 @@ class WalletImportResponse(BaseModel):
 class StashSecretResponse(BaseModel):
     """Response for POST /internal/stash-secret. Opaque id only."""
 
-    secret_id: str
+    vault_token: str
     secret_ttl_seconds: int
 
 
@@ -207,8 +207,8 @@ def _secret_vault_ttl() -> int:
         return 300
 
 
-def _reveal_cmd_for(secret_id: str) -> str:
-    return f"./scripts/reveal-secret.sh {secret_id}"
+def _reveal_cmd_for(vault_token: str) -> str:
+    return f"./scripts/reveal-secret.sh {vault_token}"
 
 
 def _reveal_cmd_for_address(address: str) -> str:
@@ -216,7 +216,7 @@ def _reveal_cmd_for_address(address: str) -> str:
 
 
 # ---------------------------------------------------------------------------
-# Create wallet (secret stays in-process, MCP response has secret_id only)
+# Create wallet (secret stays in-process, MCP response has vault_token only)
 # ---------------------------------------------------------------------------
 
 
@@ -227,7 +227,7 @@ def create_wallet(
     label: str | None = None,
 ) -> WalletCreateResponse:
     """Create a new wallet. Encrypts the secret, persists to SQLite, stashes
-    plaintext in the in-process vault, returns a secret_id.
+    plaintext in the in-process vault, returns a vault_token.
     """
     chain_normalized = chain.lower()
     if chain_normalized in {"xrpl", "xrp"}:
@@ -275,7 +275,7 @@ def create_wallet(
     conn.commit()
 
     # Stash plaintext in vault. `secret` is not returned to the caller.
-    secret_id = vault.stash_for_address(secret, address=address)
+    vault_token = vault.stash_for_address(secret, address=address)
 
     _log.info(
         "wallet.created",
@@ -294,10 +294,10 @@ def create_wallet(
         chain_id=chain_id,
         label=label,
         created_at=created_at,
-        secret_id=secret_id,
+        vault_token=vault_token,
         secret_type=secret_type,
         master_key_source=get_master_key_source(),
-        reveal_cmd=_reveal_cmd_for(secret_id),
+        reveal_cmd=_reveal_cmd_for(vault_token),
         secret_ttl_seconds=_secret_vault_ttl(),
         backup_required=True,
         deposit_instructions=_deposit_instructions(address, chain_normalized, network),
@@ -306,12 +306,12 @@ def create_wallet(
 
 
 # ---------------------------------------------------------------------------
-# Import wallet (secret provided via stash_secret, consumed by secret_id)
+# Import wallet (secret provided via stash_secret, consumed by vault_token)
 # ---------------------------------------------------------------------------
 
 
 def import_wallet(
-    secret_id: str,
+    vault_token: str,
     chain: str = "evm",
     network: str = "mainnet",
     chain_id: int | None = 8453,
@@ -323,7 +323,7 @@ def import_wallet(
       1. Run `./scripts/stash-secret.sh` — it prompts for the private key via
          `read -s`, POSTs to /internal/stash-secret, prints the returned id.
       2. Ask the agent to import that id.
-      3. Agent calls import_wallet(secret_id=<id>).
+      3. Agent calls import_wallet(vault_token=<id>).
 
     The private key never enters Claude Code's conversation context.
     """
@@ -335,13 +335,13 @@ def import_wallet(
         )
 
     try:
-        secret = vault.reveal(secret_id)
+        secret = vault.reveal(vault_token)
     except KeyError as e:
         raise SigningError(
-            "secret_id is unknown or has expired.",
+            "vault_token is unknown or has expired.",
             suggestion=(
                 "Re-run `./scripts/stash-secret.sh` to stash your key and get a "
-                "fresh secret_id, then retry the import. Each secret_id is "
+                "fresh vault_token, then retry the import. Each vault_token is "
                 "single-read and TTL-bound."
             ),
         ) from e

--- a/server/tests/integration/test_wallet_routes.py
+++ b/server/tests/integration/test_wallet_routes.py
@@ -91,9 +91,9 @@ def test_create_wallet_happy_path(client):
     assert "seed_phrase" not in body
     assert "private_key" not in body
     assert _TEST_PRIVKEY not in r.text
-    # The response carries a secret_id that the CLI consumes via
+    # The response carries a vault_token that the CLI consumes via
     # /wallet/reveal-secret/{id}. Plaintext flows out-of-band, never via MCP.
-    assert body["secret_id"]
+    assert body["vault_token"]
     assert body["reveal_cmd"].startswith("./scripts/reveal-secret.sh ")
     assert body["backup_required"] is True
     assert body["secret_type"] in {"private_key", "mnemonic"}
@@ -109,15 +109,15 @@ def test_stash_then_import_flow(client):
         json={"secret": _TEST_PRIVKEY},
     )
     assert stash.status_code == 200
-    secret_id = stash.json()["secret_id"]
-    assert secret_id
+    vault_token = stash.json()["vault_token"]
+    assert vault_token
 
-    # Step 2: agent-equivalent — import_wallet with the secret_id.
+    # Step 2: agent-equivalent — import_wallet with the vault_token.
     imp = client.post(
         "/api/v1/agent/wallet/import",
         headers=_auth(),
         json={
-            "secret_id": secret_id,
+            "vault_token": vault_token,
             "chain": "evm",
             "network": "testnet",
             "chain_id": 84532,
@@ -131,13 +131,13 @@ def test_stash_then_import_flow(client):
 
 
 def test_reveal_secret_is_single_read(client):
-    # Create a wallet to get a valid secret_id.
+    # Create a wallet to get a valid vault_token.
     r = client.post(
         "/api/v1/agent/wallet/create",
         headers=_auth(),
         json={"chain": "evm", "network": "testnet", "chain_id": 84532},
     )
-    sid = r.json()["secret_id"]
+    sid = r.json()["vault_token"]
 
     # First reveal: 200 + plaintext.
     r1 = client.get(f"/api/v1/agent/wallet/reveal-secret/{sid}", headers=_auth())

--- a/server/tests/unit/test_reference_strategies_service.py
+++ b/server/tests/unit/test_reference_strategies_service.py
@@ -140,6 +140,38 @@ class TestBuildFromReference:
         assert isinstance(payload["entry"], list)
         assert isinstance(payload["exit"], list)
 
+    def test_execution_config_includes_initial_balance(self):
+        """Regression: build_from_reference must produce a complete execution_config.
+
+        The reference JSON only stores per-strategy *overrides* (e.g.
+        max_risk_per_trade=0.008). The SDK's strategies.create endpoint
+        requires a full flat execution_config including initial_balance;
+        previously build_from_reference returned only the overrides and the
+        downstream create_strategy_manual call 500'd on the missing key.
+        """
+        ref = svc.list_all()[0]
+        payload = svc.build_from_reference(reference_id=ref.id)
+        exec_cfg = payload["execution_config"]
+        assert "initial_balance" in exec_cfg, (
+            "execution_config must carry initial_balance from trading_defaults.json"
+        )
+        assert exec_cfg["initial_balance"] > 0
+
+    def test_execution_config_merges_trading_defaults_under_reference_overrides(self):
+        """Reference overrides must win over trading_defaults.json; the rest fills from defaults."""
+        # ref-009 in the seed has max_risk_per_trade=0.008 (an override below the 0.01 default).
+        # After the merge, that override must be preserved.
+        ref = svc.get("ref-009")
+        if ref is None:
+            pytest.skip("ref-009 not present in seed")
+        payload = svc.build_from_reference(reference_id=ref.id)
+        exec_cfg = payload["execution_config"]
+        # Reference override wins:
+        assert exec_cfg["max_risk_per_trade"] == 0.008
+        # Default fills in missing fields:
+        assert exec_cfg.get("reward_factor") is not None
+        assert exec_cfg.get("atr_period") is not None
+
 
 class TestCategoryDetection:
     @pytest.mark.parametrize(

--- a/server/tests/unit/test_wallet_manager.py
+++ b/server/tests/unit/test_wallet_manager.py
@@ -118,8 +118,8 @@ def test_create_wallet_evm_persists_encrypted(temp_db, stub_keyring, mock_sdk_cr
 
     response = create_wallet(chain="evm", network="testnet", chain_id=84532, label="test")
     assert response.address == _TEST_ADDRESS
-    # The plaintext is NOT in the response — only a secret_id pointing at the vault.
-    assert response.secret_id and len(response.secret_id) >= 16
+    # The plaintext is NOT in the response — only a vault_token pointing at the vault.
+    assert response.vault_token and len(response.vault_token) >= 16
     assert response.secret_type == "private_key"
     assert response.master_key_source in {"keyfile", "keychain", "generated_keyfile"}
     assert response.reveal_cmd.startswith("./scripts/reveal-secret.sh ")
@@ -133,7 +133,7 @@ def test_create_wallet_evm_persists_encrypted(temp_db, stub_keyring, mock_sdk_cr
     assert "small test amount" in response.deposit_instructions.lower()
 
     # The vault must have the plaintext (so reveal-secret.sh can retrieve it).
-    plaintext = vault.reveal(response.secret_id)
+    plaintext = vault.reveal(response.vault_token)
     assert plaintext == _TEST_PRIVKEY
 
     row = get_connection().execute(
@@ -359,7 +359,7 @@ def test_stash_external_secret_then_import(temp_db, stub_keyring):
     sid = stash_external_secret(_TEST_PRIVKEY)
     assert sid
 
-    response = import_wallet(secret_id=sid, chain="evm", network="testnet", chain_id=84532)
+    response = import_wallet(vault_token=sid, chain="evm", network="testnet", chain_id=84532)
     assert response.address == _TEST_ADDRESS
     # Imported wallets auto-confirm backup (user typed the key into the CLI,
     # so they have it off-agent by definition).
@@ -372,12 +372,12 @@ def test_stash_external_secret_then_import(temp_db, stub_keyring):
     assert row["backup_confirmed_at"] is not None
 
 
-def test_import_wallet_expired_secret_id_raises(temp_db, stub_keyring):
+def test_import_wallet_expired_vault_token_raises(temp_db, stub_keyring):
     from src.services.wallet_manager import import_wallet
     from src.shared.errors import SigningError
 
     with pytest.raises(SigningError, match="unknown or has expired"):
-        import_wallet(secret_id="bogus-id-that-was-never-stashed")
+        import_wallet(vault_token="bogus-id-that-was-never-stashed")
 
 
 def test_reveal_wallet_secret_roundtrip(temp_db, stub_keyring, mock_sdk_create):


### PR DESCRIPTION
Bundles two workshop-blocking fixes flagged during dry-run.

## Summary

### 1. Rename `secret_id` → `vault_token`

The old name repeatedly confused users mid-flow: *secret* is the word we train them to flag as dangerous (the hooks block it, the security primer warns against it), but the field is actually a reference token — TTL-bound, single-read, meaningless on its own. Calling it `secret_id` made the safe handle look like the forbidden thing.

`vault_token` signals "reference, not secret" using industry-standard terminology (HashiCorp Vault, AWS Secrets Manager, Kubernetes). Breaking API change, acceptable pre-launch.

**Scope:** Pydantic request/response models, MCP tool signatures, REST route handlers, `scripts/stash-secret.sh` + `reveal-secret.sh`, wallet-presentation + trading-bot-workflow rules, hook messages, README, docs, tests.

**NOT renamed** (intentionally): `secret_id` in `server/src/config.py` + `server/src/shared/gcp_secret_utils.py`. Those are GCP Secret Manager's native API parameter, unrelated to the wallet vault.

### 2. Fix `build_from_reference` payload missing `initial_balance`

Reference JSON seed stores only per-strategy *overrides* (e.g. `max_risk_per_trade=0.008` on `ref-009`), but the SDK's `strategies.create` endpoint requires a complete flat `execution_config`. Previously `build_from_reference` returned only the overrides and `create_strategy_manual` 500'd on the missing `initial_balance` — forcing agents to patch the payload and break the `/create-strategy` skill's "don't modify execution_config" Phase B rule.

**Mechanism:** the reference data is intentionally sparse; the flatten-and-merge responsibility belongs at `build_from_reference`, not at the caller or upstream. Added `_load_execution_defaults()` helper that flattens `trading_defaults.json` and merges the reference's `execution_config` over it (reference overrides win).

Two regression tests added:
- `test_execution_config_includes_initial_balance` — payload carries the default
- `test_execution_config_merges_trading_defaults_under_reference_overrides` — ref-009's `max_risk_per_trade=0.008` override wins over the 0.01 default; missing fields fill from defaults

## Files

| Change | File count |
|---|---|
| Wallet rename (Python + rules + scripts + docs + tests) | 14 |
| `build_from_reference` fix + tests | 2 |

Full stat: `16 files changed, 163 insertions(+), 96 deletions(-)`.

## Test plan

- [x] `pytest server/tests/` — 330 passed, 2 skipped (opt-in live swaps). Ran locally in the worktree.
- [x] `ruff check server/src/` — clean.
- [ ] On merge: CI green.
- [ ] Smoke test from a fresh Claude Code session: `create_wallet` returns `vault_token` (not `secret_id`), `import_wallet` accepts it, and `build_from_reference` → `create_strategy_manual` chain succeeds without the agent patching `initial_balance` manually.
- [ ] Verify `stash-secret.sh` + `reveal-secret.sh` still work end-to-end against the new JSON field names.

## Out of scope (still blocked)

The MangroveOracle `/api/v1/backtest` endpoint 500s observed during the dry-run are still an upstream issue — not fixable in this repo. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)