### PR TITLE
feat(strategies): 132-entry reference library + portable bulk-backtest flow

### DIFF
--- a/.claude/rules/trading-bot-workflow.md
+++ b/.claude/rules/trading-bot-workflow.md
@@ -111,9 +111,15 @@ Then ask:
 Detailed authoring flow (reference-first, KB-grounded, autonomous fallback) lives in the **`/create-strategy` skill**. Load and follow that — it covers:
 
 - **Phase A** — `search_reference_strategies` first (always)
-- **Phase B** — `build_strategy_from_reference` when a reference matches (signals + params copied exactly)
+- **Phase B-bulk** — when 2+ references match, build all onto the user's (asset, timeframe) and bulk-backtest; rank by performance, not by label
+- **Phase B** — single build when exactly one reference matches
 - **Phase C** — custom build with required `kb_search` citation per signal (no library-default params)
 - **Phase D** — `create_strategy_autonomous` only when the user says "pick for me"
+
+Two invariants for Stage 2:
+
+1. **Reference strategies are portable.** The asset and timeframe on a reference record are provenance, not constraints. `build_strategy_from_reference` accepts `asset` + `timeframe` overrides — retarget freely and let the backtest decide.
+2. **Bulk-backtest beats label-pick.** When multiple references match, always build + backtest all of them before presenting a winner. Don't ask the user to pick a reference from names and descriptions; picking by label is a KB-grounding regression.
 
 Never default to Phase D as the first move.
 

--- a/.claude/rules/trading-bot-workflow.md
+++ b/.claude/rules/trading-bot-workflow.md
@@ -125,13 +125,14 @@ Never default to Phase D as the first move.
 
 ## Stage 3 — Review backtest
 
-Detailed review flow (thresholds, PASS/FAIL decision rule, no-fabrication rule) lives in the `/create-strategy` skill's **Phase F**. Load and follow that.
+Detailed flow lives in the **`/backtest` skill**. Load and follow that — it covers window sizing (bar-count-driven, not months-per-timeframe), the threshold verdict, the benchmark-relative line, and failure-mode advice.
 
 High-level summary for orientation:
-- Present the winning strategy + 1–2 runners-up with signal names, KB citations, and metrics
-- Verdict against 6 thresholds from `server/src/services/data/threshold_spec.json` (sortino ≥ 1.5, sharpe ≥ 1.2, calmar ≥ 1.0, irr ≥ 0.15, max_drawdown ≤ 0.7, win_rate ≥ 0.25)
+- Window is picked from a bar-count target (~2000–5000 bars), not a fixed month table — keeps ratio metrics meaningful without bleeding across regimes
+- Verdict against 6 thresholds from `server/src/services/data/threshold_spec.json` (sortino ≥ 1.5, sharpe ≥ 1.2, calmar ≥ 1.0, irr ≥ 0.15, max_drawdown ≤ 0.7, win_rate ≥ 0.25), plus a benchmark-relative line (beat buy-and-hold? beat BTC?)
 - Never invent missing metrics — if `total_trades == 0`, report as INSUFFICIENT_TRADES
-- Ask: "Promote to paper, iterate the goal, or reject?"
+- Every non-PASS ships with failure-mode advice (which threshold failed → what to try)
+- Ask: "Promote to paper, iterate via /backtest, or reject?"
 
 ## Stage 4 — Paper
 

--- a/.claude/skills/backtest/SKILL.md
+++ b/.claude/skills/backtest/SKILL.md
@@ -1,0 +1,230 @@
+---
+name: backtest
+description: >-
+  Use when the user wants to backtest an existing strategy — "run a backtest
+  on X", "how would this have done", "verify this strategy", or after
+  /create-strategy produces a draft that needs evaluation. Sizes the
+  window from a target bar count (not a fixed month table), caps against
+  data availability, reports a verdict against `threshold_spec.json`
+  plus benchmark deltas, and recommends the next action (promote,
+  iterate, reject). Wraps `backtest_strategy` + `get_market_data` +
+  optionally `list_ohlcv_coverage` (when available) for the SDK
+  consumer — no manual date math.
+---
+
+# Backtest Skill
+
+This skill exists because **picking the backtest window well is more
+important than picking the strategy**. A strategy that looks great over
+the last 30 days of a grinding uptrend tells you nothing about how it
+behaves when the market turns. A window that's too short produces <10
+trades and makes every ratio meaningless. A window that's too long
+bleeds across regime changes and flatters overfit strategies.
+
+The `/create-strategy` skill hands off here after Phase B-bulk (or
+earlier, for single-candidate builds). Users can also invoke `/backtest`
+directly on any existing `strategy_id`.
+
+## Trigger
+
+Activate when the user:
+
+- Explicitly asks to backtest ("run a backtest on ref-004 with ETH 1h",
+  "how would this have done over the last year", "test this")
+- Has just promoted a draft from `/create-strategy` and needs a verdict
+- Asks to re-evaluate a paper or live strategy on a new window
+- Asks "is this strategy any good"
+
+Do NOT activate for:
+
+- Promotion decisions → `/promote-strategy`
+- Live monitoring / evaluations → `/monitor-trades`
+- Authoring new strategies → `/create-strategy`
+
+## Phase A — Collect
+
+Required inputs:
+
+1. **strategy_id** — UUID from `list_strategies` or a `create_strategy_manual` response. If the user says "the one I just made" and there's only one draft, infer it. Otherwise call `list_strategies(status="draft")` and present choices.
+
+Optional overrides (skill proposes defaults in Phase B — don't ask the user for these cold):
+
+- **lookback window** — days, hours, or explicit start/end dates. If user volunteers one, respect it.
+- **slippage_pct** / **fee_pct** — override `trading_defaults.json`. Only touch if the user mentions they want realistic frictions tuned.
+
+Pull the strategy's asset + timeframe via `get_strategy(strategy_id)` so the window sizing can reason about bar counts.
+
+## Phase B — Size the window
+
+**Target bar count: 2000–5000.** That's the range where ratio metrics
+stabilize (enough for 20–100 trades) without the window spanning so much
+history that regime drift dominates. Translate to wall-clock via the
+timeframe:
+
+| Timeframe | Bars/day | Target window (bars ÷ bars/day) |
+|-----------|----------|-----|
+| 5m | 288 | **7–17 days** (default: 14d) |
+| 15m | 96 | **20–50 days** (default: 30d) |
+| 30m | 48 | **40–100 days** (default: 60d) |
+| 1h | 24 | **3–7 months** (default: 6mo) |
+| 4h | 6 | **12–30 months** (default: 18mo) |
+| 1d | 1 | **5–14 years** (default: 5y, capped by provider history) |
+
+The table is the default. Override reasons:
+
+- **Data availability caps.** If the asset launched 8 months ago, a 5y
+  daily window silently truncates. Before committing, sanity-check via
+  `get_market_data(asset, interval, limit=1, end_date=<proposed_start>)`
+  — if the response shows no bars before the proposed start, shrink the
+  window to match actual coverage.
+- **User asked for a specific window.** Respect it, but if their window
+  produces <500 bars, warn once: "That window gives ~N bars — ratio
+  metrics are unreliable below ~1000. Want me to widen to {default}
+  instead?" Then proceed with their pick if they decline.
+- **Regime check.** If the window is entirely one direction (pure
+  uptrend or pure downtrend against the benchmark), flag it in the
+  Phase D verdict — the strategy wasn't stress-tested. Don't auto-widen;
+  let the user decide.
+
+Tell the user the resolved window before running: "Backtesting on
+`{asset}` `{timeframe}` from `{start}` to `{end}` — ~{bar_count} bars."
+
+## Phase C — Run
+
+Call `backtest_strategy(strategy_id, mode="full", start_date=..., end_date=...)`. Mode is always `"full"` for this skill (quick mode is for the bulk-candidate flow in `/create-strategy` Phase B-bulk).
+
+Set expectations on latency:
+
+- 5m × 14d (~4000 bars): a few seconds
+- 1h × 6mo (~4400 bars): a few seconds
+- 1d × 5y (~1800 bars): a few seconds
+- Anything >10000 bars: disclose "this may take up to ~30s" before the call
+
+If the SDK returns an error, surface the exact message. Don't retry silently — a failed backtest usually means bad data coverage or a strategy config issue, both of which the user needs to see.
+
+## Phase D — Verdict
+
+### Threshold gate
+
+Evaluate against the 6 thresholds in `server/src/services/data/threshold_spec.json`:
+
+| Metric | Threshold | Direction |
+|---|---|---|
+| `sortino_ratio` | ≥ 1.5 | higher is better |
+| `sharpe_ratio` | ≥ 1.2 | higher is better |
+| `calmar_ratio` | ≥ 1.0 | higher is better |
+| `irr_annualized` | ≥ 0.15 | higher is better |
+| `max_drawdown` | ≤ 0.7 | lower is better |
+| `win_rate` | ≥ 0.25 | higher is better |
+
+Decision rule:
+- **PASS** — all 6 pass
+- **MARGINAL** — 4–5 of 6 pass
+- **FAIL** — ≤3 of 6 pass
+- **INSUFFICIENT_TRADES** — `total_trades < 10`, regardless of ratios. Not a PASS, not a FAIL. Ratios with <10 trades are statistical noise.
+
+### Benchmark-relative line
+
+Every verdict includes a second-class line: **did the strategy beat
+buy-and-hold?** Oracle stores `benchmark_asset_return`,
+`benchmark_btc_return`, `benchmark_sp500_return` per result row for
+exactly this question. Compute:
+
+- `strategy_return - benchmark_asset_return` (same asset, same window)
+- `strategy_return - benchmark_btc_return` (crypto-market proxy)
+
+A PASS that loses to buy-and-hold is **still a useful strategy** (lower
+drawdown, less correlation) but the user must see that tradeoff. A FAIL
+that loses to buy-and-hold is a clear-cut reject.
+
+### Failure-mode advice
+
+Never stop at "FAIL." Always pair the verdict with what to try:
+
+- **Failed on `total_trades` (INSUFFICIENT_TRADES)** → widen the window,
+  loosen entry filters, or reconsider the timeframe (maybe 1h is too
+  slow for a momentum strategy on this asset).
+- **Failed on `sharpe_ratio` / `sortino_ratio`** → the strategy is
+  taking risk disproportionate to reward. Try tightening the exit
+  (earlier take-profit), lowering `max_risk_per_trade`, or reviewing
+  whether the entry signal is firing in noise.
+- **Failed on `calmar_ratio` / `max_drawdown`** → one or two losing
+  streaks dominated. Try a volatility filter (only trade when ATR is
+  below percentile X), or cap `max_open_positions` lower.
+- **Failed on `irr_annualized`** → the strategy is boring, not broken.
+  Often shows up with tight stops and conservative sizing. Widen
+  `reward_factor` or pick a higher-volatility asset.
+- **Failed on `win_rate`** → entries are firing too early or in
+  counter-trend. Add a trend-filter FILTER signal to the entry group
+  (e.g., `is_above_sma` or `adx_strong_trend`).
+
+### Presenting the verdict
+
+1. Verdict label (PASS / MARGINAL / FAIL / INSUFFICIENT_TRADES) in one line
+2. Per-threshold table: metric | actual | threshold | ✓/✗
+3. Benchmark line: "Strategy return: X%. Buy-and-hold on {asset}: Y%. vs BTC: Z%."
+4. Next-step recommendation, chosen from the failure-mode advice above based on which thresholds failed.
+5. For PASS: "Promote to paper (unrestricted) or live (requires allocation + backup confirmation). Which?"
+
+## Phase E — Iterate
+
+The user reviews the verdict and picks one of:
+
+- **Accept** → hand off to `/promote-strategy` (skill boundary; don't promote from here)
+- **Alt window** → re-run Phase B–D with a different window. Common
+  asks: "try YTD", "try last 3 months only", "try the 2023 drawdown".
+  Resolve the window, confirm bar count, re-run.
+- **Walk-forward** → for a MARGINAL or borderline PASS, offer a
+  walk-forward check: split the window into 3 consecutive sub-windows,
+  backtest on each, report per-sub-window metrics. If performance holds
+  across all three, the strategy is more likely to generalize. If it
+  falls off a cliff on one, that's the regime it doesn't handle.
+- **Alt reference** → user wants to try a different reference from the
+  same Phase A search in `/create-strategy`. Reinvoke `/create-strategy`
+  at Phase B-bulk with the shortlist.
+- **Reject** → archive the strategy via
+  `update_strategy_status(strategy_id, status="archived")` so it stops
+  showing up in `list_strategies(status="draft")`. Don't delete — the
+  record is useful for the user to remember what they tried.
+
+## Prohibited
+
+- **Never** invent metrics. If `metrics` is missing or null fields, say
+  so verbatim: "The SDK response is missing `sharpe_ratio` — I can't
+  verdict against the threshold. This usually means too few trades or
+  the data provider returned insufficient history."
+- **Never** declare PASS with `total_trades < 10`. INSUFFICIENT_TRADES,
+  full stop.
+- **Never** pick a window based on "feel." Every window choice either
+  follows the bar-count table or is user-specified.
+- **Never** hide a buy-and-hold loss. If the strategy underperforms the
+  asset's buy-and-hold, say so in the verdict — even for PASSes.
+- **Never** promote from inside this skill. `/promote-strategy` owns
+  that transition.
+
+## Summary — Decision Tree
+
+```
+User wants to backtest
+│
+├─ Phase A: collect strategy_id (+ optional overrides)
+│
+├─ Phase B: size window from bar-count table
+│     → sanity-check provider coverage
+│     → warn if <500 bars or regime-homogeneous
+│     → disclose resolved window to user
+│
+├─ Phase C: backtest_strategy(mode="full", resolved window)
+│     → disclose latency up front
+│     → surface SDK errors verbatim
+│
+├─ Phase D: verdict
+│     → PASS / MARGINAL / FAIL / INSUFFICIENT_TRADES
+│     → threshold table + benchmark-relative line
+│     → failure-mode advice paired with every non-PASS
+│
+└─ Phase E: iterate
+      → accept (hand off to /promote-strategy)
+      → alt window / walk-forward / alt reference
+      → reject (archive)
+```

--- a/.claude/skills/create-strategy/SKILL.md
+++ b/.claude/skills/create-strategy/SKILL.md
@@ -170,56 +170,26 @@ Autonomous is the "I don't care, you decide" escape hatch. It's NOT the primary 
 
 Under no circumstances go straight to Phase D as the first move. Always try Phase A first.
 
-## Phase E — Backtest
+## Phase E — Hand off to /backtest
 
-Regardless of which phase built the strategy, hand off to backtesting immediately:
+Regardless of which phase built the strategy, hand off to the
+**`/backtest` skill** for the backtest + verdict + iteration flow. That
+skill owns window sizing (bar-count-driven, not months-per-timeframe),
+the threshold verdict, the benchmark-relative line, and failure-mode
+advice.
 
-```
-backtest_strategy(strategy_id, mode="full")
-```
+For Phase B-bulk: the bulk-backtest loop inside this skill still runs
+`backtest_strategy` per candidate with a shared window (so the ranked
+table is comparable). Size that shared window via the same bar-count
+table `/backtest` uses (2000–5000 bars target). Once the winner is
+picked, the user can invoke `/backtest` on the winner alone for deeper
+investigation (walk-forward, alternative windows).
 
-Omit `lookback_*` and date fields unless the user asked for a specific window — `backtest_service` picks a timeframe-aware default via `recommended_lookback_months(timeframe)`: 3 months for 5m/15m/30m/1h, 6 months for 4h, 12 months for 1d.
-
-Overrides go through the single `config` dict (matches `trading_defaults.json` keys). Example:
-```
-backtest_strategy(strategy_id, mode="full", lookback_hours=24, config={"slippage_pct": 0.002})
-```
-
-## Phase F — Review (PASS/FAIL against threshold_spec)
-
-Evaluate the backtest against 6 fixed thresholds from `server/src/services/data/threshold_spec.json` (copied verbatim from MangroveAI — `git diff` vs upstream is the drift check):
-
-| Metric | Threshold | Direction |
-|---|---|---|
-| `sortino_ratio` | ≥ 1.5 | higher is better |
-| `sharpe_ratio` | ≥ 1.2 | higher is better |
-| `calmar_ratio` | ≥ 1.0 | higher is better |
-| `irr_annualized` | ≥ 0.15 | higher is better |
-| `max_drawdown` | ≤ 0.7 | lower is better |
-| `win_rate` | ≥ 0.25 | higher is better |
-
-**Decision rule:**
-- **PASS** iff ALL six thresholds satisfied
-- **MARGINAL** if 4-5 of 6 satisfied (worth iterating; not ready for live)
-- **FAIL** if ≤ 3 of 6 satisfied (redesign or reject)
-
-### Present the verdict
-
-Always show the user:
-1. The verdict (PASS / MARGINAL / FAIL)
-2. Per-threshold breakdown — actual value vs threshold, ✓ or ✗ per row
-3. Next-step recommendation based on verdict:
-   - **PASS** → "Promote to paper (unrestricted) or live (requires allocation + backup confirmation). Which?"
-   - **MARGINAL** → "Iterate: widen backtest window, tweak params, or try a different reference. Want me to rerun with {specific change}?"
-   - **FAIL** → "This won't work as-is. Options: pick a different reference, change the goal, or accept it's not a viable strategy right now."
-
-### Never fabricate metrics
-
-If the `metrics` dict is missing, empty, or any field is null, **say so explicitly** — do not invent values. Quote the exact SDK response:
-
-> "The backtest response is missing `sharpe_ratio` — I can't verdict against the threshold. This usually means the SDK couldn't compute it (too few trades, or the data provider returned insufficient history). Options: rerun with a longer window, or check `resolved_window` in the response to confirm the window the server actually used."
-
-Likewise: if `total_trades == 0`, every ratio metric is meaningless (division by zero or undefined). Report it as **INSUFFICIENT_TRADES** — not PASS, not FAIL. Suggest widening the window or loosening signal filters.
+Do not duplicate the threshold table or verdict rules here — they live
+in `/backtest`. If this skill detects a PASS, tell the user the result
+and let them invoke `/promote-strategy` directly; if it detects a FAIL
+or MARGINAL, suggest `/backtest` for the iteration path rather than
+iterating in-place.
 
 ## Prohibited
 
@@ -260,7 +230,6 @@ User wants a strategy
 └─ Phase D: create_strategy_autonomous(goal, asset, timeframe)
         (server generates + backtests N candidates, returns winner)
 
-→ backtest_strategy (timeframe-aware default window)
-→ /review-backtest skill (PASS/FAIL verdict)
+→ /backtest skill (window sizing, verdict, iteration)
 → /promote-strategy skill (draft → paper → live)
 ```

--- a/.claude/skills/create-strategy/SKILL.md
+++ b/.claude/skills/create-strategy/SKILL.md
@@ -21,13 +21,34 @@ backed by evidence**, not library defaults.
 Two mechanisms drive "intuition":
 
 - **Mechanism 2 (reference strategies) — the primary path.** Curated
-  known-good configs. The agent searches these FIRST, presents matches
-  to the user, and materializes the chosen one exactly. Zero parameter
-  guessing for the common case.
+  known-good configs. The agent searches these FIRST, bulk-backtests
+  the top matches onto the user's target, and promotes by ranked
+  performance. Zero parameter guessing for the common case.
 - **Mechanism 1 (KB-grounded parameters) — the fallback.** When
   references don't fit (unusual asset, unusual goal, or user wants to
   modify), the agent is REQUIRED to call `kb_search` for every signal
   it picks before finalizing params. No library-default fallback.
+
+### Portability — reference strategies are signal combos, not pins
+
+Every reference in the library is a **portable signal combination**: the
+asset and timeframe on the reference record are where Oracle *found*
+the combo worked, not a constraint on where you can apply it.
+`build_strategy_from_reference` accepts both `asset` and `timeframe`
+overrides for exactly this reason. If the user asks for a strategy on
+AVAX 1h and search returns references recorded on BTC 1h + SOL 5m,
+both are valid candidates — retarget them onto (AVAX, 1h) and let the
+backtest pick the winner. Never quote the reference's own stored
+metrics to the user as if they apply to the retarget.
+
+### Bulk-backtest is the default
+
+When Phase A returns multiple plausible matches (the common case),
+**do not ask the user to pick by label or description** — build all of
+them onto the user's (asset, timeframe), backtest each, and rank by
+actual performance. Picking by label is a KB-grounding regression; the
+whole point of the library is measured outcomes. Ask the user to choose
+only when the backtests tie, or to pick between equivalent PASSes.
 
 A third mechanism (mined parameter priors from the 1.4M-strategy DB)
 will land via MangroveAI endpoint after MangroveOracle issue #156. This
@@ -63,29 +84,54 @@ Example FAST ADVANCE triggers:
 
 Call `search_reference_strategies(asset, timeframe, goal_hint)`. You will get back up to 5 ranked candidates, each with:
 
-- `id` (e.g. `ref-004`)
+- `id` (e.g. `ref-004` or `oracle-exp_…-<run_index>`)
 - `label` (human-readable)
-- `description` (why this works)
+- `description` (why this works / source lineage)
 - `entry_signals` + `exit_signals` (names, types, params)
 - `category`
-- `notes` (tuning hints)
+- `notes` (tuning hints — may be empty for Oracle-sourced entries)
 
-Present the top 2-3 to the user, ranked. For each: show the label, the signal names (not param values — too noisy), the category, and one sentence from `description`. Ask: "Want to use one of these, or should I design something custom?"
+If search returns 2+ plausible candidates, **do not ask the user to pick by label** — move straight to Phase B-bulk. If search returns exactly one, proceed to Phase B. If it returns 0 results or only low-score matches, jump to **Phase C (Custom build, KB-grounded)**.
 
-If `search_reference_strategies` returns 0 results or only low-score matches: jump to **Phase C (Custom build, KB-grounded)**.
+Note: the library spans assets and timeframes beyond just the user's target — Oracle-sourced entries have lineage tied to the experiment where the combo was found, but the combo itself is portable. Treat the returned set as candidates regardless of their recorded asset/TF.
 
-## Phase B — Build from Reference (PREFERRED)
+## Phase B — Build from Reference (single match)
 
-User picks a reference (by id or label). Call `build_strategy_from_reference(reference_id, timeframe=<user's>, name=<optional>)`.
+Only when Phase A returned exactly one candidate. Call `build_strategy_from_reference(reference_id, asset=<user's>, timeframe=<user's>, name=<optional>)`.
 
 You get back a `create_strategy_manual`-compatible payload. Pass it directly to `create_strategy_manual(...)` — DO NOT modify `entry`, `exit`, or `execution_config`. The whole point of Mechanism 2 is that these values came from strategies that already backtested well.
 
 Only adjustable fields:
 
-- `timeframe` override (already handled by build_strategy_from_reference)
+- `asset` override (retarget the combo onto the user's asset)
+- `timeframe` override (retarget onto the user's TF)
 - `name` (cosmetic)
 
 If the user wants to TWEAK the reference (e.g. "but use RSI(9) not RSI(14)"): acknowledge their change, then move to Phase C's KB-citation discipline BEFORE applying the tweak. Don't change params without citation.
+
+## Phase B-bulk — Build + backtest the top N references (common case)
+
+When Phase A returns multiple candidates, bulk-build and bulk-backtest. This is the default path because picking by label means picking by description — and descriptions don't predict backtest performance.
+
+```
+for ref in references[:N]:        # N ~= 3-5
+    payload = build_strategy_from_reference(
+        reference_id=ref.id,
+        asset=<user's asset>,     # retarget every ref onto the user's target
+        timeframe=<user's TF>,    # same
+    )
+    strategy = create_strategy_manual(**payload)
+    backtest_strategy(strategy.id, mode="full")
+```
+
+Then rank the results by the Phase F thresholds (sortino, sharpe, calmar, irr, max_drawdown, win_rate). Present the ranked table to the user:
+
+- Winner (PASS) + 1–2 runners-up with per-threshold verdicts
+- The loser(s) shown briefly so the user sees that the top one earned its spot, not picked blindly
+
+Ask: "Promote the winner to paper, iterate on the runners-up, or start over with a different goal?" Do NOT auto-promote — the transition is the user's call.
+
+If every backtest fails (all FAIL against threshold_spec), that's a signal the combos in the library don't fit this (asset, TF, goal). Move to Phase C or Phase D rather than promoting a losing config.
 
 ## Phase C — Custom Build (KB-GROUNDED, Mechanism 1)
 
@@ -196,12 +242,17 @@ User wants a strategy
 │
 ├─→ Phase A: search_reference_strategies(asset, timeframe, goal_hint)
 │       │
-│       ├─ ≥1 good match → present to user → pick → Phase B
-│       ├─ 0 good matches → Phase C
+│       ├─ ≥2 candidates → Phase B-bulk (build all, backtest all, rank)
+│       ├─ 1 candidate   → Phase B (single build + backtest)
+│       ├─ 0 candidates  → Phase C
 │       └─ user says "just pick" → Phase D (autonomous)
 │
+├─ Phase B-bulk: loop build_strategy_from_reference → create_strategy_manual
+│       → backtest_strategy for each; retarget every ref onto the user's
+│       (asset, timeframe); rank by threshold_spec; present ranked table
+│
 ├─ Phase B: build_strategy_from_reference + create_strategy_manual
-│       (signals + params copied exactly, timeframe applied)
+│       (single match; signals + params copied exactly, asset/tf applied)
 │
 ├─ Phase C: kb_search each signal → cite → create_strategy_manual
 │       (custom, evidence-backed)

--- a/server/src/api/routes/reference_strategies.py
+++ b/server/src/api/routes/reference_strategies.py
@@ -82,6 +82,7 @@ async def get_reference(reference_id: str) -> dict[str, Any]:
 
 class BuildFromReferenceRequest(BaseModel):
     timeframe: str | None = None  # Defaults to the reference's own timeframe.
+    asset: str | None = None  # Retarget onto a different asset; defaults to the reference's own.
     name: str | None = None  # Optional override; auto-labelled if omitted.
 
 
@@ -89,10 +90,12 @@ class BuildFromReferenceRequest(BaseModel):
     "/{reference_id}/build",
     summary="Materialize a create-strategy-manual payload from a reference",
     description=(
-        "Copies the reference's signals exactly, only rewriting each "
-        "signal's `timeframe` if overridden. Returns a payload the caller "
-        "can POST to /strategies/manual as-is. The agent uses this after "
-        "presenting reference candidates and letting the user pick one."
+        "Copies the reference's signals exactly. `timeframe` and `asset` "
+        "are free-to-override — a reference strategy is a portable signal "
+        "combo, not a pin to the source asset/timeframe. Returns a payload "
+        "the caller can POST to /strategies/manual as-is, or bulk-backtest "
+        "by calling build N times across candidate references and routing "
+        "each result through /backtest."
     ),
 )
 async def build_from_reference(
@@ -103,6 +106,7 @@ async def build_from_reference(
         return reference_strategies_service.build_from_reference(
             reference_id=reference_id,
             timeframe_override=req.timeframe,
+            asset_override=req.asset,
             name=req.name,
         )
     except ValueError as e:

--- a/server/src/mcp/tools.py
+++ b/server/src/mcp/tools.py
@@ -1677,15 +1677,17 @@ def _register_strategy(server: FastMCP) -> None:
     async def build_strategy_from_reference(
         reference_id: str,
         timeframe: str | None = None,
+        asset: str | None = None,
         name: str | None = None,
         api_key: str = "",
     ) -> str:
         """Materialize a reference into a create_strategy_manual payload.
 
-        Called after search_reference_strategies + user pick. Copies the
-        reference's signals EXACTLY (parameters untouched) and only
-        rewrites each signal's timeframe if overridden. Returns a payload
-        the caller passes straight to create_strategy_manual.
+        Copies the reference's signals EXACTLY (names and params untouched).
+        `timeframe` and `asset` are free-to-override — reference strategies
+        are portable signal combos, not pins to a specific asset/TF. Bulk
+        pattern: loop over the top N references from search, build each
+        onto the user's target (asset, timeframe), backtest all, rank.
         """
         if not _require(api_key):
             return _auth_error()
@@ -1694,6 +1696,7 @@ def _register_strategy(server: FastMCP) -> None:
             payload = reference_strategies_service.build_from_reference(
                 reference_id=reference_id,
                 timeframe_override=timeframe,
+                asset_override=asset,
                 name=name,
             )
         except ValueError as e:
@@ -1703,15 +1706,18 @@ def _register_strategy(server: FastMCP) -> None:
     register_tool(ToolEntry(
         name="build_strategy_from_reference",
         description=(
-            "After search_reference_strategies returns candidates and the "
-            "user picks one, call this to produce a create_strategy_manual "
-            "payload. Signals and params are copied exactly — the agent "
-            "must NOT modify them. Only timeframe and name can be overridden."
+            "After search_reference_strategies returns candidates, call this "
+            "to produce a create_strategy_manual payload. Signals and params "
+            "are copied exactly — the agent must NOT modify them. `timeframe` "
+            "and `asset` are free overrides: a reference is a portable combo, "
+            "so retarget onto the user's asset/TF and bulk-backtest the top "
+            "matches rather than single-pick by label."
         ),
         access="auth",
         parameters=[
             ToolParam(name="reference_id", type="string", required=True, description="e.g. ref-001 — from search_reference_strategies"),
             ToolParam(name="timeframe", type="string", required=False, description="Override the reference's timeframe (canonicalized)"),
+            ToolParam(name="asset", type="string", required=False, description="Retarget onto a different asset — reference strategies are portable"),
             ToolParam(name="name", type="string", required=False, description="Optional strategy name override"),
             _APIKEY,
         ],

--- a/server/src/services/data/reference_strategies.json
+++ b/server/src/services/data/reference_strategies.json
@@ -4,214 +4,9567 @@
   "strategies": [
     {
       "id": "ref-001",
-      "label": "ETH momentum — MACD bullish cross on 1h",
+      "label": "ETH momentum \u2014 MACD bullish cross on 1h",
       "asset": "ETH",
       "timeframe": "1h",
       "category": "momentum",
       "description": "Enters on a MACD bullish cross, exits on bearish cross. MACD(12,26,9) is the canonical setup; proven on crypto 1h for catching multi-hour momentum legs without chasing single-bar noise.",
       "entry_signals": [
-        { "name": "macd_bullish_cross", "signal_type": "TRIGGER", "params": { "window_fast": 12, "window_slow": 26, "window_sign": 9 } }
+        {
+          "name": "macd_bullish_cross",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 12,
+            "window_slow": 26,
+            "window_sign": 9
+          }
+        }
       ],
       "exit_signals": [
-        { "name": "macd_bearish_cross", "signal_type": "TRIGGER", "params": { "window_fast": 12, "window_slow": 26, "window_sign": 9 } }
+        {
+          "name": "macd_bearish_cross",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 12,
+            "window_slow": 26,
+            "window_sign": 9
+          }
+        }
       ],
-      "execution_config": { "max_risk_per_trade": 0.01, "max_open_positions": 3 },
+      "execution_config": {
+        "max_risk_per_trade": 0.01,
+        "max_open_positions": 3
+      },
       "source": "curated/MangroveAI ref",
       "notes": "Starter config. Backtest before going live; MACD params can be tuned tighter on 1h crypto (e.g. 8,21,5) for more trades."
     },
     {
       "id": "ref-002",
-      "label": "BTC trend-follow — SMA crossover 20/50 on 1h",
+      "label": "BTC trend-follow \u2014 SMA crossover 20/50 on 1h",
       "asset": "BTC",
       "timeframe": "1h",
       "category": "trend_following",
       "description": "Classic SMA crossover: fast crosses above slow = long, cross down = exit. 20/50 on 1h captures swing trends without the whipsaw of faster periods on crypto noise.",
       "entry_signals": [
-        { "name": "sma_cross_up", "signal_type": "TRIGGER", "params": { "window_fast": 20, "window_slow": 50 } }
+        {
+          "name": "sma_cross_up",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 20,
+            "window_slow": 50
+          }
+        }
       ],
       "exit_signals": [
-        { "name": "sma_cross_down", "signal_type": "TRIGGER", "params": { "window_fast": 20, "window_slow": 50 } }
+        {
+          "name": "sma_cross_down",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 20,
+            "window_slow": 50
+          }
+        }
       ],
-      "execution_config": { "max_risk_per_trade": 0.015, "max_open_positions": 2 },
+      "execution_config": {
+        "max_risk_per_trade": 0.015,
+        "max_open_positions": 2
+      },
       "source": "curated",
-      "notes": "Tune window_fast up (→30) and window_slow up (→100) if churn is high. ADX filter can be added to trade only in trending markets."
+      "notes": "Tune window_fast up (\u219230) and window_slow up (\u2192100) if churn is high. ADX filter can be added to trade only in trending markets."
     },
     {
       "id": "ref-003",
-      "label": "ETH mean-reversion — RSI oversold bounce on 4h",
+      "label": "ETH mean-reversion \u2014 RSI oversold bounce on 4h",
       "asset": "ETH",
       "timeframe": "4h",
       "category": "mean_reversion",
       "description": "Enters when RSI crosses up through 30 (oversold exit), exits when RSI crosses down through 70 (overbought exit). 4h timeframe keeps the setup away from intraday noise.",
       "entry_signals": [
-        { "name": "rsi_cross_up", "signal_type": "TRIGGER", "params": { "window": 14, "threshold": 30 } }
+        {
+          "name": "rsi_cross_up",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 14,
+            "threshold": 30
+          }
+        }
       ],
       "exit_signals": [
-        { "name": "rsi_cross_down", "signal_type": "TRIGGER", "params": { "window": 14, "threshold": 70 } }
+        {
+          "name": "rsi_cross_down",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 14,
+            "threshold": 70
+          }
+        }
       ],
-      "execution_config": { "max_risk_per_trade": 0.01, "max_open_positions": 2 },
+      "execution_config": {
+        "max_risk_per_trade": 0.01,
+        "max_open_positions": 2
+      },
       "source": "curated",
       "notes": "Classic RSI(14, 30/70). Tighter thresholds (25/75) yield fewer but higher-quality entries on ranging markets."
     },
     {
       "id": "ref-004",
-      "label": "BTC momentum + trend filter — MACD entry, SMA filter on 1h",
+      "label": "BTC momentum + trend filter \u2014 MACD entry, SMA filter on 1h",
       "asset": "BTC",
       "timeframe": "1h",
       "category": "momentum",
-      "description": "Enters on MACD bullish cross ONLY when price is above SMA(50) — filters out counter-trend momentum pops. Exits on MACD bearish cross.",
+      "description": "Enters on MACD bullish cross ONLY when price is above SMA(50) \u2014 filters out counter-trend momentum pops. Exits on MACD bearish cross.",
       "entry_signals": [
-        { "name": "macd_bullish_cross", "signal_type": "TRIGGER", "params": { "window_fast": 12, "window_slow": 26, "window_sign": 9 } },
-        { "name": "is_above_sma", "signal_type": "FILTER", "params": { "window": 50 } }
+        {
+          "name": "macd_bullish_cross",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 12,
+            "window_slow": 26,
+            "window_sign": 9
+          }
+        },
+        {
+          "name": "is_above_sma",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 50
+          }
+        }
       ],
       "exit_signals": [
-        { "name": "macd_bearish_cross", "signal_type": "TRIGGER", "params": { "window_fast": 12, "window_slow": 26, "window_sign": 9 } }
+        {
+          "name": "macd_bearish_cross",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 12,
+            "window_slow": 26,
+            "window_sign": 9
+          }
+        }
       ],
-      "execution_config": { "max_risk_per_trade": 0.01, "max_open_positions": 2 },
+      "execution_config": {
+        "max_risk_per_trade": 0.01,
+        "max_open_positions": 2
+      },
       "source": "curated/KB-informed",
       "notes": "The trend filter cuts trade count ~60% but typically lifts win rate. Good starter for a cautious momentum player."
     },
     {
       "id": "ref-005",
-      "label": "ETH trend-follow — EMA crossover with ADX filter on 4h",
+      "label": "ETH trend-follow \u2014 EMA crossover with ADX filter on 4h",
       "asset": "ETH",
       "timeframe": "4h",
       "category": "trend_following",
       "description": "EMA(12) crosses EMA(26) up = long, cross down = exit. ADX > 25 filter ensures we only trade when there's actual trend strength.",
       "entry_signals": [
-        { "name": "ema_cross_up", "signal_type": "TRIGGER", "params": { "window_fast": 12, "window_slow": 26 } },
-        { "name": "adx_strong_trend", "signal_type": "FILTER", "params": { "window": 14, "threshold": 25 } }
+        {
+          "name": "ema_cross_up",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 12,
+            "window_slow": 26
+          }
+        },
+        {
+          "name": "adx_strong_trend",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 14,
+            "threshold": 25
+          }
+        }
       ],
       "exit_signals": [
-        { "name": "ema_cross_down", "signal_type": "TRIGGER", "params": { "window_fast": 12, "window_slow": 26 } }
+        {
+          "name": "ema_cross_down",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 12,
+            "window_slow": 26
+          }
+        }
       ],
-      "execution_config": { "max_risk_per_trade": 0.012, "max_open_positions": 2 },
+      "execution_config": {
+        "max_risk_per_trade": 0.012,
+        "max_open_positions": 2
+      },
       "source": "curated",
       "notes": "ADX filter is the single biggest quality lever on crypto trend systems. Disable it to see the noise for yourself."
     },
     {
       "id": "ref-006",
-      "label": "BTC momentum long-term — MACD on 1d",
+      "label": "BTC momentum long-term \u2014 MACD on 1d",
       "asset": "BTC",
       "timeframe": "1d",
       "category": "momentum",
-      "description": "Daily MACD(12,26,9) — the textbook swing-trading setup. Low trade count but high per-trade expectancy on BTC historically.",
+      "description": "Daily MACD(12,26,9) \u2014 the textbook swing-trading setup. Low trade count but high per-trade expectancy on BTC historically.",
       "entry_signals": [
-        { "name": "macd_bullish_cross", "signal_type": "TRIGGER", "params": { "window_fast": 12, "window_slow": 26, "window_sign": 9 } }
+        {
+          "name": "macd_bullish_cross",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 12,
+            "window_slow": 26,
+            "window_sign": 9
+          }
+        }
       ],
       "exit_signals": [
-        { "name": "macd_bearish_cross", "signal_type": "TRIGGER", "params": { "window_fast": 12, "window_slow": 26, "window_sign": 9 } }
+        {
+          "name": "macd_bearish_cross",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 12,
+            "window_slow": 26,
+            "window_sign": 9
+          }
+        }
       ],
-      "execution_config": { "max_risk_per_trade": 0.02, "max_open_positions": 1 },
+      "execution_config": {
+        "max_risk_per_trade": 0.02,
+        "max_open_positions": 1
+      },
       "source": "curated",
       "notes": "1d MACD expects 4-8 trades per year on BTC. Use for a low-attention, high-conviction live wallet."
     },
     {
       "id": "ref-007",
-      "label": "ETH momentum — ROC positive + above SMA on 4h",
+      "label": "ETH momentum \u2014 ROC positive + above SMA on 4h",
       "asset": "ETH",
       "timeframe": "4h",
       "category": "momentum",
       "description": "Enters when Rate of Change flips positive AND price is above SMA(50). Exits on ROC flipping negative. Catches sustained momentum rather than single-bar spikes.",
       "entry_signals": [
-        { "name": "roc_momentum_shift", "signal_type": "TRIGGER", "params": { "window": 12, "direction": "up" } },
-        { "name": "is_above_sma", "signal_type": "FILTER", "params": { "window": 50 } }
+        {
+          "name": "roc_momentum_shift",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 12,
+            "direction": "up"
+          }
+        },
+        {
+          "name": "is_above_sma",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 50
+          }
+        }
       ],
       "exit_signals": [
-        { "name": "roc_momentum_shift", "signal_type": "TRIGGER", "params": { "window": 12, "direction": "down" } }
+        {
+          "name": "roc_momentum_shift",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 12,
+            "direction": "down"
+          }
+        }
       ],
-      "execution_config": { "max_risk_per_trade": 0.01, "max_open_positions": 2 },
+      "execution_config": {
+        "max_risk_per_trade": 0.01,
+        "max_open_positions": 2
+      },
       "source": "curated",
       "notes": "ROC period 12 = ~2 days on 4h. Shorter periods = more trades but more noise; 6 is the typical noise floor."
     },
     {
       "id": "ref-008",
-      "label": "BTC trend + volume confirmation — EMA cross + PVO on 1h",
+      "label": "BTC trend + volume confirmation \u2014 EMA cross + PVO on 1h",
       "asset": "BTC",
       "timeframe": "1h",
       "category": "trend_following",
-      "description": "EMA(9) crosses EMA(21) up AND PVO (Percentage Volume Oscillator) is bullish = enter. Combines price trend + volume participation — reduces false breakouts.",
+      "description": "EMA(9) crosses EMA(21) up AND PVO (Percentage Volume Oscillator) is bullish = enter. Combines price trend + volume participation \u2014 reduces false breakouts.",
       "entry_signals": [
-        { "name": "ema_cross_up", "signal_type": "TRIGGER", "params": { "window_fast": 9, "window_slow": 21 } },
-        { "name": "pvo_bullish_cross", "signal_type": "FILTER", "params": { "window_slow": 26, "window_fast": 12, "window_sign": 9 } }
+        {
+          "name": "ema_cross_up",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 9,
+            "window_slow": 21
+          }
+        },
+        {
+          "name": "pvo_bullish_cross",
+          "signal_type": "FILTER",
+          "params": {
+            "window_slow": 26,
+            "window_fast": 12,
+            "window_sign": 9
+          }
+        }
       ],
       "exit_signals": [
-        { "name": "ema_cross_down", "signal_type": "TRIGGER", "params": { "window_fast": 9, "window_slow": 21 } }
+        {
+          "name": "ema_cross_down",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 9,
+            "window_slow": 21
+          }
+        }
       ],
-      "execution_config": { "max_risk_per_trade": 0.01, "max_open_positions": 2 },
+      "execution_config": {
+        "max_risk_per_trade": 0.01,
+        "max_open_positions": 2
+      },
       "source": "curated",
       "notes": "PVO filter rejects ~40% of pure price-only crossovers. Good defense against choppy ranges."
     },
     {
       "id": "ref-009",
-      "label": "ETH mean-reversion tight — Stoch oversold bounce on 1h",
+      "label": "ETH mean-reversion tight \u2014 Stoch oversold bounce on 1h",
       "asset": "ETH",
       "timeframe": "1h",
       "category": "mean_reversion",
       "description": "Stochastic(14,3) oversold (< 20) crosses back up = enter. Exits on overbought (> 80). Tighter + faster than RSI mean-reversion.",
       "entry_signals": [
-        { "name": "rsi_cross_up", "signal_type": "TRIGGER", "params": { "window": 14, "threshold": 30 } },
-        { "name": "stoch_oversold", "signal_type": "FILTER", "params": { "window": 14, "smooth_window": 3, "threshold": 20 } }
+        {
+          "name": "rsi_cross_up",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 14,
+            "threshold": 30
+          }
+        },
+        {
+          "name": "stoch_oversold",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 14,
+            "smooth_window": 3,
+            "threshold": 20
+          }
+        }
       ],
       "exit_signals": [
-        { "name": "rsi_cross_down", "signal_type": "TRIGGER", "params": { "window": 14, "threshold": 70 } }
+        {
+          "name": "rsi_cross_down",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 14,
+            "threshold": 70
+          }
+        }
       ],
-      "execution_config": { "max_risk_per_trade": 0.008, "max_open_positions": 2 },
+      "execution_config": {
+        "max_risk_per_trade": 0.008,
+        "max_open_positions": 2
+      },
       "source": "curated",
-      "notes": "Dual oscillator confluence. High trade count, small edges — slippage/fees matter more here. Measure carefully in backtest."
+      "notes": "Dual oscillator confluence. High trade count, small edges \u2014 slippage/fees matter more here. Measure carefully in backtest."
     },
     {
       "id": "ref-010",
-      "label": "BTC breakout — Ichimoku TK cross on 4h",
+      "label": "BTC breakout \u2014 Ichimoku TK cross on 4h",
       "asset": "BTC",
       "timeframe": "4h",
       "category": "breakout",
-      "description": "Ichimoku Tenkan/Kijun crossover — a trend-confirmation breakout. Enters on TK cross up with bullish cloud posture, exits on TK cross down.",
+      "description": "Ichimoku Tenkan/Kijun crossover \u2014 a trend-confirmation breakout. Enters on TK cross up with bullish cloud posture, exits on TK cross down.",
       "entry_signals": [
-        { "name": "ichimoku_tk_cross", "signal_type": "TRIGGER", "params": { "window_tenkan": 9, "window_kijun": 26, "window_senkou": 52, "direction": "up" } },
-        { "name": "ichimoku_bullish", "signal_type": "FILTER", "params": { "window_tenkan": 9, "window_kijun": 26, "window_senkou": 52 } }
+        {
+          "name": "ichimoku_tk_cross",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_tenkan": 9,
+            "window_kijun": 26,
+            "window_senkou": 52,
+            "direction": "up"
+          }
+        },
+        {
+          "name": "ichimoku_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "window_tenkan": 9,
+            "window_kijun": 26,
+            "window_senkou": 52
+          }
+        }
       ],
       "exit_signals": [
-        { "name": "ichimoku_tk_cross", "signal_type": "TRIGGER", "params": { "window_tenkan": 9, "window_kijun": 26, "window_senkou": 52, "direction": "down" } }
+        {
+          "name": "ichimoku_tk_cross",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_tenkan": 9,
+            "window_kijun": 26,
+            "window_senkou": 52,
+            "direction": "down"
+          }
+        }
       ],
-      "execution_config": { "max_risk_per_trade": 0.012, "max_open_positions": 2 },
+      "execution_config": {
+        "max_risk_per_trade": 0.012,
+        "max_open_positions": 2
+      },
       "source": "curated",
-      "notes": "Ichimoku is self-filtering — the bullish-cloud filter ensures we only take TK crosses in confirmed uptrends. Classic 9/26/52 periods."
+      "notes": "Ichimoku is self-filtering \u2014 the bullish-cloud filter ensures we only take TK crosses in confirmed uptrends. Classic 9/26/52 periods."
     },
     {
       "id": "ref-011",
-      "label": "ETH trend-follow conservative — SMA 50/200 on 1d",
+      "label": "ETH trend-follow conservative \u2014 SMA 50/200 on 1d",
       "asset": "ETH",
       "timeframe": "1d",
       "category": "trend_following",
       "description": "The 'golden cross' on daily: SMA(50) crosses above SMA(200). Long-term position trading. Trade count per year: 1-3.",
       "entry_signals": [
-        { "name": "sma_cross_up", "signal_type": "TRIGGER", "params": { "window_fast": 50, "window_slow": 200 } }
+        {
+          "name": "sma_cross_up",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 50,
+            "window_slow": 200
+          }
+        }
       ],
       "exit_signals": [
-        { "name": "sma_cross_down", "signal_type": "TRIGGER", "params": { "window_fast": 50, "window_slow": 200 } }
+        {
+          "name": "sma_cross_down",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 50,
+            "window_slow": 200
+          }
+        }
       ],
-      "execution_config": { "max_risk_per_trade": 0.025, "max_open_positions": 1 },
+      "execution_config": {
+        "max_risk_per_trade": 0.025,
+        "max_open_positions": 1
+      },
       "source": "curated",
       "notes": "Slow as molasses, but on BTC/ETH historically captures the bulk of bull markets. Zero daily attention required."
     },
     {
       "id": "ref-012",
-      "label": "BTC volatility expansion — ATR filter + MACD on 4h",
+      "label": "BTC volatility expansion \u2014 ATR filter + MACD on 4h",
       "asset": "BTC",
       "timeframe": "4h",
       "category": "volatility",
       "description": "Trade MACD crossovers only during high-volatility regimes (ATR-based). Avoids the death of trend systems during ranging markets.",
       "entry_signals": [
-        { "name": "macd_bullish_cross", "signal_type": "TRIGGER", "params": { "window_fast": 12, "window_slow": 26, "window_sign": 9 } },
-        { "name": "atr_high_volatility", "signal_type": "FILTER", "params": { "window": 14, "threshold_pct": 2.0 } }
+        {
+          "name": "macd_bullish_cross",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 12,
+            "window_slow": 26,
+            "window_sign": 9
+          }
+        },
+        {
+          "name": "atr_high_volatility",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 14,
+            "threshold_pct": 2.0
+          }
+        }
       ],
       "exit_signals": [
-        { "name": "macd_bearish_cross", "signal_type": "TRIGGER", "params": { "window_fast": 12, "window_slow": 26, "window_sign": 9 } }
+        {
+          "name": "macd_bearish_cross",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 12,
+            "window_slow": 26,
+            "window_sign": 9
+          }
+        }
       ],
-      "execution_config": { "max_risk_per_trade": 0.015, "max_open_positions": 2 },
+      "execution_config": {
+        "max_risk_per_trade": 0.015,
+        "max_open_positions": 2
+      },
       "source": "curated",
       "notes": "Volatility filter reduces trade count but systematically skips the worst regime for trend systems. Good pairing for momentum goals."
+    },
+    {
+      "id": "oracle-exp_20260325T052040807444Z-322473",
+      "label": "MATIC 1h psar_reversal (Oracle sweep)",
+      "asset": "MATIC",
+      "timeframe": "1h",
+      "category": "mean_reversion",
+      "description": "Oracle sweep lineage: experiment exp_20260325T052040807444Z run_index 322473. Entry filters: ichimoku_bullish, daily_return_negative. See data/exports/reference_strategies_curated_*.json for the source cohort row.",
+      "entry_signals": [
+        {
+          "name": "psar_reversal",
+          "signal_type": "TRIGGER",
+          "params": {
+            "step": 0.0713,
+            "max_step": 0.1061,
+            "direction": "bullish"
+          }
+        },
+        {
+          "name": "ichimoku_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "window_tenkan": 15,
+            "window_kijun": 27,
+            "window_senkou": 57
+          }
+        },
+        {
+          "name": "daily_return_negative",
+          "signal_type": "FILTER",
+          "params": {
+            "threshold": 95.7821
+          }
+        }
+      ],
+      "exit_signals": [],
+      "execution_config": {
+        "reward_factor": 3.2479710578918457,
+        "max_risk_per_trade": 0.03810200095176697,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10000000149011612,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 621,
+        "exit_on_profit_after_bars": 884,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997,
+        "network_fees_enabled": null
+      },
+      "source": "oracle/sweep/exp_20260325T052040807444Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260421T124958707655Z-53250",
+      "label": "BTC 1h dc_lower_breakout (Oracle sweep)",
+      "asset": "BTC",
+      "timeframe": "1h",
+      "category": "breakout",
+      "description": "Oracle sweep lineage: experiment exp_20260421T124958707655Z run_index 53250. Entry filters: obv_bullish, supertrend_long. See data/exports/reference_strategies_curated_*.json for the source cohort row.",
+      "entry_signals": [
+        {
+          "name": "dc_lower_breakout",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 10
+          }
+        },
+        {
+          "name": "obv_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 32
+          }
+        },
+        {
+          "name": "supertrend_long",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 32,
+            "multiplier": 5.9928
+          }
+        }
+      ],
+      "exit_signals": [
+        {
+          "name": "aroon_crossover",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 38,
+            "direction": "bearish"
+          }
+        },
+        {
+          "name": "adosc_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "fast": 8,
+            "slow": 31
+          }
+        },
+        {
+          "name": "ulcer_high_risk",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 40,
+            "threshold": 10.974
+          }
+        }
+      ],
+      "execution_config": {
+        "reward_factor": 2.5270400047302246,
+        "max_risk_per_trade": 0.3714419901371002,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10000000149011612,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 9999996.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 1000,
+        "exit_on_profit_after_bars": 1000,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997,
+        "network_fees_enabled": true
+      },
+      "source": "oracle/sweep/exp_20260421T124958707655Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260421T124958707655Z-57531",
+      "label": "BTC 1h kc_lower_breakout (Oracle sweep)",
+      "asset": "BTC",
+      "timeframe": "1h",
+      "category": "breakout",
+      "description": "Oracle sweep lineage: experiment exp_20260421T124958707655Z run_index 57531. Entry filters: psar_bearish. See data/exports/reference_strategies_curated_*.json for the source cohort row.",
+      "entry_signals": [
+        {
+          "name": "kc_lower_breakout",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 35,
+            "window_atr": 25,
+            "multiplier": 2.4789,
+            "original_version": true
+          }
+        },
+        {
+          "name": "psar_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "step": 0.018,
+            "max_step": 0.4318
+          }
+        }
+      ],
+      "exit_signals": [],
+      "execution_config": {
+        "reward_factor": 3.1213910579681396,
+        "max_risk_per_trade": 0.2823129892349243,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10000000149011612,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 9999996.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 1000,
+        "exit_on_profit_after_bars": 1000,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997,
+        "network_fees_enabled": true
+      },
+      "source": "oracle/sweep/exp_20260421T124958707655Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260420T053742727970Z-115841",
+      "label": "AVAX 1h roc_momentum_shift (Oracle sweep)",
+      "asset": "AVAX",
+      "timeframe": "1h",
+      "category": "momentum",
+      "description": "Oracle sweep lineage: experiment exp_20260420T053742727970Z run_index 115841. Entry filters: stoch_oversold. See data/exports/reference_strategies_curated_*.json for the source cohort row.",
+      "entry_signals": [
+        {
+          "name": "roc_momentum_shift",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 2,
+            "direction": "bullish"
+          }
+        },
+        {
+          "name": "stoch_oversold",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 17,
+            "smooth_window": 2,
+            "threshold": 12.1005
+          }
+        }
+      ],
+      "exit_signals": [],
+      "execution_config": {
+        "reward_factor": 3.3673810958862305,
+        "max_risk_per_trade": 0.2947160005569458,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10000000149011612,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 9999996.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 1000,
+        "exit_on_profit_after_bars": 1000,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997,
+        "network_fees_enabled": true
+      },
+      "source": "oracle/sweep/exp_20260420T053742727970Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260421T124958707655Z-28032",
+      "label": "BTC 1h mom_cross_down (Oracle sweep)",
+      "asset": "BTC",
+      "timeframe": "1h",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260421T124958707655Z run_index 28032. Entry filters: vwap_below. See data/exports/reference_strategies_curated_*.json for the source cohort row.",
+      "entry_signals": [
+        {
+          "name": "mom_cross_down",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 15
+          }
+        },
+        {
+          "name": "vwap_below",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 45
+          }
+        }
+      ],
+      "exit_signals": [
+        {
+          "name": "smma_cross_down",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 55,
+            "window_slow": 160
+          }
+        }
+      ],
+      "execution_config": {
+        "reward_factor": 2.430619955062866,
+        "max_risk_per_trade": 0.15136699378490448,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10000000149011612,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 9999996.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 1000,
+        "exit_on_profit_after_bars": 1000,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997,
+        "network_fees_enabled": true
+      },
+      "source": "oracle/sweep/exp_20260421T124958707655Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260421T124958707655Z-18731",
+      "label": "BTC 1h mom_cross_up (Oracle sweep)",
+      "asset": "BTC",
+      "timeframe": "1h",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260421T124958707655Z run_index 18731. Entry filters: ulcer_low_risk. See data/exports/reference_strategies_curated_*.json for the source cohort row.",
+      "entry_signals": [
+        {
+          "name": "mom_cross_up",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 51
+          }
+        },
+        {
+          "name": "ulcer_low_risk",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 43,
+            "threshold": 8.9068
+          }
+        }
+      ],
+      "exit_signals": [
+        {
+          "name": "kc_upper_breakout",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 12,
+            "window_atr": 9,
+            "multiplier": 2.3982,
+            "original_version": false
+          }
+        },
+        {
+          "name": "ichimoku_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "window_tenkan": 6,
+            "window_kijun": 22,
+            "window_senkou": 49
+          }
+        },
+        {
+          "name": "stc_oversold",
+          "signal_type": "FILTER",
+          "params": {
+            "window_slow": 184,
+            "window_fast": 15,
+            "cycle": 70,
+            "smooth1": 88,
+            "smooth2": 111,
+            "threshold": 24.2826
+          }
+        }
+      ],
+      "execution_config": {
+        "reward_factor": 2.9470338821411133,
+        "max_risk_per_trade": 0.3797129988670349,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10000000149011612,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 9999996.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 1000,
+        "exit_on_profit_after_bars": 1000,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997,
+        "network_fees_enabled": true
+      },
+      "source": "oracle/sweep/exp_20260421T124958707655Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260421T124958707655Z-16209",
+      "label": "BTC 1h aroon_crossover (Oracle sweep)",
+      "asset": "BTC",
+      "timeframe": "1h",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260421T124958707655Z run_index 16209. Entry filters: reversal_pattern_bearish. See data/exports/reference_strategies_curated_*.json for the source cohort row.",
+      "entry_signals": [
+        {
+          "name": "aroon_crossover",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 34,
+            "direction": "bearish"
+          }
+        },
+        {
+          "name": "reversal_pattern_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 16
+          }
+        }
+      ],
+      "exit_signals": [
+        {
+          "name": "atr_trailing_stop_flip_up",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 46,
+            "multiplier": 8.8232
+          }
+        },
+        {
+          "name": "ichimoku_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "window_tenkan": 14,
+            "window_kijun": 30,
+            "window_senkou": 35
+          }
+        }
+      ],
+      "execution_config": {
+        "reward_factor": 2.8700790405273438,
+        "max_risk_per_trade": 0.21991600096225739,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10000000149011612,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 9999996.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 1000,
+        "exit_on_profit_after_bars": 1000,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997,
+        "network_fees_enabled": true
+      },
+      "source": "oracle/sweep/exp_20260421T124958707655Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260313T014209439318Z-117680",
+      "label": "SOL 5m psar_reversal (Oracle sweep)",
+      "asset": "SOL",
+      "timeframe": "5m",
+      "category": "mean_reversion",
+      "description": "Oracle sweep lineage: experiment exp_20260313T014209439318Z run_index 117680. Entry filters: tsi_bearish, daily_return_negative, price_above_ema. See data/exports/reference_strategies_curated_*.json for the source cohort row.",
+      "entry_signals": [
+        {
+          "name": "psar_reversal",
+          "signal_type": "TRIGGER",
+          "params": {
+            "step": 0.0348,
+            "max_step": 0.2025,
+            "direction": "bullish"
+          }
+        },
+        {
+          "name": "tsi_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "window_slow": 50,
+            "window_fast": 9,
+            "threshold": 32.1458
+          }
+        },
+        {
+          "name": "daily_return_negative",
+          "signal_type": "FILTER",
+          "params": {
+            "threshold": 85.2246
+          }
+        },
+        {
+          "name": "price_above_ema",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 113
+          }
+        }
+      ],
+      "exit_signals": [],
+      "execution_config": {
+        "reward_factor": 3.0,
+        "max_risk_per_trade": 0.01931600086390972,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.2531970143318176,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 10000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 1000,
+        "exit_on_profit_after_bars": 1000,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997,
+        "network_fees_enabled": null
+      },
+      "source": "oracle/sweep/exp_20260313T014209439318Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260313T014209439318Z-7210",
+      "label": "SOL 5m macd_bearish_cross (Oracle sweep)",
+      "asset": "SOL",
+      "timeframe": "5m",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260313T014209439318Z run_index 7210. Entry filters: is_above_sma. See data/exports/reference_strategies_curated_*.json for the source cohort row.",
+      "entry_signals": [
+        {
+          "name": "macd_bearish_cross",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 6,
+            "window_slow": 46,
+            "window_sign": 2
+          }
+        },
+        {
+          "name": "is_above_sma",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 416
+          }
+        }
+      ],
+      "exit_signals": [
+        {
+          "name": "bb_squeeze",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 96,
+            "window_dev": 4,
+            "threshold": 8.5847
+          }
+        },
+        {
+          "name": "adx_bullish_di",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 45
+          }
+        }
+      ],
+      "execution_config": {
+        "reward_factor": 5.0,
+        "max_risk_per_trade": 0.026738999411463737,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.11017800122499466,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 10000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 1000,
+        "exit_on_profit_after_bars": 1000,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997,
+        "network_fees_enabled": null
+      },
+      "source": "oracle/sweep/exp_20260313T014209439318Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260313T014209439318Z-113483",
+      "label": "XRP 15m kc_upper_breakout (Oracle sweep)",
+      "asset": "XRP",
+      "timeframe": "15m",
+      "category": "breakout",
+      "description": "Oracle sweep lineage: experiment exp_20260313T014209439318Z run_index 113483. Entry filters: aroon_up_trend, is_above_sma, obv_bullish. See data/exports/reference_strategies_curated_*.json for the source cohort row.",
+      "entry_signals": [
+        {
+          "name": "kc_upper_breakout",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 44,
+            "window_atr": 15,
+            "multiplier": 2.7751,
+            "original_version": false
+          }
+        },
+        {
+          "name": "aroon_up_trend",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 10,
+            "threshold": 73.8099
+          }
+        },
+        {
+          "name": "is_above_sma",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 782
+          }
+        },
+        {
+          "name": "obv_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 44
+          }
+        }
+      ],
+      "exit_signals": [
+        {
+          "name": "wma_cross_up",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 43,
+            "window_slow": 72
+          }
+        },
+        {
+          "name": "stoch_overbought",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 36,
+            "smooth_window": 2,
+            "threshold": 99.0382
+          }
+        },
+        {
+          "name": "mfi_oversold",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 24,
+            "threshold": 9.0249
+          }
+        }
+      ],
+      "execution_config": {
+        "reward_factor": 4.0,
+        "max_risk_per_trade": 0.011381999589502811,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.23322300612926483,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 10000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 1000,
+        "exit_on_profit_after_bars": 1000,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997,
+        "network_fees_enabled": null
+      },
+      "source": "oracle/sweep/exp_20260313T014209439318Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260325T052040807444Z-145375",
+      "label": "HBAR 1h dc_lower_breakout (Oracle sweep)",
+      "asset": "HBAR",
+      "timeframe": "1h",
+      "category": "breakout",
+      "description": "Oracle sweep lineage: experiment exp_20260325T052040807444Z run_index 145375. Entry filters: aroon_down_trend. See data/exports/reference_strategies_curated_*.json for the source cohort row.",
+      "entry_signals": [
+        {
+          "name": "dc_lower_breakout",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 53
+          }
+        },
+        {
+          "name": "aroon_down_trend",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 10,
+            "threshold": 94.3032
+          }
+        }
+      ],
+      "exit_signals": [],
+      "execution_config": {
+        "reward_factor": 1.7504990100860596,
+        "max_risk_per_trade": 0.025397000834345818,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10000000149011612,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 919,
+        "exit_on_profit_after_bars": 788,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997,
+        "network_fees_enabled": null
+      },
+      "source": "oracle/sweep/exp_20260325T052040807444Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260325T052040807444Z-677463",
+      "label": "ALGO 15m vortex_crossover (Oracle sweep)",
+      "asset": "ALGO",
+      "timeframe": "15m",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260325T052040807444Z run_index 677463. Entry filters: adx_strong_trend. See data/exports/reference_strategies_curated_*.json for the source cohort row.",
+      "entry_signals": [
+        {
+          "name": "vortex_crossover",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 21,
+            "direction": "bullish"
+          }
+        },
+        {
+          "name": "adx_strong_trend",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 31,
+            "threshold": 35.042
+          }
+        }
+      ],
+      "exit_signals": [
+        {
+          "name": "kst_bullish_cross",
+          "signal_type": "TRIGGER",
+          "params": {
+            "roc1": 133,
+            "roc2": 25,
+            "roc3": 51,
+            "roc4": 165,
+            "window_sma1": 183,
+            "window_sma2": 132,
+            "window_sma3": 151,
+            "window_sma4": 103,
+            "nsig": 172
+          }
+        },
+        {
+          "name": "cmf_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 15,
+            "threshold": -0.5619
+          }
+        },
+        {
+          "name": "ao_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "window_fast": 12,
+            "window_slow": 47,
+            "threshold": 61.2868
+          }
+        },
+        {
+          "name": "vwap_above",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 35
+          }
+        }
+      ],
+      "execution_config": {
+        "reward_factor": 1.8511229753494263,
+        "max_risk_per_trade": 0.030957000330090523,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10000000149011612,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 888,
+        "exit_on_profit_after_bars": 741,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997,
+        "network_fees_enabled": null
+      },
+      "source": "oracle/sweep/exp_20260325T052040807444Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260420T053742727970Z-90122",
+      "label": "AVAX 1h pvo_bullish_cross (Oracle sweep)",
+      "asset": "AVAX",
+      "timeframe": "1h",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260420T053742727970Z run_index 90122. Entry filters: ichimoku_bullish, adi_bearish. See data/exports/reference_strategies_curated_*.json for the source cohort row.",
+      "entry_signals": [
+        {
+          "name": "pvo_bullish_cross",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_slow": 38,
+            "window_fast": 20,
+            "window_sign": 3
+          }
+        },
+        {
+          "name": "ichimoku_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "window_tenkan": 7,
+            "window_kijun": 27,
+            "window_senkou": 44
+          }
+        },
+        {
+          "name": "adi_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 49
+          }
+        }
+      ],
+      "exit_signals": [],
+      "execution_config": {
+        "reward_factor": 1.7407100200653076,
+        "max_risk_per_trade": 0.2125609964132309,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10000000149011612,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 9999996.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 1000,
+        "exit_on_profit_after_bars": 1000,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997,
+        "network_fees_enabled": true
+      },
+      "source": "oracle/sweep/exp_20260420T053742727970Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260401T215530598480Z-2041868",
+      "label": "NEAR 1d psar_reversal (Oracle sweep)",
+      "asset": "NEAR",
+      "timeframe": "1d",
+      "category": "mean_reversion",
+      "description": "Oracle sweep lineage: experiment exp_20260401T215530598480Z run_index 2041868. Entry filters: vwap_above. See data/exports/reference_strategies_curated_*.json for the source cohort row.",
+      "entry_signals": [
+        {
+          "name": "psar_reversal",
+          "signal_type": "TRIGGER",
+          "params": {
+            "step": 0.0579,
+            "max_step": 0.4137,
+            "direction": "bullish"
+          }
+        },
+        {
+          "name": "vwap_above",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 11
+          }
+        }
+      ],
+      "exit_signals": [
+        {
+          "name": "ema_cross_down",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 16,
+            "window_slow": 116
+          }
+        }
+      ],
+      "execution_config": {
+        "reward_factor": 2.470916986465454,
+        "max_risk_per_trade": 0.03167099878191948,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10000000149011612,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 504,
+        "exit_on_profit_after_bars": 875,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997,
+        "network_fees_enabled": null
+      },
+      "source": "oracle/sweep/exp_20260401T215530598480Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260410T044615231015Z-112064",
+      "label": "BTC 1d inside_bar_trigger (Oracle sweep)",
+      "asset": "BTC",
+      "timeframe": "1d",
+      "category": "breakout",
+      "description": "Oracle sweep lineage: experiment exp_20260410T044615231015Z run_index 112064. Entry filters: reversal_pattern_bearish, adi_bullish, nvi_bearish. See data/exports/reference_strategies_curated_*.json for the source cohort row.",
+      "entry_signals": [
+        {
+          "name": "inside_bar_trigger",
+          "signal_type": "TRIGGER",
+          "params": {}
+        },
+        {
+          "name": "reversal_pattern_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 19
+          }
+        },
+        {
+          "name": "adi_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 25
+          }
+        },
+        {
+          "name": "nvi_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 124
+          }
+        }
+      ],
+      "exit_signals": [
+        {
+          "name": "ichimoku_tk_cross",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_tenkan": 14,
+            "window_kijun": 19,
+            "window_senkou": 63,
+            "direction": "bullish"
+          }
+        },
+        {
+          "name": "cumulative_return_positive",
+          "signal_type": "FILTER",
+          "params": {
+            "threshold": 27.8838
+          }
+        },
+        {
+          "name": "stochrsi_oversold",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 11,
+            "smooth1": 7,
+            "smooth2": 7,
+            "threshold": 0.0088
+          }
+        }
+      ],
+      "execution_config": {
+        "reward_factor": 3.522397994995117,
+        "max_risk_per_trade": 0.03253699839115143,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.1031700000166893,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 10000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 1000,
+        "exit_on_profit_after_bars": 1000,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997,
+        "network_fees_enabled": null
+      },
+      "source": "oracle/sweep/exp_20260410T044615231015Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260420T053742727970Z-653283",
+      "label": "XRP 1h mom_cross_down (Oracle sweep)",
+      "asset": "XRP",
+      "timeframe": "1h",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260420T053742727970Z run_index 653283. Entry filters: is_above_hma. See data/exports/reference_strategies_curated_*.json for the source cohort row.",
+      "entry_signals": [
+        {
+          "name": "mom_cross_down",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 154
+          }
+        },
+        {
+          "name": "is_above_hma",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 90
+          }
+        }
+      ],
+      "exit_signals": [
+        {
+          "name": "macd_bullish_cross",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 8,
+            "window_slow": 74,
+            "window_sign": 34
+          }
+        },
+        {
+          "name": "strong_body_recent",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 16
+          }
+        },
+        {
+          "name": "roc_positive",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 24,
+            "threshold": -9.5748
+          }
+        }
+      ],
+      "execution_config": {
+        "reward_factor": 2.097080945968628,
+        "max_risk_per_trade": 0.18701300024986267,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10000000149011612,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 9999996.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 1000,
+        "exit_on_profit_after_bars": 1000,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997,
+        "network_fees_enabled": true
+      },
+      "source": "oracle/sweep/exp_20260420T053742727970Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260320T174739679755Z-18895",
+      "label": "LINK 1h psar_reversal (Oracle sweep)",
+      "asset": "LINK",
+      "timeframe": "1h",
+      "category": "mean_reversion",
+      "description": "Oracle sweep lineage: experiment exp_20260320T174739679755Z run_index 18895. Entry filters: ulcer_high_risk. See data/exports/reference_strategies_curated_*.json for the source cohort row.",
+      "entry_signals": [
+        {
+          "name": "psar_reversal",
+          "signal_type": "TRIGGER",
+          "params": {
+            "step": 0.016,
+            "max_step": 0.2554,
+            "direction": "bullish"
+          }
+        },
+        {
+          "name": "ulcer_high_risk",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 28,
+            "threshold": 12.8246
+          }
+        }
+      ],
+      "exit_signals": [
+        {
+          "name": "ppo_bearish_cross",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_slow": 31,
+            "window_fast": 8,
+            "window_sign": 8
+          }
+        },
+        {
+          "name": "vwap_above",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 47
+          }
+        }
+      ],
+      "execution_config": {
+        "reward_factor": 3.454371929168701,
+        "max_risk_per_trade": 0.028189999982714653,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.13801999390125275,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 1000,
+        "exit_on_profit_after_bars": 1000,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997,
+        "network_fees_enabled": null
+      },
+      "source": "oracle/sweep/exp_20260320T174739679755Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260325T052040807444Z-522259",
+      "label": "BTC 15m ema_crossover (Oracle sweep)",
+      "asset": "BTC",
+      "timeframe": "15m",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260325T052040807444Z run_index 522259. Entry filters: dpo_negative. See data/exports/reference_strategies_curated_*.json for the source cohort row.",
+      "entry_signals": [
+        {
+          "name": "ema_crossover",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 86,
+            "window_slow": 138,
+            "direction": "bullish"
+          }
+        },
+        {
+          "name": "dpo_negative",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 26
+          }
+        }
+      ],
+      "exit_signals": [
+        {
+          "name": "kst_bearish_cross",
+          "signal_type": "TRIGGER",
+          "params": {
+            "roc1": 183,
+            "roc2": 177,
+            "roc3": 72,
+            "roc4": 56,
+            "window_sma1": 175,
+            "window_sma2": 92,
+            "window_sma3": 162,
+            "window_sma4": 112,
+            "nsig": 72
+          }
+        },
+        {
+          "name": "mfi_oversold",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 20,
+            "threshold": 24.2652
+          }
+        },
+        {
+          "name": "cmf_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 42,
+            "threshold": -0.9409
+          }
+        }
+      ],
+      "execution_config": {
+        "reward_factor": 3.761138916015625,
+        "max_risk_per_trade": 0.029284000396728516,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10000000149011612,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 596,
+        "exit_on_profit_after_bars": 723,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997,
+        "network_fees_enabled": null
+      },
+      "source": "oracle/sweep/exp_20260325T052040807444Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260421T124958707655Z-31224",
+      "label": "BTC 1h epma_cross_up (Oracle sweep)",
+      "asset": "BTC",
+      "timeframe": "1h",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260421T124958707655Z run_index 31224. Entry filters: kvo_bullish. See data/exports/reference_strategies_curated_*.json for the source cohort row.",
+      "entry_signals": [
+        {
+          "name": "epma_cross_up",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 5,
+            "window_slow": 195
+          }
+        },
+        {
+          "name": "kvo_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "fast": 67,
+            "slow": 74,
+            "signal_window": 36
+          }
+        }
+      ],
+      "exit_signals": [
+        {
+          "name": "three_white_soldiers_trigger",
+          "signal_type": "TRIGGER",
+          "params": {
+            "min_body_ratio": 0.511
+          }
+        }
+      ],
+      "execution_config": {
+        "reward_factor": 2.2924530506134033,
+        "max_risk_per_trade": 0.10396099835634232,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10000000149011612,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 9999996.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 1000,
+        "exit_on_profit_after_bars": 1000,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997,
+        "network_fees_enabled": true
+      },
+      "source": "oracle/sweep/exp_20260421T124958707655Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260421T124958707655Z-17555",
+      "label": "BTC 1h mama_cross_down (Oracle sweep)",
+      "asset": "BTC",
+      "timeframe": "1h",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260421T124958707655Z run_index 17555. Entry filters: adi_bullish. See data/exports/reference_strategies_curated_*.json for the source cohort row.",
+      "entry_signals": [
+        {
+          "name": "mama_cross_down",
+          "signal_type": "TRIGGER",
+          "params": {
+            "fast_limit": 0.4138,
+            "slow_limit": 0.2383
+          }
+        },
+        {
+          "name": "adi_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 47
+          }
+        }
+      ],
+      "exit_signals": [],
+      "execution_config": {
+        "reward_factor": 4.117804050445557,
+        "max_risk_per_trade": 0.3733980059623718,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10000000149011612,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 9999996.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 1000,
+        "exit_on_profit_after_bars": 1000,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997,
+        "network_fees_enabled": true
+      },
+      "source": "oracle/sweep/exp_20260421T124958707655Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260421T124958707655Z-57130",
+      "label": "BTC 1h sma_cross_down (Oracle sweep)",
+      "asset": "BTC",
+      "timeframe": "1h",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260421T124958707655Z run_index 57130. Entry filters: vpt_bearish. See data/exports/reference_strategies_curated_*.json for the source cohort row.",
+      "entry_signals": [
+        {
+          "name": "sma_cross_down",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 105,
+            "window_slow": 128
+          }
+        },
+        {
+          "name": "vpt_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 29
+          }
+        }
+      ],
+      "exit_signals": [
+        {
+          "name": "dc_upper_breakout",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 44
+          }
+        },
+        {
+          "name": "adosc_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "fast": 18,
+            "slow": 27
+          }
+        }
+      ],
+      "execution_config": {
+        "reward_factor": 2.960455894470215,
+        "max_risk_per_trade": 0.12173400074243546,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10000000149011612,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 9999996.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 1000,
+        "exit_on_profit_after_bars": 1000,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997,
+        "network_fees_enabled": true
+      },
+      "source": "oracle/sweep/exp_20260421T124958707655Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260325T052040807444Z-18168",
+      "label": "MATIC 5m sma_cross_up (Oracle sweep)",
+      "asset": "MATIC",
+      "timeframe": "5m",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260325T052040807444Z run_index 18168. Entry filters: nvi_bearish, trix_bearish. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "sma_cross_up",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 195,
+            "window_slow": 197
+          }
+        },
+        {
+          "name": "nvi_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 181
+          }
+        },
+        {
+          "name": "trix_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 17,
+            "threshold": 75.2921
+          }
+        }
+      ],
+      "exit_signals": [
+        {
+          "name": "kc_upper_breakout",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 13,
+            "window_atr": 29,
+            "multiplier": 2.7916,
+            "original_version": true
+          }
+        },
+        {
+          "name": "tsi_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "window_slow": 27,
+            "window_fast": 22,
+            "threshold": -31.3535
+          }
+        },
+        {
+          "name": "adi_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 35
+          }
+        }
+      ],
+      "execution_config": {
+        "reward_factor": 3.767210006713867,
+        "max_risk_per_trade": 0.027462000027298927,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10000000149011612,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 927,
+        "exit_on_profit_after_bars": 965,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260325T052040807444Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260325T052040807444Z-23316",
+      "label": "UNI 5m aroon_crossover (Oracle sweep)",
+      "asset": "UNI",
+      "timeframe": "5m",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260325T052040807444Z run_index 23316. Entry filters: psar_bearish. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "aroon_crossover",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 14,
+            "direction": "bullish"
+          }
+        },
+        {
+          "name": "psar_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "step": 0.0721,
+            "max_step": 0.2265
+          }
+        }
+      ],
+      "exit_signals": [],
+      "execution_config": {
+        "reward_factor": 2.9436678886413574,
+        "max_risk_per_trade": 0.01975799910724163,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10000000149011612,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 704,
+        "exit_on_profit_after_bars": 810,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260325T052040807444Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260325T052040807444Z-351161",
+      "label": "SUI 5m ema_cross_up (Oracle sweep)",
+      "asset": "SUI",
+      "timeframe": "5m",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260325T052040807444Z run_index 351161. Entry filters: adi_bullish, mfi_overbought. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "ema_cross_up",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 67,
+            "window_slow": 141
+          }
+        },
+        {
+          "name": "adi_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 10
+          }
+        },
+        {
+          "name": "mfi_overbought",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 7,
+            "threshold": 71.1687
+          }
+        }
+      ],
+      "exit_signals": [],
+      "execution_config": {
+        "reward_factor": 3.645277976989746,
+        "max_risk_per_trade": 0.038322001695632935,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10000000149011612,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 513,
+        "exit_on_profit_after_bars": 950,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260325T052040807444Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260320T174739679755Z-66908",
+      "label": "NEAR 5m ema_cross_down (Oracle sweep)",
+      "asset": "NEAR",
+      "timeframe": "5m",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260320T174739679755Z run_index 66908. Entry filters: vwap_below. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "ema_cross_down",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 5,
+            "window_slow": 161
+          }
+        },
+        {
+          "name": "vwap_below",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 17
+          }
+        }
+      ],
+      "exit_signals": [
+        {
+          "name": "vortex_crossover",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 27,
+            "direction": "bullish"
+          }
+        },
+        {
+          "name": "trix_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 9,
+            "threshold": 6.5048
+          }
+        },
+        {
+          "name": "nvi_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 171
+          }
+        },
+        {
+          "name": "williams_r_oversold",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 28,
+            "threshold": -77.7798
+          }
+        }
+      ],
+      "execution_config": {
+        "reward_factor": 4.623664855957031,
+        "max_risk_per_trade": 0.03280699998140335,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.29473501443862915,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 1000,
+        "exit_on_profit_after_bars": 1000,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260320T174739679755Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260320T174739679755Z-62589",
+      "label": "NEAR 5m ichimoku_tk_cross (Oracle sweep)",
+      "asset": "NEAR",
+      "timeframe": "5m",
+      "category": "breakout",
+      "description": "Oracle sweep lineage: experiment exp_20260320T174739679755Z run_index 62589. Entry filters: vpt_bullish. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "ichimoku_tk_cross",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_tenkan": 20,
+            "window_kijun": 16,
+            "window_senkou": 51,
+            "direction": "bullish"
+          }
+        },
+        {
+          "name": "vpt_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 44
+          }
+        }
+      ],
+      "exit_signals": [
+        {
+          "name": "sma_cross_up",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 440,
+            "window_slow": 879
+          }
+        },
+        {
+          "name": "vortex_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 12
+          }
+        }
+      ],
+      "execution_config": {
+        "reward_factor": 4.465967178344727,
+        "max_risk_per_trade": 0.033073000609874725,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.2843010127544403,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 1000,
+        "exit_on_profit_after_bars": 1000,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260320T174739679755Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260325T052040807444Z-357694",
+      "label": "ETH 5m ppo_bullish_cross (Oracle sweep)",
+      "asset": "ETH",
+      "timeframe": "5m",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260325T052040807444Z run_index 357694. Entry filters: adx_bullish_di. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "ppo_bullish_cross",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_slow": 20,
+            "window_fast": 8,
+            "window_sign": 12
+          }
+        },
+        {
+          "name": "adx_bullish_di",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 41
+          }
+        }
+      ],
+      "exit_signals": [
+        {
+          "name": "bb_squeeze",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 6,
+            "window_dev": 2,
+            "threshold": 18.0985
+          }
+        }
+      ],
+      "execution_config": {
+        "reward_factor": 3.739089012145996,
+        "max_risk_per_trade": 0.024176999926567078,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10000000149011612,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 764,
+        "exit_on_profit_after_bars": 996,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260325T052040807444Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260325T052040807444Z-371284",
+      "label": "ADA 5m psar_reversal (Oracle sweep)",
+      "asset": "ADA",
+      "timeframe": "5m",
+      "category": "mean_reversion",
+      "description": "Oracle sweep lineage: experiment exp_20260325T052040807444Z run_index 371284. Entry filters: stoch_oversold. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "psar_reversal",
+          "signal_type": "TRIGGER",
+          "params": {
+            "step": 0.0357,
+            "max_step": 0.1427,
+            "direction": "bullish"
+          }
+        },
+        {
+          "name": "stoch_oversold",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 20,
+            "smooth_window": 1,
+            "threshold": 25.874
+          }
+        }
+      ],
+      "exit_signals": [],
+      "execution_config": {
+        "reward_factor": 3.8702640533447266,
+        "max_risk_per_trade": 0.033810000866651535,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10000000149011612,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 789,
+        "exit_on_profit_after_bars": 974,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260325T052040807444Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260325T052040807444Z-688204",
+      "label": "BTC 15m kc_lower_breakout (Oracle sweep)",
+      "asset": "BTC",
+      "timeframe": "15m",
+      "category": "breakout",
+      "description": "Oracle sweep lineage: experiment exp_20260325T052040807444Z run_index 688204. Entry filters: eom_bearish. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "kc_lower_breakout",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 15,
+            "window_atr": 12,
+            "multiplier": 0.7057,
+            "original_version": false
+          }
+        },
+        {
+          "name": "eom_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 16,
+            "threshold": 61.2221
+          }
+        }
+      ],
+      "exit_signals": [
+        {
+          "name": "sma_crossover",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 26,
+            "window_slow": 187,
+            "direction": "bullish"
+          }
+        }
+      ],
+      "execution_config": {
+        "reward_factor": 3.545361042022705,
+        "max_risk_per_trade": 0.034818001091480255,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10000000149011612,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 704,
+        "exit_on_profit_after_bars": 517,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260325T052040807444Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260320T174739679755Z-29819",
+      "label": "FIL 1h ao_zero_cross (Oracle sweep)",
+      "asset": "FIL",
+      "timeframe": "1h",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260320T174739679755Z run_index 29819. Entry filters: daily_return_negative, ao_bearish, adx_bullish_di. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "ao_zero_cross",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 14,
+            "window_slow": 22,
+            "direction": "bullish"
+          }
+        },
+        {
+          "name": "daily_return_negative",
+          "signal_type": "FILTER",
+          "params": {
+            "threshold": 39.8426
+          }
+        },
+        {
+          "name": "ao_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "window_fast": 3,
+            "window_slow": 37,
+            "threshold": 31.3552
+          }
+        },
+        {
+          "name": "adx_bullish_di",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 21
+          }
+        }
+      ],
+      "exit_signals": [
+        {
+          "name": "aroon_crossover",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 36,
+            "direction": "bullish"
+          }
+        },
+        {
+          "name": "ichimoku_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "window_tenkan": 10,
+            "window_kijun": 17,
+            "window_senkou": 59
+          }
+        },
+        {
+          "name": "rsi_overbought",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 66,
+            "threshold": 60.7567
+          }
+        }
+      ],
+      "execution_config": {
+        "reward_factor": 3.7746191024780273,
+        "max_risk_per_trade": 0.03793700039386749,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.11510500311851501,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 1000,
+        "exit_on_profit_after_bars": 1000,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260320T174739679755Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260320T174739679755Z-18036",
+      "label": "MATIC 1h pvo_bullish_cross (Oracle sweep)",
+      "asset": "MATIC",
+      "timeframe": "1h",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260320T174739679755Z run_index 18036. Entry filters: adi_bearish. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "pvo_bullish_cross",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_slow": 16,
+            "window_fast": 10,
+            "window_sign": 14
+          }
+        },
+        {
+          "name": "adi_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 40
+          }
+        }
+      ],
+      "exit_signals": [],
+      "execution_config": {
+        "reward_factor": 4.4824538230896,
+        "max_risk_per_trade": 0.024042999371886253,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.1492069959640503,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 1000,
+        "exit_on_profit_after_bars": 1000,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260320T174739679755Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260320T174739679755Z-61294",
+      "label": "UNI 5m rsi_cross_down (Oracle sweep)",
+      "asset": "UNI",
+      "timeframe": "5m",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260320T174739679755Z run_index 61294. Entry filters: adi_bullish. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "rsi_cross_down",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 51,
+            "threshold": 55.237
+          }
+        },
+        {
+          "name": "adi_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 44
+          }
+        }
+      ],
+      "exit_signals": [
+        {
+          "name": "ppo_bullish_cross",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_slow": 19,
+            "window_fast": 15,
+            "window_sign": 7
+          }
+        },
+        {
+          "name": "trix_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 10,
+            "threshold": 49.6169
+          }
+        },
+        {
+          "name": "tsi_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "window_slow": 19,
+            "window_fast": 5,
+            "threshold": 33.1856
+          }
+        },
+        {
+          "name": "ichimoku_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "window_tenkan": 6,
+            "window_kijun": 33,
+            "window_senkou": 37
+          }
+        }
+      ],
+      "execution_config": {
+        "reward_factor": 4.013936996459961,
+        "max_risk_per_trade": 0.03366199880838394,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.17689499258995056,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 1000,
+        "exit_on_profit_after_bars": 1000,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260320T174739679755Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260325T052040807444Z-34370",
+      "label": "SUI 5m rsi_cross_up (Oracle sweep)",
+      "asset": "SUI",
+      "timeframe": "5m",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260325T052040807444Z run_index 34370. Entry filters: nvi_bullish. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "rsi_cross_up",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 76,
+            "threshold": 38.2818
+          }
+        },
+        {
+          "name": "nvi_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 193
+          }
+        }
+      ],
+      "exit_signals": [],
+      "execution_config": {
+        "reward_factor": 3.3172950744628906,
+        "max_risk_per_trade": 0.03785400092601776,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10000000149011612,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 557,
+        "exit_on_profit_after_bars": 676,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260325T052040807444Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260320T174739679755Z-2748",
+      "label": "UNI 5m wma_cross_up (Oracle sweep)",
+      "asset": "UNI",
+      "timeframe": "5m",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260320T174739679755Z run_index 2748. Entry filters: eom_bearish, obv_bearish. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "wma_cross_up",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 24,
+            "window_slow": 29
+          }
+        },
+        {
+          "name": "eom_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 28,
+            "threshold": 20.8495
+          }
+        },
+        {
+          "name": "obv_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 15
+          }
+        }
+      ],
+      "exit_signals": [
+        {
+          "name": "ppo_bullish_cross",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_slow": 33,
+            "window_fast": 11,
+            "window_sign": 4
+          }
+        },
+        {
+          "name": "uo_overbought",
+          "signal_type": "FILTER",
+          "params": {
+            "window_short": 5,
+            "window_medium": 27,
+            "window_long": 33,
+            "threshold": 81.214
+          }
+        }
+      ],
+      "execution_config": {
+        "reward_factor": 4.037697792053223,
+        "max_risk_per_trade": 0.0220940001308918,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.17899900674819946,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 1000,
+        "exit_on_profit_after_bars": 1000,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260320T174739679755Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260320T174739679755Z-57767",
+      "label": "XRP 1h kc_upper_breakout (Oracle sweep)",
+      "asset": "XRP",
+      "timeframe": "1h",
+      "category": "breakout",
+      "description": "Oracle sweep lineage: experiment exp_20260320T174739679755Z run_index 57767. Entry filters: vortex_bullish. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "kc_upper_breakout",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 10,
+            "window_atr": 14,
+            "multiplier": 4.8084,
+            "original_version": true
+          }
+        },
+        {
+          "name": "vortex_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 14
+          }
+        }
+      ],
+      "exit_signals": [
+        {
+          "name": "rsi_cross_up",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 67,
+            "threshold": 87.464
+          }
+        },
+        {
+          "name": "vpt_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 35
+          }
+        },
+        {
+          "name": "ao_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "window_fast": 14,
+            "window_slow": 59,
+            "threshold": 28.993
+          }
+        },
+        {
+          "name": "rsi_overbought",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 8,
+            "threshold": 58.129
+          }
+        }
+      ],
+      "execution_config": {
+        "reward_factor": 4.862052917480469,
+        "max_risk_per_trade": 0.027751000598073006,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10445299744606018,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 1000,
+        "exit_on_profit_after_bars": 1000,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260320T174739679755Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260325T052040807444Z-27510",
+      "label": "LINK 5m psar_reversal (Oracle sweep)",
+      "asset": "LINK",
+      "timeframe": "5m",
+      "category": "mean_reversion",
+      "description": "Oracle sweep lineage: experiment exp_20260325T052040807444Z run_index 27510. Entry filters: nvi_bullish, eom_bearish. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "psar_reversal",
+          "signal_type": "TRIGGER",
+          "params": {
+            "step": 0.0471,
+            "max_step": 0.234,
+            "direction": "bullish"
+          }
+        },
+        {
+          "name": "nvi_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 132
+          }
+        },
+        {
+          "name": "eom_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 13,
+            "threshold": 12.5263
+          }
+        }
+      ],
+      "exit_signals": [],
+      "execution_config": {
+        "reward_factor": 3.394257068634033,
+        "max_risk_per_trade": 0.031346000730991364,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10000000149011612,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 861,
+        "exit_on_profit_after_bars": 749,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260325T052040807444Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260325T052040807444Z-164456",
+      "label": "APT 5m sma_cross_up (Oracle sweep)",
+      "asset": "APT",
+      "timeframe": "5m",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260325T052040807444Z run_index 164456. Entry filters: vwap_below, aroon_down_trend. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "sma_cross_up",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 71,
+            "window_slow": 80
+          }
+        },
+        {
+          "name": "vwap_below",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 28
+          }
+        },
+        {
+          "name": "aroon_down_trend",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 42,
+            "threshold": 95.9543
+          }
+        }
+      ],
+      "exit_signals": [
+        {
+          "name": "kst_bearish_cross",
+          "signal_type": "TRIGGER",
+          "params": {
+            "roc1": 123,
+            "roc2": 3,
+            "roc3": 13,
+            "roc4": 60,
+            "window_sma1": 3,
+            "window_sma2": 136,
+            "window_sma3": 102,
+            "window_sma4": 75,
+            "nsig": 33
+          }
+        },
+        {
+          "name": "price_above_ema",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 49
+          }
+        },
+        {
+          "name": "ulcer_low_risk",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 15,
+            "threshold": 14.2479
+          }
+        }
+      ],
+      "execution_config": {
+        "reward_factor": 3.9491350650787354,
+        "max_risk_per_trade": 0.026494000107049942,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10000000149011612,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 711,
+        "exit_on_profit_after_bars": 817,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260325T052040807444Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260320T174739679755Z-62182",
+      "label": "MATIC 1h ichimoku_tk_cross (Oracle sweep)",
+      "asset": "MATIC",
+      "timeframe": "1h",
+      "category": "breakout",
+      "description": "Oracle sweep lineage: experiment exp_20260320T174739679755Z run_index 62182. Entry filters: adx_bullish_di, cmf_bullish, daily_return_negative. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "ichimoku_tk_cross",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_tenkan": 14,
+            "window_kijun": 20,
+            "window_senkou": 49,
+            "direction": "bullish"
+          }
+        },
+        {
+          "name": "adx_bullish_di",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 36
+          }
+        },
+        {
+          "name": "cmf_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 44,
+            "threshold": -0.035
+          }
+        },
+        {
+          "name": "daily_return_negative",
+          "signal_type": "FILTER",
+          "params": {
+            "threshold": 11.8523
+          }
+        }
+      ],
+      "exit_signals": [
+        {
+          "name": "kc_lower_breakout",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 47,
+            "window_atr": 22,
+            "multiplier": 4.9444,
+            "original_version": true
+          }
+        },
+        {
+          "name": "rsi_overbought",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 8,
+            "threshold": 79.5857
+          }
+        }
+      ],
+      "execution_config": {
+        "reward_factor": 4.912208080291748,
+        "max_risk_per_trade": 0.036423999816179276,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.1483670026063919,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 1000,
+        "exit_on_profit_after_bars": 1000,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260320T174739679755Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260320T174739679755Z-31884",
+      "label": "MATIC 1h aroon_crossover (Oracle sweep)",
+      "asset": "MATIC",
+      "timeframe": "1h",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260320T174739679755Z run_index 31884. Entry filters: trix_bearish, price_above_ema. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "aroon_crossover",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 27,
+            "direction": "bullish"
+          }
+        },
+        {
+          "name": "trix_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 27,
+            "threshold": 2.8049
+          }
+        },
+        {
+          "name": "price_above_ema",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 61
+          }
+        }
+      ],
+      "exit_signals": [
+        {
+          "name": "ema_cross_down",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 60,
+            "window_slow": 143
+          }
+        },
+        {
+          "name": "roc_negative",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 38,
+            "threshold": 6.3539
+          }
+        }
+      ],
+      "execution_config": {
+        "reward_factor": 3.9302170276641846,
+        "max_risk_per_trade": 0.03155200183391571,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.2607539892196655,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 1000,
+        "exit_on_profit_after_bars": 1000,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260320T174739679755Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260320T174739679755Z-24207",
+      "label": "MATIC 1h rsi_cross_down (Oracle sweep)",
+      "asset": "MATIC",
+      "timeframe": "1h",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260320T174739679755Z run_index 24207. Entry filters: ulcer_low_risk. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "rsi_cross_down",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 93,
+            "threshold": 56.532
+          }
+        },
+        {
+          "name": "ulcer_low_risk",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 10,
+            "threshold": 14.4327
+          }
+        }
+      ],
+      "exit_signals": [],
+      "execution_config": {
+        "reward_factor": 3.7348849773406982,
+        "max_risk_per_trade": 0.024253999814391136,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.21290799975395203,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 1000,
+        "exit_on_profit_after_bars": 1000,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260320T174739679755Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260320T174739679755Z-55143",
+      "label": "APT 5m sma_cross_down (Oracle sweep)",
+      "asset": "APT",
+      "timeframe": "5m",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260320T174739679755Z run_index 55143. Entry filters: roc_positive. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "sma_cross_down",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 256,
+            "window_slow": 440
+          }
+        },
+        {
+          "name": "roc_positive",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 3,
+            "threshold": -8.0198
+          }
+        }
+      ],
+      "exit_signals": [
+        {
+          "name": "kc_upper_breakout",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 36,
+            "window_atr": 6,
+            "multiplier": 1.9331,
+            "original_version": true
+          }
+        },
+        {
+          "name": "ao_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "window_fast": 7,
+            "window_slow": 38,
+            "threshold": 23.7497
+          }
+        },
+        {
+          "name": "roc_negative",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 11,
+            "threshold": -9.3516
+          }
+        },
+        {
+          "name": "daily_return_positive",
+          "signal_type": "FILTER",
+          "params": {
+            "threshold": 58.9433
+          }
+        }
+      ],
+      "execution_config": {
+        "reward_factor": 4.682103157043457,
+        "max_risk_per_trade": 0.03334999829530716,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.18168899416923523,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 1000,
+        "exit_on_profit_after_bars": 1000,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260320T174739679755Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260325T052040807444Z-418126",
+      "label": "SUI 5m ema_crossover (Oracle sweep)",
+      "asset": "SUI",
+      "timeframe": "5m",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260325T052040807444Z run_index 418126. Entry filters: adi_bearish. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "ema_crossover",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 12,
+            "window_slow": 148,
+            "direction": "bullish"
+          }
+        },
+        {
+          "name": "adi_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 29
+          }
+        }
+      ],
+      "exit_signals": [
+        {
+          "name": "rsi_cross_down",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 77,
+            "threshold": 65.5446
+          }
+        },
+        {
+          "name": "tsi_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "window_slow": 16,
+            "window_fast": 7,
+            "threshold": 49.7545
+          }
+        },
+        {
+          "name": "eom_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 8,
+            "threshold": 61.8298
+          }
+        },
+        {
+          "name": "mfi_overbought",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 28,
+            "threshold": 72.759
+          }
+        }
+      ],
+      "execution_config": {
+        "reward_factor": 3.3831610679626465,
+        "max_risk_per_trade": 0.014945999719202518,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10000000149011612,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 889,
+        "exit_on_profit_after_bars": 974,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260325T052040807444Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260325T052040807444Z-4703",
+      "label": "UNI 5m rsi_cross_up (Oracle sweep)",
+      "asset": "UNI",
+      "timeframe": "5m",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260325T052040807444Z run_index 4703. Entry filters: nvi_bearish, obv_bullish, vpt_bullish. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "rsi_cross_up",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 36,
+            "threshold": 54.7441
+          }
+        },
+        {
+          "name": "nvi_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 104
+          }
+        },
+        {
+          "name": "obv_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 42
+          }
+        },
+        {
+          "name": "vpt_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 26
+          }
+        }
+      ],
+      "exit_signals": [
+        {
+          "name": "rsi_cross_down",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 89,
+            "threshold": 39.5683
+          }
+        },
+        {
+          "name": "macd_positive",
+          "signal_type": "FILTER",
+          "params": {
+            "window_fast": 25,
+            "window_slow": 91,
+            "window_sign": 48
+          }
+        }
+      ],
+      "execution_config": {
+        "reward_factor": 3.8302810192108154,
+        "max_risk_per_trade": 0.024173999205231667,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10000000149011612,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 875,
+        "exit_on_profit_after_bars": 742,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260325T052040807444Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260325T052040807444Z-396098",
+      "label": "QNT 1h roc_momentum_shift (Oracle sweep)",
+      "asset": "QNT",
+      "timeframe": "1h",
+      "category": "momentum",
+      "description": "Oracle sweep lineage: experiment exp_20260325T052040807444Z run_index 396098. Entry filters: macd_positive, roc_positive. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "roc_momentum_shift",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 33,
+            "direction": "bullish"
+          }
+        },
+        {
+          "name": "macd_positive",
+          "signal_type": "FILTER",
+          "params": {
+            "window_fast": 24,
+            "window_slow": 41,
+            "window_sign": 11
+          }
+        },
+        {
+          "name": "roc_positive",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 39,
+            "threshold": 0.4178
+          }
+        }
+      ],
+      "exit_signals": [
+        {
+          "name": "wma_cross_up",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 19,
+            "window_slow": 57
+          }
+        },
+        {
+          "name": "uo_oversold",
+          "signal_type": "FILTER",
+          "params": {
+            "window_short": 14,
+            "window_medium": 7,
+            "window_long": 46,
+            "threshold": 23.2914
+          }
+        },
+        {
+          "name": "rsi_oversold",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 70,
+            "threshold": 13.6091
+          }
+        },
+        {
+          "name": "vortex_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 7
+          }
+        }
+      ],
+      "execution_config": {
+        "reward_factor": 3.58634090423584,
+        "max_risk_per_trade": 0.03235799819231033,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10000000149011612,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 1000,
+        "exit_on_profit_after_bars": 724,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260325T052040807444Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260325T052040807444Z-362876",
+      "label": "SUI 5m ema_cross_up (Oracle sweep)",
+      "asset": "SUI",
+      "timeframe": "5m",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260325T052040807444Z run_index 362876. Entry filters: is_above_sma, tsi_bullish. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "ema_cross_up",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 30,
+            "window_slow": 184
+          }
+        },
+        {
+          "name": "is_above_sma",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 68
+          }
+        },
+        {
+          "name": "tsi_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "window_slow": 20,
+            "window_fast": 6,
+            "threshold": -6.2658
+          }
+        }
+      ],
+      "exit_signals": [
+        {
+          "name": "bb_squeeze",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 5,
+            "window_dev": 2,
+            "threshold": 10.0323
+          }
+        },
+        {
+          "name": "williams_r_overbought",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 11,
+            "threshold": -1.3767
+          }
+        },
+        {
+          "name": "mfi_oversold",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 17,
+            "threshold": 18.73
+          }
+        }
+      ],
+      "execution_config": {
+        "reward_factor": 3.3399689197540283,
+        "max_risk_per_trade": 0.030579999089241028,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10000000149011612,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 665,
+        "exit_on_profit_after_bars": 929,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260325T052040807444Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260320T174739679755Z-62217",
+      "label": "SKY 1h pvo_bearish_cross (Oracle sweep)",
+      "asset": "SKY",
+      "timeframe": "1h",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260320T174739679755Z run_index 62217. Entry filters: ichimoku_bearish, ulcer_low_risk. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "pvo_bearish_cross",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_slow": 37,
+            "window_fast": 13,
+            "window_sign": 3
+          }
+        },
+        {
+          "name": "ichimoku_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "window_tenkan": 20,
+            "window_kijun": 31,
+            "window_senkou": 60
+          }
+        },
+        {
+          "name": "ulcer_low_risk",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 19,
+            "threshold": 9.8779
+          }
+        }
+      ],
+      "exit_signals": [],
+      "execution_config": {
+        "reward_factor": 3.5686089992523193,
+        "max_risk_per_trade": 0.0319489985704422,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.2408130019903183,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 1000,
+        "exit_on_profit_after_bars": 1000,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260320T174739679755Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260325T052040807444Z-81052",
+      "label": "RENDER 1h pvo_bearish_cross (Oracle sweep)",
+      "asset": "RENDER",
+      "timeframe": "1h",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260325T052040807444Z run_index 81052. Entry filters: ulcer_low_risk. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "pvo_bearish_cross",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_slow": 16,
+            "window_fast": 6,
+            "window_sign": 12
+          }
+        },
+        {
+          "name": "ulcer_low_risk",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 6,
+            "threshold": 4.2711
+          }
+        }
+      ],
+      "exit_signals": [
+        {
+          "name": "rsi_cross_down",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 68,
+            "threshold": 60.1484
+          }
+        },
+        {
+          "name": "tsi_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "window_slow": 24,
+            "window_fast": 17,
+            "threshold": 7.547
+          }
+        }
+      ],
+      "execution_config": {
+        "reward_factor": 3.193110942840576,
+        "max_risk_per_trade": 0.0248780008405447,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10000000149011612,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 921,
+        "exit_on_profit_after_bars": 591,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260325T052040807444Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260325T052040807444Z-298776",
+      "label": "ADA 5m wma_cross_up (Oracle sweep)",
+      "asset": "ADA",
+      "timeframe": "5m",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260325T052040807444Z run_index 298776. Entry filters: stochrsi_overbought. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "wma_cross_up",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 42,
+            "window_slow": 95
+          }
+        },
+        {
+          "name": "stochrsi_overbought",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 28,
+            "smooth1": 1,
+            "smooth2": 9,
+            "threshold": 0.8782
+          }
+        }
+      ],
+      "exit_signals": [],
+      "execution_config": {
+        "reward_factor": 3.6835079193115234,
+        "max_risk_per_trade": 0.018108999356627464,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10000000149011612,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 702,
+        "exit_on_profit_after_bars": 914,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260325T052040807444Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260325T052040807444Z-653366",
+      "label": "SUI 5m aroon_crossover (Oracle sweep)",
+      "asset": "SUI",
+      "timeframe": "5m",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260325T052040807444Z run_index 653366. Entry filters: psar_bearish, williams_r_overbought. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "aroon_crossover",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 33,
+            "direction": "bullish"
+          }
+        },
+        {
+          "name": "psar_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "step": 0.0657,
+            "max_step": 0.4028
+          }
+        },
+        {
+          "name": "williams_r_overbought",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 19,
+            "threshold": -29.0659
+          }
+        }
+      ],
+      "exit_signals": [],
+      "execution_config": {
+        "reward_factor": 3.850822925567627,
+        "max_risk_per_trade": 0.03343399986624718,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10000000149011612,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 879,
+        "exit_on_profit_after_bars": 823,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260325T052040807444Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260320T174739679755Z-28325",
+      "label": "NEAR 1h dc_upper_breakout (Oracle sweep)",
+      "asset": "NEAR",
+      "timeframe": "1h",
+      "category": "breakout",
+      "description": "Oracle sweep lineage: experiment exp_20260320T174739679755Z run_index 28325. Entry filters: psar_bullish, nvi_bearish, daily_return_negative. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "dc_upper_breakout",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 86
+          }
+        },
+        {
+          "name": "psar_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "step": 0.0961,
+            "max_step": 0.2148
+          }
+        },
+        {
+          "name": "nvi_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 145
+          }
+        },
+        {
+          "name": "daily_return_negative",
+          "signal_type": "FILTER",
+          "params": {
+            "threshold": 24.0862
+          }
+        }
+      ],
+      "exit_signals": [],
+      "execution_config": {
+        "reward_factor": 4.232470989227295,
+        "max_risk_per_trade": 0.023569000884890556,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.25742998719215393,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 1000,
+        "exit_on_profit_after_bars": 1000,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260320T174739679755Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260320T174739679755Z-40215",
+      "label": "FET 1h bb_upper_breakout (Oracle sweep)",
+      "asset": "FET",
+      "timeframe": "1h",
+      "category": "breakout",
+      "description": "Oracle sweep lineage: experiment exp_20260320T174739679755Z run_index 40215. Entry filters: nvi_bearish, vpt_bullish. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "bb_upper_breakout",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 64,
+            "window_dev": 1
+          }
+        },
+        {
+          "name": "nvi_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 154
+          }
+        },
+        {
+          "name": "vpt_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 47
+          }
+        }
+      ],
+      "exit_signals": [
+        {
+          "name": "pvo_bullish_cross",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_slow": 45,
+            "window_fast": 13,
+            "window_sign": 15
+          }
+        },
+        {
+          "name": "ulcer_high_risk",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 21,
+            "threshold": 28.861
+          }
+        },
+        {
+          "name": "adx_bullish_di",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 21
+          }
+        }
+      ],
+      "execution_config": {
+        "reward_factor": 3.3591020107269287,
+        "max_risk_per_trade": 0.03907499834895134,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.16284699738025665,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 1000,
+        "exit_on_profit_after_bars": 1000,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260320T174739679755Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260325T052040807444Z-28955",
+      "label": "SUI 5m ichimoku_tk_cross (Oracle sweep)",
+      "asset": "SUI",
+      "timeframe": "5m",
+      "category": "breakout",
+      "description": "Oracle sweep lineage: experiment exp_20260325T052040807444Z run_index 28955. Entry filters: adx_strong_trend, adi_bearish. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "ichimoku_tk_cross",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_tenkan": 19,
+            "window_kijun": 40,
+            "window_senkou": 57,
+            "direction": "bullish"
+          }
+        },
+        {
+          "name": "adx_strong_trend",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 38,
+            "threshold": 40.5891
+          }
+        },
+        {
+          "name": "adi_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 39
+          }
+        }
+      ],
+      "exit_signals": [],
+      "execution_config": {
+        "reward_factor": 3.293212890625,
+        "max_risk_per_trade": 0.025750000029802322,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10000000149011612,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 718,
+        "exit_on_profit_after_bars": 636,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260325T052040807444Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260320T174739679755Z-34524",
+      "label": "QNT 1h macd_bullish_cross (Oracle sweep)",
+      "asset": "QNT",
+      "timeframe": "1h",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260320T174739679755Z run_index 34524. Entry filters: vwap_below. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "macd_bullish_cross",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 7,
+            "window_slow": 87,
+            "window_sign": 49
+          }
+        },
+        {
+          "name": "vwap_below",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 44
+          }
+        }
+      ],
+      "exit_signals": [
+        {
+          "name": "sma_cross_up",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 293,
+            "window_slow": 605
+          }
+        },
+        {
+          "name": "vortex_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 16
+          }
+        },
+        {
+          "name": "tsi_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "window_slow": 39,
+            "window_fast": 6,
+            "threshold": 28.3085
+          }
+        },
+        {
+          "name": "stoch_overbought",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 35,
+            "smooth_window": 4,
+            "threshold": 89.2967
+          }
+        }
+      ],
+      "execution_config": {
+        "reward_factor": 4.597963809967041,
+        "max_risk_per_trade": 0.03362800180912018,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.12194100022315979,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 1000,
+        "exit_on_profit_after_bars": 1000,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260320T174739679755Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260320T174739679755Z-21343",
+      "label": "AAVE 5m kc_upper_breakout (Oracle sweep)",
+      "asset": "AAVE",
+      "timeframe": "5m",
+      "category": "breakout",
+      "description": "Oracle sweep lineage: experiment exp_20260320T174739679755Z run_index 21343. Entry filters: vortex_bearish. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "kc_upper_breakout",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 32,
+            "window_atr": 18,
+            "multiplier": 1.0869,
+            "original_version": false
+          }
+        },
+        {
+          "name": "vortex_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 5
+          }
+        }
+      ],
+      "exit_signals": [],
+      "execution_config": {
+        "reward_factor": 4.8839521408081055,
+        "max_risk_per_trade": 0.0133670000359416,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.24849699437618256,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 1000,
+        "exit_on_profit_after_bars": 1000,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260320T174739679755Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260320T174739679755Z-34572",
+      "label": "SUI 5m kc_upper_breakout (Oracle sweep)",
+      "asset": "SUI",
+      "timeframe": "5m",
+      "category": "breakout",
+      "description": "Oracle sweep lineage: experiment exp_20260320T174739679755Z run_index 34572. Entry filters: ao_bearish. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "kc_upper_breakout",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 21,
+            "window_atr": 9,
+            "multiplier": 4.1216,
+            "original_version": false
+          }
+        },
+        {
+          "name": "ao_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "window_fast": 6,
+            "window_slow": 45,
+            "threshold": 33.5755
+          }
+        }
+      ],
+      "exit_signals": [
+        {
+          "name": "sma_cross_down",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 209,
+            "window_slow": 948
+          }
+        },
+        {
+          "name": "cci_oversold",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 45,
+            "constant": 0.0528,
+            "threshold": -100.5818
+          }
+        },
+        {
+          "name": "tsi_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "window_slow": 36,
+            "window_fast": 5,
+            "threshold": -12.9762
+          }
+        }
+      ],
+      "execution_config": {
+        "reward_factor": 3.95120906829834,
+        "max_risk_per_trade": 0.029361000284552574,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10194899886846542,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 1000,
+        "exit_on_profit_after_bars": 1000,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260320T174739679755Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260320T174739679755Z-25410",
+      "label": "BNB 5m wma_cross_down (Oracle sweep)",
+      "asset": "BNB",
+      "timeframe": "5m",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260320T174739679755Z run_index 25410. Entry filters: ulcer_low_risk, trix_bearish, dpo_negative. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "wma_cross_down",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 44,
+            "window_slow": 61
+          }
+        },
+        {
+          "name": "ulcer_low_risk",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 29,
+            "threshold": 10.7063
+          }
+        },
+        {
+          "name": "trix_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 23,
+            "threshold": 58.4808
+          }
+        },
+        {
+          "name": "dpo_negative",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 19
+          }
+        }
+      ],
+      "exit_signals": [],
+      "execution_config": {
+        "reward_factor": 4.901524066925049,
+        "max_risk_per_trade": 0.0365540012717247,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.2073889970779419,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 1000,
+        "exit_on_profit_after_bars": 1000,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260320T174739679755Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260320T174739679755Z-20882",
+      "label": "AAVE 5m vortex_crossover (Oracle sweep)",
+      "asset": "AAVE",
+      "timeframe": "5m",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260320T174739679755Z run_index 20882. Entry filters: force_bullish. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "vortex_crossover",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 5,
+            "direction": "bullish"
+          }
+        },
+        {
+          "name": "force_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 19,
+            "threshold": 37.7625
+          }
+        }
+      ],
+      "exit_signals": [],
+      "execution_config": {
+        "reward_factor": 4.973645210266113,
+        "max_risk_per_trade": 0.01486200001090765,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.2705000042915344,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 1000,
+        "exit_on_profit_after_bars": 1000,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260320T174739679755Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260320T174739679755Z-55893",
+      "label": "ADA 5m sma_cross_up (Oracle sweep)",
+      "asset": "ADA",
+      "timeframe": "5m",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260320T174739679755Z run_index 55893. Entry filters: stochrsi_overbought. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "sma_cross_up",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 65,
+            "window_slow": 67
+          }
+        },
+        {
+          "name": "stochrsi_overbought",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 19,
+            "smooth1": 5,
+            "smooth2": 10,
+            "threshold": 0.9735
+          }
+        }
+      ],
+      "exit_signals": [
+        {
+          "name": "psar_reversal",
+          "signal_type": "TRIGGER",
+          "params": {
+            "step": 0.0556,
+            "max_step": 0.4203,
+            "direction": "bullish"
+          }
+        },
+        {
+          "name": "atr_high_volatility",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 35,
+            "threshold_pct": 8.6853
+          }
+        },
+        {
+          "name": "vortex_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 13
+          }
+        },
+        {
+          "name": "roc_positive",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 31,
+            "threshold": -9.1402
+          }
+        }
+      ],
+      "execution_config": {
+        "reward_factor": 4.936397075653076,
+        "max_risk_per_trade": 0.014178999699652195,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.1866140067577362,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 1000,
+        "exit_on_profit_after_bars": 1000,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260320T174739679755Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260325T052040807444Z-347948",
+      "label": "RENDER 1h bb_upper_breakout (Oracle sweep)",
+      "asset": "RENDER",
+      "timeframe": "1h",
+      "category": "breakout",
+      "description": "Oracle sweep lineage: experiment exp_20260325T052040807444Z run_index 347948. Entry filters: ichimoku_bullish. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "bb_upper_breakout",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 35,
+            "window_dev": 1
+          }
+        },
+        {
+          "name": "ichimoku_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "window_tenkan": 16,
+            "window_kijun": 34,
+            "window_senkou": 46
+          }
+        }
+      ],
+      "exit_signals": [
+        {
+          "name": "ema_crossover",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 170,
+            "window_slow": 174,
+            "direction": "bullish"
+          }
+        }
+      ],
+      "execution_config": {
+        "reward_factor": 2.2896080017089844,
+        "max_risk_per_trade": 0.018967000767588615,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10000000149011612,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 910,
+        "exit_on_profit_after_bars": 543,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260325T052040807444Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260325T052040807444Z-133582",
+      "label": "SUI 5m bb_lower_breakout (Oracle sweep)",
+      "asset": "SUI",
+      "timeframe": "5m",
+      "category": "breakout",
+      "description": "Oracle sweep lineage: experiment exp_20260325T052040807444Z run_index 133582. Entry filters: mfi_oversold. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "bb_lower_breakout",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 32,
+            "window_dev": 2
+          }
+        },
+        {
+          "name": "mfi_oversold",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 11,
+            "threshold": 10.8477
+          }
+        }
+      ],
+      "exit_signals": [
+        {
+          "name": "ppo_bearish_cross",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_slow": 25,
+            "window_fast": 20,
+            "window_sign": 13
+          }
+        },
+        {
+          "name": "uo_oversold",
+          "signal_type": "FILTER",
+          "params": {
+            "window_short": 11,
+            "window_medium": 25,
+            "window_long": 18,
+            "threshold": 21.9635
+          }
+        }
+      ],
+      "execution_config": {
+        "reward_factor": 2.7766919136047363,
+        "max_risk_per_trade": 0.03940499946475029,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10000000149011612,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 846,
+        "exit_on_profit_after_bars": 518,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260325T052040807444Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260320T174739679755Z-40450",
+      "label": "FET 1h dc_upper_breakout (Oracle sweep)",
+      "asset": "FET",
+      "timeframe": "1h",
+      "category": "breakout",
+      "description": "Oracle sweep lineage: experiment exp_20260320T174739679755Z run_index 40450. Entry filters: daily_return_negative. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "dc_upper_breakout",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 81
+          }
+        },
+        {
+          "name": "daily_return_negative",
+          "signal_type": "FILTER",
+          "params": {
+            "threshold": 27.0153
+          }
+        }
+      ],
+      "exit_signals": [
+        {
+          "name": "ao_zero_cross",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 2,
+            "window_slow": 39,
+            "direction": "bullish"
+          }
+        },
+        {
+          "name": "dpo_positive",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 48
+          }
+        },
+        {
+          "name": "adi_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 41
+          }
+        },
+        {
+          "name": "daily_return_negative",
+          "signal_type": "FILTER",
+          "params": {
+            "threshold": 32.6221
+          }
+        }
+      ],
+      "execution_config": {
+        "reward_factor": 4.4567108154296875,
+        "max_risk_per_trade": 0.02110699936747551,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.23084700107574463,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 1000,
+        "exit_on_profit_after_bars": 1000,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260320T174739679755Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260320T174739679755Z-36408",
+      "label": "AAVE 5m ichimoku_tk_cross (Oracle sweep)",
+      "asset": "AAVE",
+      "timeframe": "5m",
+      "category": "breakout",
+      "description": "Oracle sweep lineage: experiment exp_20260320T174739679755Z run_index 36408. Entry filters: nvi_bullish, daily_return_negative, stoch_overbought. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "ichimoku_tk_cross",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_tenkan": 10,
+            "window_kijun": 31,
+            "window_senkou": 43,
+            "direction": "bullish"
+          }
+        },
+        {
+          "name": "nvi_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 273
+          }
+        },
+        {
+          "name": "daily_return_negative",
+          "signal_type": "FILTER",
+          "params": {
+            "threshold": 19.4762
+          }
+        },
+        {
+          "name": "stoch_overbought",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 32,
+            "smooth_window": 8,
+            "threshold": 76.5794
+          }
+        }
+      ],
+      "exit_signals": [],
+      "execution_config": {
+        "reward_factor": 3.394437074661255,
+        "max_risk_per_trade": 0.0320190005004406,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.2623710036277771,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 1000,
+        "exit_on_profit_after_bars": 1000,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260320T174739679755Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260325T052040807444Z-487091",
+      "label": "ADA 5m pvo_bullish_cross (Oracle sweep)",
+      "asset": "ADA",
+      "timeframe": "5m",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260325T052040807444Z run_index 487091. Entry filters: uo_oversold. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "pvo_bullish_cross",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_slow": 22,
+            "window_fast": 11,
+            "window_sign": 12
+          }
+        },
+        {
+          "name": "uo_oversold",
+          "signal_type": "FILTER",
+          "params": {
+            "window_short": 4,
+            "window_medium": 13,
+            "window_long": 41,
+            "threshold": 27.4352
+          }
+        }
+      ],
+      "exit_signals": [],
+      "execution_config": {
+        "reward_factor": 3.253477096557617,
+        "max_risk_per_trade": 0.025380000472068787,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10000000149011612,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 732,
+        "exit_on_profit_after_bars": 762,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260325T052040807444Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260325T052040807444Z-702030",
+      "label": "ALGO 5m dc_lower_breakout (Oracle sweep)",
+      "asset": "ALGO",
+      "timeframe": "5m",
+      "category": "breakout",
+      "description": "Oracle sweep lineage: experiment exp_20260325T052040807444Z run_index 702030. Entry filters: cci_oversold. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "dc_lower_breakout",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 16
+          }
+        },
+        {
+          "name": "cci_oversold",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 32,
+            "constant": 0.0322,
+            "threshold": -123.438
+          }
+        }
+      ],
+      "exit_signals": [
+        {
+          "name": "mass_reversal_signal",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 14,
+            "window_slow": 32,
+            "threshold_high": 29.0719,
+            "threshold_low": 26.7469
+          }
+        },
+        {
+          "name": "daily_return_negative",
+          "signal_type": "FILTER",
+          "params": {
+            "threshold": 0.8479
+          }
+        },
+        {
+          "name": "dpo_negative",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 12
+          }
+        },
+        {
+          "name": "macd_positive",
+          "signal_type": "FILTER",
+          "params": {
+            "window_fast": 44,
+            "window_slow": 90,
+            "window_sign": 41
+          }
+        }
+      ],
+      "execution_config": {
+        "reward_factor": 2.0569729804992676,
+        "max_risk_per_trade": 0.034797001630067825,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10000000149011612,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 718,
+        "exit_on_profit_after_bars": 685,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260325T052040807444Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260325T052040807444Z-72235",
+      "label": "APT 5m pvo_bullish_cross (Oracle sweep)",
+      "asset": "APT",
+      "timeframe": "5m",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260325T052040807444Z run_index 72235. Entry filters: nvi_bullish, adx_bullish_di. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "pvo_bullish_cross",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_slow": 27,
+            "window_fast": 12,
+            "window_sign": 8
+          }
+        },
+        {
+          "name": "nvi_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 127
+          }
+        },
+        {
+          "name": "adx_bullish_di",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 39
+          }
+        }
+      ],
+      "exit_signals": [],
+      "execution_config": {
+        "reward_factor": 2.877413034439087,
+        "max_risk_per_trade": 0.027615999802947044,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10000000149011612,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 716,
+        "exit_on_profit_after_bars": 761,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260325T052040807444Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260325T052040807444Z-521224",
+      "label": "RENDER 1h ao_zero_cross (Oracle sweep)",
+      "asset": "RENDER",
+      "timeframe": "1h",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260325T052040807444Z run_index 521224. Entry filters: adi_bullish. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "ao_zero_cross",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 15,
+            "window_slow": 20,
+            "direction": "bullish"
+          }
+        },
+        {
+          "name": "adi_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 38
+          }
+        }
+      ],
+      "exit_signals": [
+        {
+          "name": "rsi_cross_up",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 62,
+            "threshold": 13.3066
+          }
+        },
+        {
+          "name": "nvi_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 134
+          }
+        },
+        {
+          "name": "atr_high_volatility",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 27,
+            "threshold_pct": 7.0082
+          }
+        }
+      ],
+      "execution_config": {
+        "reward_factor": 3.7801051139831543,
+        "max_risk_per_trade": 0.02710999920964241,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10000000149011612,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 658,
+        "exit_on_profit_after_bars": 743,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260325T052040807444Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260325T052040807444Z-442453",
+      "label": "QNT 1h sma_cross_up (Oracle sweep)",
+      "asset": "QNT",
+      "timeframe": "1h",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260325T052040807444Z run_index 442453. Entry filters: force_bullish. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "sma_cross_up",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 43,
+            "window_slow": 91
+          }
+        },
+        {
+          "name": "force_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 8,
+            "threshold": 23.7469
+          }
+        }
+      ],
+      "exit_signals": [],
+      "execution_config": {
+        "reward_factor": 3.7872719764709473,
+        "max_risk_per_trade": 0.02214599959552288,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10000000149011612,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 658,
+        "exit_on_profit_after_bars": 781,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260325T052040807444Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260325T052040807444Z-99883",
+      "label": "ETH 5m bb_upper_breakout (Oracle sweep)",
+      "asset": "ETH",
+      "timeframe": "5m",
+      "category": "breakout",
+      "description": "Oracle sweep lineage: experiment exp_20260325T052040807444Z run_index 99883. Entry filters: vwap_above. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "bb_upper_breakout",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 70,
+            "window_dev": 5
+          }
+        },
+        {
+          "name": "vwap_above",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 34
+          }
+        }
+      ],
+      "exit_signals": [
+        {
+          "name": "rsi_cross_up",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 24,
+            "threshold": 26.454
+          }
+        },
+        {
+          "name": "ao_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "window_fast": 14,
+            "window_slow": 30,
+            "threshold": 53.2324
+          }
+        },
+        {
+          "name": "obv_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 33
+          }
+        }
+      ],
+      "execution_config": {
+        "reward_factor": 3.3583199977874756,
+        "max_risk_per_trade": 0.02359900064766407,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10000000149011612,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 850,
+        "exit_on_profit_after_bars": 780,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260325T052040807444Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260325T052040807444Z-141633",
+      "label": "ADA 5m mass_reversal_signal (Oracle sweep)",
+      "asset": "ADA",
+      "timeframe": "5m",
+      "category": "mean_reversion",
+      "description": "Oracle sweep lineage: experiment exp_20260325T052040807444Z run_index 141633. Entry filters: price_above_ema. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "mass_reversal_signal",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 11,
+            "window_slow": 28,
+            "threshold_high": 25.8315,
+            "threshold_low": 25.4185
+          }
+        },
+        {
+          "name": "price_above_ema",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 111
+          }
+        }
+      ],
+      "exit_signals": [],
+      "execution_config": {
+        "reward_factor": 3.4143850803375244,
+        "max_risk_per_trade": 0.01899299956858158,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10000000149011612,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 512,
+        "exit_on_profit_after_bars": 974,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260325T052040807444Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260325T052040807444Z-702887",
+      "label": "ALGO 5m wma_cross_up (Oracle sweep)",
+      "asset": "ALGO",
+      "timeframe": "5m",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260325T052040807444Z run_index 702887. Entry filters: atr_high_volatility. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "wma_cross_up",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 23,
+            "window_slow": 31
+          }
+        },
+        {
+          "name": "atr_high_volatility",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 25,
+            "threshold_pct": 0.805
+          }
+        }
+      ],
+      "exit_signals": [
+        {
+          "name": "rsi_cross_down",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 86,
+            "threshold": 62.2807
+          }
+        },
+        {
+          "name": "roc_negative",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 27,
+            "threshold": 9.554
+          }
+        },
+        {
+          "name": "daily_return_positive",
+          "signal_type": "FILTER",
+          "params": {
+            "threshold": 74.168
+          }
+        },
+        {
+          "name": "force_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 8,
+            "threshold": 14.7761
+          }
+        }
+      ],
+      "execution_config": {
+        "reward_factor": 3.0787670612335205,
+        "max_risk_per_trade": 0.035996001213788986,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10000000149011612,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 938,
+        "exit_on_profit_after_bars": 683,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260325T052040807444Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260325T052040807444Z-41106",
+      "label": "RENDER 1h macd_bullish_cross (Oracle sweep)",
+      "asset": "RENDER",
+      "timeframe": "1h",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260325T052040807444Z run_index 41106. Entry filters: price_above_ema. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "macd_bullish_cross",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 24,
+            "window_slow": 54,
+            "window_sign": 42
+          }
+        },
+        {
+          "name": "price_above_ema",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 136
+          }
+        }
+      ],
+      "exit_signals": [],
+      "execution_config": {
+        "reward_factor": 2.824863910675049,
+        "max_risk_per_trade": 0.03302000090479851,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10000000149011612,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 975,
+        "exit_on_profit_after_bars": 516,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260325T052040807444Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260320T174739679755Z-61726",
+      "label": "RENDER 1h wma_cross_down (Oracle sweep)",
+      "asset": "RENDER",
+      "timeframe": "1h",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260320T174739679755Z run_index 61726. Entry filters: eom_bearish. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "wma_cross_down",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 50,
+            "window_slow": 74
+          }
+        },
+        {
+          "name": "eom_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 5,
+            "threshold": 78.1736
+          }
+        }
+      ],
+      "exit_signals": [],
+      "execution_config": {
+        "reward_factor": 4.439002990722656,
+        "max_risk_per_trade": 0.025078000500798225,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.2740040123462677,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 1000,
+        "exit_on_profit_after_bars": 1000,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260320T174739679755Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260325T052040807444Z-284667",
+      "label": "RENDER 1h kc_upper_breakout (Oracle sweep)",
+      "asset": "RENDER",
+      "timeframe": "1h",
+      "category": "breakout",
+      "description": "Oracle sweep lineage: experiment exp_20260325T052040807444Z run_index 284667. Entry filters: roc_positive. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "kc_upper_breakout",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 10,
+            "window_atr": 20,
+            "multiplier": 0.9439,
+            "original_version": true
+          }
+        },
+        {
+          "name": "roc_positive",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 7,
+            "threshold": -6.9417
+          }
+        }
+      ],
+      "exit_signals": [],
+      "execution_config": {
+        "reward_factor": 2.7591331005096436,
+        "max_risk_per_trade": 0.02669600024819374,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10000000149011612,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 779,
+        "exit_on_profit_after_bars": 750,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260325T052040807444Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260325T052040807444Z-408294",
+      "label": "SUI 5m ema_cross_up (Oracle sweep)",
+      "asset": "SUI",
+      "timeframe": "5m",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260325T052040807444Z run_index 408294. Entry filters: ulcer_low_risk, psar_bearish. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "ema_cross_up",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 9,
+            "window_slow": 61
+          }
+        },
+        {
+          "name": "ulcer_low_risk",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 50,
+            "threshold": 5.7275
+          }
+        },
+        {
+          "name": "psar_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "step": 0.0434,
+            "max_step": 0.4741
+          }
+        }
+      ],
+      "exit_signals": [],
+      "execution_config": {
+        "reward_factor": 2.302701950073242,
+        "max_risk_per_trade": 0.024379000067710876,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10000000149011612,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 960,
+        "exit_on_profit_after_bars": 745,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260325T052040807444Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260320T174739679755Z-81121",
+      "label": "FET 1h pvo_bearish_cross (Oracle sweep)",
+      "asset": "FET",
+      "timeframe": "1h",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260320T174739679755Z run_index 81121. Entry filters: adx_bullish_di, aroon_up_trend, vwap_above. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "pvo_bearish_cross",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_slow": 26,
+            "window_fast": 5,
+            "window_sign": 8
+          }
+        },
+        {
+          "name": "adx_bullish_di",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 17
+          }
+        },
+        {
+          "name": "aroon_up_trend",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 23,
+            "threshold": 53.2528
+          }
+        },
+        {
+          "name": "vwap_above",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 37
+          }
+        }
+      ],
+      "exit_signals": [],
+      "execution_config": {
+        "reward_factor": 2.1046650409698486,
+        "max_risk_per_trade": 0.026892999187111855,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.1894419938325882,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 1000,
+        "exit_on_profit_after_bars": 1000,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260320T174739679755Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260325T052040807444Z-548596",
+      "label": "ADA 5m psar_reversal (Oracle sweep)",
+      "asset": "ADA",
+      "timeframe": "5m",
+      "category": "mean_reversion",
+      "description": "Oracle sweep lineage: experiment exp_20260325T052040807444Z run_index 548596. Entry filters: adx_bullish_di. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "psar_reversal",
+          "signal_type": "TRIGGER",
+          "params": {
+            "step": 0.0187,
+            "max_step": 0.2432,
+            "direction": "bullish"
+          }
+        },
+        {
+          "name": "adx_bullish_di",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 14
+          }
+        }
+      ],
+      "exit_signals": [],
+      "execution_config": {
+        "reward_factor": 3.6767539978027344,
+        "max_risk_per_trade": 0.018946999683976173,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10000000149011612,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 730,
+        "exit_on_profit_after_bars": 888,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260325T052040807444Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260325T052040807444Z-511501",
+      "label": "ADA 5m macd_bullish_cross (Oracle sweep)",
+      "asset": "ADA",
+      "timeframe": "5m",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260325T052040807444Z run_index 511501. Entry filters: stochrsi_overbought, price_above_ema. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "macd_bullish_cross",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 29,
+            "window_slow": 78,
+            "window_sign": 17
+          }
+        },
+        {
+          "name": "stochrsi_overbought",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 15,
+            "smooth1": 7,
+            "smooth2": 8,
+            "threshold": 0.9333
+          }
+        },
+        {
+          "name": "price_above_ema",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 133
+          }
+        }
+      ],
+      "exit_signals": [
+        {
+          "name": "mass_reversal_signal",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 13,
+            "window_slow": 33,
+            "threshold_high": 28.1039,
+            "threshold_low": 25.5394
+          }
+        },
+        {
+          "name": "williams_r_oversold",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 36,
+            "threshold": -87.0856
+          }
+        },
+        {
+          "name": "stochrsi_oversold",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 5,
+            "smooth1": 9,
+            "smooth2": 4,
+            "threshold": 0.3719
+          }
+        }
+      ],
+      "execution_config": {
+        "reward_factor": 3.208996057510376,
+        "max_risk_per_trade": 0.03581500053405762,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10000000149011612,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 506,
+        "exit_on_profit_after_bars": 645,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260325T052040807444Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260320T174739679755Z-26633",
+      "label": "FET 1h ao_zero_cross (Oracle sweep)",
+      "asset": "FET",
+      "timeframe": "1h",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260320T174739679755Z run_index 26633. Entry filters: ao_bearish, williams_r_overbought, obv_bullish. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "ao_zero_cross",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 11,
+            "window_slow": 56,
+            "direction": "bullish"
+          }
+        },
+        {
+          "name": "ao_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "window_fast": 4,
+            "window_slow": 46,
+            "threshold": 43.2337
+          }
+        },
+        {
+          "name": "williams_r_overbought",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 24,
+            "threshold": -29.9718
+          }
+        },
+        {
+          "name": "obv_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 47
+          }
+        }
+      ],
+      "exit_signals": [
+        {
+          "name": "ppo_bearish_cross",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_slow": 23,
+            "window_fast": 11,
+            "window_sign": 11
+          }
+        },
+        {
+          "name": "uo_overbought",
+          "signal_type": "FILTER",
+          "params": {
+            "window_short": 7,
+            "window_medium": 18,
+            "window_long": 20,
+            "threshold": 79.6909
+          }
+        },
+        {
+          "name": "cumulative_return_positive",
+          "signal_type": "FILTER",
+          "params": {
+            "threshold": 7.9631
+          }
+        },
+        {
+          "name": "cmf_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 40,
+            "threshold": -0.3059
+          }
+        }
+      ],
+      "execution_config": {
+        "reward_factor": 2.8154189586639404,
+        "max_risk_per_trade": 0.03512600064277649,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.266882985830307,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 1000,
+        "exit_on_profit_after_bars": 1000,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260320T174739679755Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260320T174739679755Z-43104",
+      "label": "ETH 15m roc_momentum_shift (Oracle sweep)",
+      "asset": "ETH",
+      "timeframe": "15m",
+      "category": "momentum",
+      "description": "Oracle sweep lineage: experiment exp_20260320T174739679755Z run_index 43104. Entry filters: is_above_sma. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "roc_momentum_shift",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 5,
+            "direction": "bullish"
+          }
+        },
+        {
+          "name": "is_above_sma",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 148
+          }
+        }
+      ],
+      "exit_signals": [],
+      "execution_config": {
+        "reward_factor": 4.630002021789551,
+        "max_risk_per_trade": 0.030740000307559967,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.28543999791145325,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 1000,
+        "exit_on_profit_after_bars": 1000,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260320T174739679755Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260325T052040807444Z-35951",
+      "label": "LINK 5m sma_cross_up (Oracle sweep)",
+      "asset": "LINK",
+      "timeframe": "5m",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260325T052040807444Z run_index 35951. Entry filters: obv_bullish, adx_strong_trend. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "sma_cross_up",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 93,
+            "window_slow": 94
+          }
+        },
+        {
+          "name": "obv_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 37
+          }
+        },
+        {
+          "name": "adx_strong_trend",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 25,
+            "threshold": 16.0997
+          }
+        }
+      ],
+      "exit_signals": [],
+      "execution_config": {
+        "reward_factor": 3.751405954360962,
+        "max_risk_per_trade": 0.012005999684333801,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10000000149011612,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 719,
+        "exit_on_profit_after_bars": 975,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260325T052040807444Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260325T052040807444Z-622129",
+      "label": "SUI 5m macd_bearish_cross (Oracle sweep)",
+      "asset": "SUI",
+      "timeframe": "5m",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260325T052040807444Z run_index 622129. Entry filters: ichimoku_bearish, obv_bullish. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "macd_bearish_cross",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 46,
+            "window_slow": 99,
+            "window_sign": 31
+          }
+        },
+        {
+          "name": "ichimoku_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "window_tenkan": 20,
+            "window_kijun": 37,
+            "window_senkou": 39
+          }
+        },
+        {
+          "name": "obv_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 11
+          }
+        }
+      ],
+      "exit_signals": [
+        {
+          "name": "kst_bullish_cross",
+          "signal_type": "TRIGGER",
+          "params": {
+            "roc1": 15,
+            "roc2": 79,
+            "roc3": 155,
+            "roc4": 65,
+            "window_sma1": 116,
+            "window_sma2": 105,
+            "window_sma3": 144,
+            "window_sma4": 78,
+            "nsig": 159
+          }
+        }
+      ],
+      "execution_config": {
+        "reward_factor": 3.2705159187316895,
+        "max_risk_per_trade": 0.032614000141620636,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10000000149011612,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 887,
+        "exit_on_profit_after_bars": 956,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260325T052040807444Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260325T052040807444Z-246856",
+      "label": "ADA 5m bb_lower_breakout (Oracle sweep)",
+      "asset": "ADA",
+      "timeframe": "5m",
+      "category": "breakout",
+      "description": "Oracle sweep lineage: experiment exp_20260325T052040807444Z run_index 246856. Entry filters: vortex_bearish. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "bb_lower_breakout",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 43,
+            "window_dev": 4
+          }
+        },
+        {
+          "name": "vortex_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 21
+          }
+        }
+      ],
+      "exit_signals": [],
+      "execution_config": {
+        "reward_factor": 3.9917991161346436,
+        "max_risk_per_trade": 0.022562000900506973,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10000000149011612,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 761,
+        "exit_on_profit_after_bars": 959,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260325T052040807444Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260325T052040807444Z-636153",
+      "label": "ADA 5m kc_lower_breakout (Oracle sweep)",
+      "asset": "ADA",
+      "timeframe": "5m",
+      "category": "breakout",
+      "description": "Oracle sweep lineage: experiment exp_20260325T052040807444Z run_index 636153. Entry filters: uo_oversold, nvi_bullish. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "kc_lower_breakout",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 16,
+            "window_atr": 30,
+            "multiplier": 1.1148,
+            "original_version": false
+          }
+        },
+        {
+          "name": "uo_oversold",
+          "signal_type": "FILTER",
+          "params": {
+            "window_short": 4,
+            "window_medium": 23,
+            "window_long": 14,
+            "threshold": 29.4557
+          }
+        },
+        {
+          "name": "nvi_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 179
+          }
+        }
+      ],
+      "exit_signals": [],
+      "execution_config": {
+        "reward_factor": 3.4600210189819336,
+        "max_risk_per_trade": 0.02664799988269806,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10000000149011612,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 534,
+        "exit_on_profit_after_bars": 509,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260325T052040807444Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260325T052040807444Z-130225",
+      "label": "DOT 5m bb_lower_breakout (Oracle sweep)",
+      "asset": "DOT",
+      "timeframe": "5m",
+      "category": "breakout",
+      "description": "Oracle sweep lineage: experiment exp_20260325T052040807444Z run_index 130225. Entry filters: stoch_oversold, cci_oversold, ulcer_low_risk. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "bb_lower_breakout",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 74,
+            "window_dev": 3
+          }
+        },
+        {
+          "name": "stoch_oversold",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 15,
+            "smooth_window": 8,
+            "threshold": 18.566
+          }
+        },
+        {
+          "name": "cci_oversold",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 31,
+            "constant": 0.0051,
+            "threshold": -154.4854
+          }
+        },
+        {
+          "name": "ulcer_low_risk",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 14,
+            "threshold": 6.6166
+          }
+        }
+      ],
+      "exit_signals": [],
+      "execution_config": {
+        "reward_factor": 1.9482150077819824,
+        "max_risk_per_trade": 0.019946999847888947,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10000000149011612,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 718,
+        "exit_on_profit_after_bars": 920,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260325T052040807444Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260325T052040807444Z-83135",
+      "label": "RENDER 1h pvo_bullish_cross (Oracle sweep)",
+      "asset": "RENDER",
+      "timeframe": "1h",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260325T052040807444Z run_index 83135. Entry filters: vortex_bullish, dpo_negative. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "pvo_bullish_cross",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_slow": 33,
+            "window_fast": 12,
+            "window_sign": 3
+          }
+        },
+        {
+          "name": "vortex_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 16
+          }
+        },
+        {
+          "name": "dpo_negative",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 44
+          }
+        }
+      ],
+      "exit_signals": [
+        {
+          "name": "psar_reversal",
+          "signal_type": "TRIGGER",
+          "params": {
+            "step": 0.0517,
+            "max_step": 0.2273,
+            "direction": "bullish"
+          }
+        },
+        {
+          "name": "force_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 16,
+            "threshold": 83.0513
+          }
+        }
+      ],
+      "execution_config": {
+        "reward_factor": 2.851490020751953,
+        "max_risk_per_trade": 0.030307000502943993,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10000000149011612,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 671,
+        "exit_on_profit_after_bars": 968,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260325T052040807444Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260320T174739679755Z-77606",
+      "label": "XLM 15m kc_upper_breakout (Oracle sweep)",
+      "asset": "XLM",
+      "timeframe": "15m",
+      "category": "breakout",
+      "description": "Oracle sweep lineage: experiment exp_20260320T174739679755Z run_index 77606. Entry filters: vwap_above, psar_bullish. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "kc_upper_breakout",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 14,
+            "window_atr": 23,
+            "multiplier": 1.3439,
+            "original_version": false
+          }
+        },
+        {
+          "name": "vwap_above",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 19
+          }
+        },
+        {
+          "name": "psar_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "step": 0.0351,
+            "max_step": 0.3816
+          }
+        }
+      ],
+      "exit_signals": [
+        {
+          "name": "ppo_bullish_cross",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_slow": 37,
+            "window_fast": 20,
+            "window_sign": 12
+          }
+        },
+        {
+          "name": "vortex_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 7
+          }
+        },
+        {
+          "name": "macd_positive",
+          "signal_type": "FILTER",
+          "params": {
+            "window_fast": 44,
+            "window_slow": 99,
+            "window_sign": 28
+          }
+        }
+      ],
+      "execution_config": {
+        "reward_factor": 2.3748888969421387,
+        "max_risk_per_trade": 0.025529000908136368,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.1392430067062378,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 1000,
+        "exit_on_profit_after_bars": 1000,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260320T174739679755Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260320T174739679755Z-2040",
+      "label": "APT 1h kama_cross_down (Oracle sweep)",
+      "asset": "APT",
+      "timeframe": "1h",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260320T174739679755Z run_index 2040. Entry filters: psar_bearish, trix_bearish, obv_bullish. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "kama_cross_down",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 28,
+            "pow1": 5,
+            "pow2": 45
+          }
+        },
+        {
+          "name": "psar_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "step": 0.0621,
+            "max_step": 0.1946
+          }
+        },
+        {
+          "name": "trix_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 30,
+            "threshold": 35.5202
+          }
+        },
+        {
+          "name": "obv_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 16
+          }
+        }
+      ],
+      "exit_signals": [
+        {
+          "name": "bb_lower_breakout",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 5,
+            "window_dev": 4
+          }
+        }
+      ],
+      "execution_config": {
+        "reward_factor": 3.509766101837158,
+        "max_risk_per_trade": 0.037167999893426895,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.23260599374771118,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 1000,
+        "exit_on_profit_after_bars": 1000,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260320T174739679755Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260325T052040807444Z-638159",
+      "label": "ADA 5m kc_upper_breakout (Oracle sweep)",
+      "asset": "ADA",
+      "timeframe": "5m",
+      "category": "breakout",
+      "description": "Oracle sweep lineage: experiment exp_20260325T052040807444Z run_index 638159. Entry filters: force_bearish, dpo_positive. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "kc_upper_breakout",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 39,
+            "window_atr": 23,
+            "multiplier": 3.0095,
+            "original_version": true
+          }
+        },
+        {
+          "name": "force_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 13,
+            "threshold": 25.496
+          }
+        },
+        {
+          "name": "dpo_positive",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 27
+          }
+        }
+      ],
+      "exit_signals": [
+        {
+          "name": "bb_squeeze",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 52,
+            "window_dev": 3,
+            "threshold": 15.1436
+          }
+        }
+      ],
+      "execution_config": {
+        "reward_factor": 1.6444580554962158,
+        "max_risk_per_trade": 0.022786999121308327,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10000000149011612,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 664,
+        "exit_on_profit_after_bars": 887,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260325T052040807444Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260320T174739679755Z-12104",
+      "label": "M 1h ppo_bullish_cross (Oracle sweep)",
+      "asset": "M",
+      "timeframe": "1h",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260320T174739679755Z run_index 12104. Entry filters: nvi_bearish, ichimoku_bearish. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "ppo_bullish_cross",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_slow": 39,
+            "window_fast": 20,
+            "window_sign": 5
+          }
+        },
+        {
+          "name": "nvi_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 183
+          }
+        },
+        {
+          "name": "ichimoku_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "window_tenkan": 13,
+            "window_kijun": 32,
+            "window_senkou": 61
+          }
+        }
+      ],
+      "exit_signals": [],
+      "execution_config": {
+        "reward_factor": 2.637990951538086,
+        "max_risk_per_trade": 0.03093400038778782,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.16950200498104095,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 1000,
+        "exit_on_profit_after_bars": 1000,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260320T174739679755Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260325T052040807444Z-724343",
+      "label": "RENDER 1h rsi_cross_up (Oracle sweep)",
+      "asset": "RENDER",
+      "timeframe": "1h",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260325T052040807444Z run_index 724343. Entry filters: psar_bearish. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "rsi_cross_up",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 43,
+            "threshold": 50.3061
+          }
+        },
+        {
+          "name": "psar_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "step": 0.0295,
+            "max_step": 0.2305
+          }
+        }
+      ],
+      "exit_signals": [],
+      "execution_config": {
+        "reward_factor": 3.491641044616699,
+        "max_risk_per_trade": 0.02556000091135502,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10000000149011612,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 672,
+        "exit_on_profit_after_bars": 793,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260325T052040807444Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260325T052040807444Z-235537",
+      "label": "XLM 1h ichimoku_tk_cross (Oracle sweep)",
+      "asset": "XLM",
+      "timeframe": "1h",
+      "category": "breakout",
+      "description": "Oracle sweep lineage: experiment exp_20260325T052040807444Z run_index 235537. Entry filters: psar_bullish. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "ichimoku_tk_cross",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_tenkan": 6,
+            "window_kijun": 18,
+            "window_senkou": 67,
+            "direction": "bullish"
+          }
+        },
+        {
+          "name": "psar_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "step": 0.0448,
+            "max_step": 0.4047
+          }
+        }
+      ],
+      "exit_signals": [],
+      "execution_config": {
+        "reward_factor": 3.016321897506714,
+        "max_risk_per_trade": 0.02979999966919422,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10000000149011612,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 801,
+        "exit_on_profit_after_bars": 844,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260325T052040807444Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260320T174739679755Z-46194",
+      "label": "SUI 5m aroon_crossover (Oracle sweep)",
+      "asset": "SUI",
+      "timeframe": "5m",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260320T174739679755Z run_index 46194. Entry filters: adx_strong_trend, ulcer_low_risk. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "aroon_crossover",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 41,
+            "direction": "bullish"
+          }
+        },
+        {
+          "name": "adx_strong_trend",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 48,
+            "threshold": 36.9884
+          }
+        },
+        {
+          "name": "ulcer_low_risk",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 21,
+            "threshold": 13.18
+          }
+        }
+      ],
+      "exit_signals": [],
+      "execution_config": {
+        "reward_factor": 4.0176849365234375,
+        "max_risk_per_trade": 0.02145799994468689,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10583099722862244,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 1000,
+        "exit_on_profit_after_bars": 1000,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260320T174739679755Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260325T052040807444Z-490717",
+      "label": "ADA 5m ema_cross_up (Oracle sweep)",
+      "asset": "ADA",
+      "timeframe": "5m",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260325T052040807444Z run_index 490717. Entry filters: macd_positive. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "ema_cross_up",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 77,
+            "window_slow": 161
+          }
+        },
+        {
+          "name": "macd_positive",
+          "signal_type": "FILTER",
+          "params": {
+            "window_fast": 42,
+            "window_slow": 75,
+            "window_sign": 22
+          }
+        }
+      ],
+      "exit_signals": [
+        {
+          "name": "kama_cross_down",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 13,
+            "pow1": 4,
+            "pow2": 46
+          }
+        },
+        {
+          "name": "stoch_overbought",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 15,
+            "smooth_window": 2,
+            "threshold": 79.9906
+          }
+        },
+        {
+          "name": "stochrsi_oversold",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 19,
+            "smooth1": 10,
+            "smooth2": 9,
+            "threshold": 0.1505
+          }
+        }
+      ],
+      "execution_config": {
+        "reward_factor": 2.7852559089660645,
+        "max_risk_per_trade": 0.015174999833106995,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10000000149011612,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 786,
+        "exit_on_profit_after_bars": 679,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260325T052040807444Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260320T174739679755Z-34267",
+      "label": "XLM 5m dc_lower_breakout (Oracle sweep)",
+      "asset": "XLM",
+      "timeframe": "5m",
+      "category": "breakout",
+      "description": "Oracle sweep lineage: experiment exp_20260320T174739679755Z run_index 34267. Entry filters: nvi_bearish, obv_bullish. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "dc_lower_breakout",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 41
+          }
+        },
+        {
+          "name": "nvi_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 285
+          }
+        },
+        {
+          "name": "obv_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 5
+          }
+        }
+      ],
+      "exit_signals": [
+        {
+          "name": "sma_cross_up",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 75,
+            "window_slow": 471
+          }
+        },
+        {
+          "name": "cci_oversold",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 37,
+            "constant": 0.0997,
+            "threshold": -160.0551
+          }
+        },
+        {
+          "name": "force_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 5,
+            "threshold": 36.3775
+          }
+        },
+        {
+          "name": "ulcer_low_risk",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 29,
+            "threshold": 9.1368
+          }
+        }
+      ],
+      "execution_config": {
+        "reward_factor": 2.7262020111083984,
+        "max_risk_per_trade": 0.0311840008944273,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.15830999612808228,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 1000,
+        "exit_on_profit_after_bars": 1000,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260320T174739679755Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260320T174739679755Z-45801",
+      "label": "VIRTUAL 1h bb_lower_breakout (Oracle sweep)",
+      "asset": "VIRTUAL",
+      "timeframe": "1h",
+      "category": "breakout",
+      "description": "Oracle sweep lineage: experiment exp_20260320T174739679755Z run_index 45801. Entry filters: roc_negative. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "bb_lower_breakout",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 97,
+            "window_dev": 1
+          }
+        },
+        {
+          "name": "roc_negative",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 8,
+            "threshold": 6.3866
+          }
+        }
+      ],
+      "exit_signals": [],
+      "execution_config": {
+        "reward_factor": 4.707971096038818,
+        "max_risk_per_trade": 0.03223799914121628,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.2762640118598938,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 1000,
+        "exit_on_profit_after_bars": 1000,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260320T174739679755Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260320T174739679755Z-29826",
+      "label": "XRP 5m sma_cross_up (Oracle sweep)",
+      "asset": "XRP",
+      "timeframe": "5m",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260320T174739679755Z run_index 29826. Entry filters: adx_bullish_di. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "sma_cross_up",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 82,
+            "window_slow": 126
+          }
+        },
+        {
+          "name": "adx_bullish_di",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 20
+          }
+        }
+      ],
+      "exit_signals": [],
+      "execution_config": {
+        "reward_factor": 2.657651901245117,
+        "max_risk_per_trade": 0.029294999316334724,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.26324599981307983,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 1000,
+        "exit_on_profit_after_bars": 1000,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260320T174739679755Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260320T174739679755Z-10292",
+      "label": "AAVE 5m bb_upper_breakout (Oracle sweep)",
+      "asset": "AAVE",
+      "timeframe": "5m",
+      "category": "breakout",
+      "description": "Oracle sweep lineage: experiment exp_20260320T174739679755Z run_index 10292. Entry filters: adi_bearish, nvi_bearish. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "bb_upper_breakout",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 57,
+            "window_dev": 2
+          }
+        },
+        {
+          "name": "adi_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 46
+          }
+        },
+        {
+          "name": "nvi_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 141
+          }
+        }
+      ],
+      "exit_signals": [],
+      "execution_config": {
+        "reward_factor": 3.423830986022949,
+        "max_risk_per_trade": 0.030493000522255898,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.18872499465942383,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 1000,
+        "exit_on_profit_after_bars": 1000,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260320T174739679755Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260325T052040807444Z-339450",
+      "label": "XLM 1h pvo_bullish_cross (Oracle sweep)",
+      "asset": "XLM",
+      "timeframe": "1h",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260325T052040807444Z run_index 339450. Entry filters: vpt_bullish. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "pvo_bullish_cross",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_slow": 27,
+            "window_fast": 5,
+            "window_sign": 7
+          }
+        },
+        {
+          "name": "vpt_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 45
+          }
+        }
+      ],
+      "exit_signals": [
+        {
+          "name": "wma_cross_up",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 25,
+            "window_slow": 72
+          }
+        },
+        {
+          "name": "vortex_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 10
+          }
+        },
+        {
+          "name": "cumulative_return_positive",
+          "signal_type": "FILTER",
+          "params": {
+            "threshold": 96.5873
+          }
+        },
+        {
+          "name": "vpt_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 26
+          }
+        }
+      ],
+      "execution_config": {
+        "reward_factor": 2.9928250312805176,
+        "max_risk_per_trade": 0.03556400164961815,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10000000149011612,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 997,
+        "exit_on_profit_after_bars": 859,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260325T052040807444Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260313T014209439318Z-43740",
+      "label": "XRP 15m rsi_cross_up (Oracle sweep)",
+      "asset": "XRP",
+      "timeframe": "15m",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260313T014209439318Z run_index 43740. Entry filters: trix_bearish. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "rsi_cross_up",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 72,
+            "threshold": 64.1976
+          }
+        },
+        {
+          "name": "trix_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 9,
+            "threshold": 0.5673
+          }
+        }
+      ],
+      "exit_signals": [],
+      "execution_config": {
+        "reward_factor": 4.0,
+        "max_risk_per_trade": 0.022081000730395317,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.19094699621200562,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 10000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 1000,
+        "exit_on_profit_after_bars": 1000,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260313T014209439318Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260325T052040807444Z-340741",
+      "label": "ADA 5m bb_squeeze (Oracle sweep)",
+      "asset": "ADA",
+      "timeframe": "5m",
+      "category": "volatility",
+      "description": "Oracle sweep lineage: experiment exp_20260325T052040807444Z run_index 340741. Entry filters: adx_strong_trend, aroon_down_trend, cmf_bullish. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "bb_squeeze",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 33,
+            "window_dev": 3,
+            "threshold": 10.317
+          }
+        },
+        {
+          "name": "adx_strong_trend",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 18,
+            "threshold": 25.9233
+          }
+        },
+        {
+          "name": "aroon_down_trend",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 14,
+            "threshold": 53.7956
+          }
+        },
+        {
+          "name": "cmf_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 10,
+            "threshold": -0.6185
+          }
+        }
+      ],
+      "exit_signals": [],
+      "execution_config": {
+        "reward_factor": 3.58240008354187,
+        "max_risk_per_trade": 0.02871599979698658,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10000000149011612,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 595,
+        "exit_on_profit_after_bars": 960,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260325T052040807444Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260320T174739679755Z-44898",
+      "label": "FET 1h kama_cross_down (Oracle sweep)",
+      "asset": "FET",
+      "timeframe": "1h",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260320T174739679755Z run_index 44898. Entry filters: nvi_bearish, psar_bearish, cmf_bullish. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "kama_cross_down",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 24,
+            "pow1": 2,
+            "pow2": 50
+          }
+        },
+        {
+          "name": "nvi_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 199
+          }
+        },
+        {
+          "name": "psar_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "step": 0.0282,
+            "max_step": 0.4847
+          }
+        },
+        {
+          "name": "cmf_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 17,
+            "threshold": -0.5344
+          }
+        }
+      ],
+      "exit_signals": [],
+      "execution_config": {
+        "reward_factor": 3.9308290481567383,
+        "max_risk_per_trade": 0.013433000072836876,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.11534400284290314,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 1000,
+        "exit_on_profit_after_bars": 1000,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260320T174739679755Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260325T052040807444Z-121698",
+      "label": "RENDER 1h kst_bullish_cross (Oracle sweep)",
+      "asset": "RENDER",
+      "timeframe": "1h",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260325T052040807444Z run_index 121698. Entry filters: is_above_sma. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "kst_bullish_cross",
+          "signal_type": "TRIGGER",
+          "params": {
+            "roc1": 67,
+            "roc2": 50,
+            "roc3": 60,
+            "roc4": 63,
+            "window_sma1": 2,
+            "window_sma2": 122,
+            "window_sma3": 32,
+            "window_sma4": 10,
+            "nsig": 12
+          }
+        },
+        {
+          "name": "is_above_sma",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 168
+          }
+        }
+      ],
+      "exit_signals": [
+        {
+          "name": "ema_cross_up",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 34,
+            "window_slow": 90
+          }
+        },
+        {
+          "name": "stc_overbought",
+          "signal_type": "FILTER",
+          "params": {
+            "window_slow": 172,
+            "window_fast": 83,
+            "cycle": 144,
+            "smooth1": 196,
+            "smooth2": 64,
+            "threshold": 65.4768
+          }
+        },
+        {
+          "name": "daily_return_positive",
+          "signal_type": "FILTER",
+          "params": {
+            "threshold": 78.862
+          }
+        },
+        {
+          "name": "uo_oversold",
+          "signal_type": "FILTER",
+          "params": {
+            "window_short": 7,
+            "window_medium": 25,
+            "window_long": 33,
+            "threshold": 22.276
+          }
+        }
+      ],
+      "execution_config": {
+        "reward_factor": 3.8347480297088623,
+        "max_risk_per_trade": 0.033190999180078506,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10000000149011612,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 971,
+        "exit_on_profit_after_bars": 861,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260325T052040807444Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260325T052040807444Z-560323",
+      "label": "RENDER 1h ema_cross_up (Oracle sweep)",
+      "asset": "RENDER",
+      "timeframe": "1h",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260325T052040807444Z run_index 560323. Entry filters: eom_bearish. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "ema_cross_up",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 80,
+            "window_slow": 122
+          }
+        },
+        {
+          "name": "eom_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 5,
+            "threshold": 5.3082
+          }
+        }
+      ],
+      "exit_signals": [
+        {
+          "name": "roc_momentum_shift",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 45,
+            "direction": "bullish"
+          }
+        },
+        {
+          "name": "ulcer_high_risk",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 34,
+            "threshold": 12.4247
+          }
+        }
+      ],
+      "execution_config": {
+        "reward_factor": 3.2017199993133545,
+        "max_risk_per_trade": 0.03873400017619133,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10000000149011612,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 984,
+        "exit_on_profit_after_bars": 834,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260325T052040807444Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260325T052040807444Z-202793",
+      "label": "SUI 5m bb_upper_breakout (Oracle sweep)",
+      "asset": "SUI",
+      "timeframe": "5m",
+      "category": "breakout",
+      "description": "Oracle sweep lineage: experiment exp_20260325T052040807444Z run_index 202793. Entry filters: aroon_up_trend. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "bb_upper_breakout",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 87,
+            "window_dev": 4
+          }
+        },
+        {
+          "name": "aroon_up_trend",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 28,
+            "threshold": 53.3343
+          }
+        }
+      ],
+      "exit_signals": [
+        {
+          "name": "bb_squeeze",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 50,
+            "window_dev": 4,
+            "threshold": 8.2275
+          }
+        },
+        {
+          "name": "vortex_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 8
+          }
+        },
+        {
+          "name": "eom_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 30,
+            "threshold": 27.1266
+          }
+        }
+      ],
+      "execution_config": {
+        "reward_factor": 3.339569091796875,
+        "max_risk_per_trade": 0.018657999113202095,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10000000149011612,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 895,
+        "exit_on_profit_after_bars": 624,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260325T052040807444Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260320T174739679755Z-22731",
+      "label": "TAO 1h aroon_crossover (Oracle sweep)",
+      "asset": "TAO",
+      "timeframe": "1h",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260320T174739679755Z run_index 22731. Entry filters: stochrsi_overbought, nvi_bearish. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "aroon_crossover",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 33,
+            "direction": "bullish"
+          }
+        },
+        {
+          "name": "stochrsi_overbought",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 20,
+            "smooth1": 5,
+            "smooth2": 9,
+            "threshold": 0.756
+          }
+        },
+        {
+          "name": "nvi_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 113
+          }
+        }
+      ],
+      "exit_signals": [
+        {
+          "name": "bb_squeeze",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 99,
+            "window_dev": 2,
+            "threshold": 17.0898
+          }
+        },
+        {
+          "name": "daily_return_negative",
+          "signal_type": "FILTER",
+          "params": {
+            "threshold": 54.8963
+          }
+        },
+        {
+          "name": "williams_r_overbought",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 19,
+            "threshold": -7.6476
+          }
+        },
+        {
+          "name": "vortex_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 5
+          }
+        }
+      ],
+      "execution_config": {
+        "reward_factor": 3.729901075363159,
+        "max_risk_per_trade": 0.029319999739527702,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.25892001390457153,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 1000,
+        "exit_on_profit_after_bars": 1000,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260320T174739679755Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260320T174739679755Z-29111",
+      "label": "MORPHO 1h rsi_cross_up (Oracle sweep)",
+      "asset": "MORPHO",
+      "timeframe": "1h",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260320T174739679755Z run_index 29111. Entry filters: psar_bearish. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "rsi_cross_up",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 27,
+            "threshold": 23.9308
+          }
+        },
+        {
+          "name": "psar_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "step": 0.0563,
+            "max_step": 0.2817
+          }
+        }
+      ],
+      "exit_signals": [],
+      "execution_config": {
+        "reward_factor": 4.542098045349121,
+        "max_risk_per_trade": 0.031599998474121094,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.2796950042247772,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 1000,
+        "exit_on_profit_after_bars": 1000,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260320T174739679755Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260320T174739679755Z-74129",
+      "label": "M 1h sma_cross_up (Oracle sweep)",
+      "asset": "M",
+      "timeframe": "1h",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260320T174739679755Z run_index 74129. Entry filters: price_above_ema. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "sma_cross_up",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 102,
+            "window_slow": 115
+          }
+        },
+        {
+          "name": "price_above_ema",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 129
+          }
+        }
+      ],
+      "exit_signals": [
+        {
+          "name": "kc_lower_breakout",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 36,
+            "window_atr": 21,
+            "multiplier": 3.6611,
+            "original_version": false
+          }
+        }
+      ],
+      "execution_config": {
+        "reward_factor": 1.9241290092468262,
+        "max_risk_per_trade": 0.028178000822663307,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.2694289982318878,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 1000,
+        "exit_on_profit_after_bars": 1000,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260320T174739679755Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260320T174739679755Z-31256",
+      "label": "CAKE 1h ppo_bullish_cross (Oracle sweep)",
+      "asset": "CAKE",
+      "timeframe": "1h",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260320T174739679755Z run_index 31256. Entry filters: force_bearish. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "ppo_bullish_cross",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_slow": 43,
+            "window_fast": 17,
+            "window_sign": 7
+          }
+        },
+        {
+          "name": "force_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 30,
+            "threshold": 9.8214
+          }
+        }
+      ],
+      "exit_signals": [
+        {
+          "name": "ema_crossover",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 77,
+            "window_slow": 129,
+            "direction": "bullish"
+          }
+        },
+        {
+          "name": "vortex_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 19
+          }
+        }
+      ],
+      "execution_config": {
+        "reward_factor": 4.233036994934082,
+        "max_risk_per_trade": 0.01747100055217743,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.1604360044002533,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 1000,
+        "exit_on_profit_after_bars": 1000,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260320T174739679755Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260320T174739679755Z-68256",
+      "label": "DOT 15m psar_reversal (Oracle sweep)",
+      "asset": "DOT",
+      "timeframe": "15m",
+      "category": "mean_reversion",
+      "description": "Oracle sweep lineage: experiment exp_20260320T174739679755Z run_index 68256. Entry filters: vpt_bullish, atr_high_volatility. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "psar_reversal",
+          "signal_type": "TRIGGER",
+          "params": {
+            "step": 0.0784,
+            "max_step": 0.1581,
+            "direction": "bullish"
+          }
+        },
+        {
+          "name": "vpt_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 6
+          }
+        },
+        {
+          "name": "atr_high_volatility",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 41,
+            "threshold_pct": 3.3731
+          }
+        }
+      ],
+      "exit_signals": [],
+      "execution_config": {
+        "reward_factor": 4.15733003616333,
+        "max_risk_per_trade": 0.025738999247550964,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.20271900296211243,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 1000,
+        "exit_on_profit_after_bars": 1000,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260320T174739679755Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260325T052040807444Z-47585",
+      "label": "RENDER 1h kc_upper_breakout (Oracle sweep)",
+      "asset": "RENDER",
+      "timeframe": "1h",
+      "category": "breakout",
+      "description": "Oracle sweep lineage: experiment exp_20260325T052040807444Z run_index 47585. Entry filters: adx_strong_trend, aroon_up_trend. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "kc_upper_breakout",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 33,
+            "window_atr": 18,
+            "multiplier": 4.5615,
+            "original_version": false
+          }
+        },
+        {
+          "name": "adx_strong_trend",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 8,
+            "threshold": 16.2529
+          }
+        },
+        {
+          "name": "aroon_up_trend",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 49,
+            "threshold": 77.5456
+          }
+        }
+      ],
+      "exit_signals": [],
+      "execution_config": {
+        "reward_factor": 2.515162944793701,
+        "max_risk_per_trade": 0.02194100059568882,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10000000149011612,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 703,
+        "exit_on_profit_after_bars": 654,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260325T052040807444Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260320T174739679755Z-21559",
+      "label": "ETH 30m dc_upper_breakout (Oracle sweep)",
+      "asset": "ETH",
+      "timeframe": "30m",
+      "category": "breakout",
+      "description": "Oracle sweep lineage: experiment exp_20260320T174739679755Z run_index 21559. Entry filters: force_bullish, aroon_up_trend. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "dc_upper_breakout",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 64
+          }
+        },
+        {
+          "name": "force_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 21,
+            "threshold": 28.3081
+          }
+        },
+        {
+          "name": "aroon_up_trend",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 45,
+            "threshold": 66.837
+          }
+        }
+      ],
+      "exit_signals": [
+        {
+          "name": "dc_lower_breakout",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 35
+          }
+        },
+        {
+          "name": "vpt_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 27
+          }
+        },
+        {
+          "name": "cumulative_return_positive",
+          "signal_type": "FILTER",
+          "params": {
+            "threshold": 15.7218
+          }
+        },
+        {
+          "name": "roc_negative",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 21,
+            "threshold": 0.7272
+          }
+        }
+      ],
+      "execution_config": {
+        "reward_factor": 4.672537803649902,
+        "max_risk_per_trade": 0.037870001047849655,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.14048799872398376,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 1000,
+        "exit_on_profit_after_bars": 1000,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260320T174739679755Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260320T174739679755Z-20351",
+      "label": "ALGO 15m kama_cross_down (Oracle sweep)",
+      "asset": "ALGO",
+      "timeframe": "15m",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260320T174739679755Z run_index 20351. Entry filters: adx_strong_trend, dpo_positive. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "kama_cross_down",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 7,
+            "pow1": 8,
+            "pow2": 28
+          }
+        },
+        {
+          "name": "adx_strong_trend",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 43,
+            "threshold": 29.0241
+          }
+        },
+        {
+          "name": "dpo_positive",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 21
+          }
+        }
+      ],
+      "exit_signals": [
+        {
+          "name": "aroon_crossover",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 44,
+            "direction": "bullish"
+          }
+        },
+        {
+          "name": "ao_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "window_fast": 2,
+            "window_slow": 26,
+            "threshold": 18.4812
+          }
+        },
+        {
+          "name": "ulcer_high_risk",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 9,
+            "threshold": 25.6781
+          }
+        },
+        {
+          "name": "cmf_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 49,
+            "threshold": 0.3534
+          }
+        }
+      ],
+      "execution_config": {
+        "reward_factor": 3.69051194190979,
+        "max_risk_per_trade": 0.02701600082218647,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.1790429949760437,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 1000,
+        "exit_on_profit_after_bars": 1000,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260320T174739679755Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260325T052040807444Z-170725",
+      "label": "RENDER 1h ema_cross_up (Oracle sweep)",
+      "asset": "RENDER",
+      "timeframe": "1h",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260325T052040807444Z run_index 170725. Entry filters: dpo_positive. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "ema_cross_up",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 93,
+            "window_slow": 111
+          }
+        },
+        {
+          "name": "dpo_positive",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 27
+          }
+        }
+      ],
+      "exit_signals": [
+        {
+          "name": "sma_cross_up",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 70,
+            "window_slow": 178
+          }
+        },
+        {
+          "name": "roc_negative",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 27,
+            "threshold": 7.6056
+          }
+        }
+      ],
+      "execution_config": {
+        "reward_factor": 2.848360061645508,
+        "max_risk_per_trade": 0.035048000514507294,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10000000149011612,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 563,
+        "exit_on_profit_after_bars": 540,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260325T052040807444Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260325T052040807444Z-305628",
+      "label": "BTC 5m ema_cross_down (Oracle sweep)",
+      "asset": "BTC",
+      "timeframe": "5m",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260325T052040807444Z run_index 305628. Entry filters: nvi_bullish. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "ema_cross_down",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 77,
+            "window_slow": 100
+          }
+        },
+        {
+          "name": "nvi_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 107
+          }
+        }
+      ],
+      "exit_signals": [],
+      "execution_config": {
+        "reward_factor": 3.915040969848633,
+        "max_risk_per_trade": 0.031137999147176743,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10000000149011612,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 772,
+        "exit_on_profit_after_bars": 758,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260325T052040807444Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260325T052040807444Z-617806",
+      "label": "ADA 5m vortex_crossover (Oracle sweep)",
+      "asset": "ADA",
+      "timeframe": "5m",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260325T052040807444Z run_index 617806. Entry filters: obv_bearish, vortex_bearish. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "vortex_crossover",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 28,
+            "direction": "bullish"
+          }
+        },
+        {
+          "name": "obv_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 29
+          }
+        },
+        {
+          "name": "vortex_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 8
+          }
+        }
+      ],
+      "exit_signals": [
+        {
+          "name": "aroon_crossover",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 28,
+            "direction": "bullish"
+          }
+        },
+        {
+          "name": "nvi_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 178
+          }
+        }
+      ],
+      "execution_config": {
+        "reward_factor": 3.686086893081665,
+        "max_risk_per_trade": 0.017726000398397446,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10000000149011612,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 750,
+        "exit_on_profit_after_bars": 863,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260325T052040807444Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260320T174739679755Z-70919",
+      "label": "FET 1h ao_zero_cross (Oracle sweep)",
+      "asset": "FET",
+      "timeframe": "1h",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260320T174739679755Z run_index 70919. Entry filters: mfi_overbought, nvi_bullish, eom_bearish. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "ao_zero_cross",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 7,
+            "window_slow": 31,
+            "direction": "bullish"
+          }
+        },
+        {
+          "name": "mfi_overbought",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 7,
+            "threshold": 80.142
+          }
+        },
+        {
+          "name": "nvi_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 139
+          }
+        },
+        {
+          "name": "eom_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 15,
+            "threshold": 74.2441
+          }
+        }
+      ],
+      "exit_signals": [],
+      "execution_config": {
+        "reward_factor": 4.284186840057373,
+        "max_risk_per_trade": 0.03393099829554558,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.21305100619792938,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 1000,
+        "exit_on_profit_after_bars": 1000,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260320T174739679755Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260320T174739679755Z-47449",
+      "label": "FET 1h bb_squeeze (Oracle sweep)",
+      "asset": "FET",
+      "timeframe": "1h",
+      "category": "volatility",
+      "description": "Oracle sweep lineage: experiment exp_20260320T174739679755Z run_index 47449. Entry filters: force_bullish. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "bb_squeeze",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 10,
+            "window_dev": 3,
+            "threshold": 16.8304
+          }
+        },
+        {
+          "name": "force_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 29,
+            "threshold": 27.6796
+          }
+        }
+      ],
+      "exit_signals": [],
+      "execution_config": {
+        "reward_factor": 3.281208038330078,
+        "max_risk_per_trade": 0.023114999756217003,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.2291650027036667,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 1000,
+        "exit_on_profit_after_bars": 1000,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260320T174739679755Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260320T174739679755Z-37584",
+      "label": "M 1h roc_momentum_shift (Oracle sweep)",
+      "asset": "M",
+      "timeframe": "1h",
+      "category": "momentum",
+      "description": "Oracle sweep lineage: experiment exp_20260320T174739679755Z run_index 37584. Entry filters: dpo_negative. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "roc_momentum_shift",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 35,
+            "direction": "bullish"
+          }
+        },
+        {
+          "name": "dpo_negative",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 30
+          }
+        }
+      ],
+      "exit_signals": [
+        {
+          "name": "macd_bullish_cross",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window_fast": 32,
+            "window_slow": 62,
+            "window_sign": 8
+          }
+        },
+        {
+          "name": "cmf_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 38,
+            "threshold": 0.3968
+          }
+        },
+        {
+          "name": "stc_overbought",
+          "signal_type": "FILTER",
+          "params": {
+            "window_slow": 138,
+            "window_fast": 73,
+            "cycle": 77,
+            "smooth1": 7,
+            "smooth2": 21,
+            "threshold": 62.3027
+          }
+        },
+        {
+          "name": "aroon_down_trend",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 37,
+            "threshold": 93.0871
+          }
+        }
+      ],
+      "execution_config": {
+        "reward_factor": 4.294212818145752,
+        "max_risk_per_trade": 0.030079999938607216,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.24776199460029602,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 1000,
+        "exit_on_profit_after_bars": 1000,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260320T174739679755Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260325T052040807444Z-240917",
+      "label": "RENDER 1h vortex_crossover (Oracle sweep)",
+      "asset": "RENDER",
+      "timeframe": "1h",
+      "category": "trend_following",
+      "description": "Oracle sweep lineage: experiment exp_20260325T052040807444Z run_index 240917. Entry filters: cmf_bearish, adi_bullish, stochrsi_oversold. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "vortex_crossover",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 15,
+            "direction": "bullish"
+          }
+        },
+        {
+          "name": "cmf_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 37,
+            "threshold": 0.4098
+          }
+        },
+        {
+          "name": "adi_bullish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 44
+          }
+        },
+        {
+          "name": "stochrsi_oversold",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 15,
+            "smooth1": 4,
+            "smooth2": 2,
+            "threshold": 0.376
+          }
+        }
+      ],
+      "exit_signals": [],
+      "execution_config": {
+        "reward_factor": 1.7940560579299927,
+        "max_risk_per_trade": 0.03731900081038475,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.10000000149011612,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 835,
+        "exit_on_profit_after_bars": 541,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260325T052040807444Z",
+      "notes": ""
+    },
+    {
+      "id": "oracle-exp_20260320T174739679755Z-16185",
+      "label": "ADA 15m dc_lower_breakout (Oracle sweep)",
+      "asset": "ADA",
+      "timeframe": "15m",
+      "category": "breakout",
+      "description": "Oracle sweep lineage: experiment exp_20260320T174739679755Z run_index 16185. Entry filters: trix_bearish, adx_bullish_di. Imported from reference_strategies_latest.json.",
+      "entry_signals": [
+        {
+          "name": "dc_lower_breakout",
+          "signal_type": "TRIGGER",
+          "params": {
+            "window": 28
+          }
+        },
+        {
+          "name": "trix_bearish",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 11,
+            "threshold": 94.8036
+          }
+        },
+        {
+          "name": "adx_bullish_di",
+          "signal_type": "FILTER",
+          "params": {
+            "window": 23
+          }
+        }
+      ],
+      "exit_signals": [],
+      "execution_config": {
+        "reward_factor": 3.9228858947753906,
+        "max_risk_per_trade": 0.03577300161123276,
+        "stop_loss_calculation": "dynamic_atr",
+        "atr_period": 14,
+        "atr_volatility_factor": 2.0,
+        "atr_short_weight": 0.949999988079071,
+        "atr_long_weight": 0.05000000074505806,
+        "min_balance_threshold": 0.21529600024223328,
+        "min_trade_amount": 25.0,
+        "max_open_positions": 10,
+        "max_trades_per_day": 50,
+        "max_units_per_trade": 100000.0,
+        "max_trade_amount": 10000000.0,
+        "volatility_window": 24,
+        "target_volatility": 0.019999999552965164,
+        "volatility_mode": "stddev",
+        "enable_volatility_adjustment": false,
+        "max_hold_time_hours": null,
+        "cooldown_bars": 24,
+        "daily_momentum_limit": 3.0,
+        "weekly_momentum_limit": 3.0,
+        "max_hold_bars": 1000,
+        "exit_on_loss_after_bars": 1000,
+        "exit_on_profit_after_bars": 1000,
+        "profit_threshold_pct": 0.05000000074505806,
+        "slippage_pct": 0.004000000189989805,
+        "fee_pct": 0.008500000461935997
+      },
+      "source": "oracle/sweep/exp_20260320T174739679755Z",
+      "notes": ""
     }
   ]
 }

--- a/server/src/services/reference_strategies_service.py
+++ b/server/src/services/reference_strategies_service.py
@@ -185,14 +185,17 @@ def list_all() -> list[ReferenceStrategy]:
 def build_from_reference(
     reference_id: str,
     timeframe_override: str | None = None,
+    asset_override: str | None = None,
     name: str | None = None,
 ) -> dict[str, Any]:
     """Produce a create_strategy_manual-compatible payload from a reference.
 
-    Copies the reference's signals EXACTLY, only rewriting each signal's
-    `timeframe` field if `timeframe_override` is supplied (and canonicalizes
-    whatever it gets). Matches ai_copilot's build_strategy skill contract:
-    reference params are trusted; user only picks timeframe + name.
+    Copies the reference's signals EXACTLY; the caller can retarget the
+    payload onto a different asset (`asset_override`) or timeframe
+    (`timeframe_override`) — signal names and params do not change, only the
+    strategy's `asset` field and each signal's `timeframe` field. Reference
+    strategies are portable: a combo that worked on BTC 1h is a candidate
+    to bulk-backtest on any other asset or timeframe.
 
     Raises ValueError if reference_id is unknown.
     """
@@ -201,6 +204,7 @@ def build_from_reference(
         raise ValueError(f"reference_id {reference_id!r} not found")
 
     tf = timeframes.canonicalize_timeframe(timeframe_override or ref.timeframe)
+    asset = (asset_override or ref.asset).upper().strip()
 
     def _to_rule(sig: ReferenceSignal) -> dict[str, Any]:
         return {
@@ -221,7 +225,7 @@ def build_from_reference(
 
     return {
         "name": name or f"{ref.label} [from {ref.id}]",
-        "asset": ref.asset,
+        "asset": asset,
         "timeframe": tf,
         "entry": entry,
         "exit": exit_rules,

--- a/server/tests/unit/test_reference_strategies_service.py
+++ b/server/tests/unit/test_reference_strategies_service.py
@@ -121,6 +121,24 @@ class TestBuildFromReference:
         for rule in payload["entry"]:
             assert rule["timeframe"] == "4h"
 
+    def test_asset_override_retargets_strategy(self):
+        """Reference strategies are portable combos — asset_override must
+        replace the strategy's asset field while leaving signal names and
+        params untouched. The retarget flow (BTC combo → user's AVAX goal)
+        depends on this."""
+        ref = svc.list_all()[0]
+        payload = svc.build_from_reference(reference_id=ref.id, asset_override="avax")
+        assert payload["asset"] == "AVAX", "asset_override must be normalized to upper"
+        # Signals must still be byte-identical to the reference.
+        for got, expected in zip(payload["entry"], ref.entry_signals):
+            assert got["name"] == expected.name
+            assert got["params"] == expected.params
+
+    def test_asset_override_absent_preserves_reference_asset(self):
+        ref = svc.list_all()[0]
+        payload = svc.build_from_reference(reference_id=ref.id)
+        assert payload["asset"] == ref.asset.upper()
+
     def test_unsupported_timeframe_rejected(self):
         ref = svc.list_all()[0]
         with pytest.raises(ValidationError):


### PR DESCRIPTION
## Summary
- Expands `server/src/services/data/reference_strategies.json` from 12 hand-curated entries to **132** (12 existing + 120 Oracle sweep winners: 100 from `reference_strategies_latest` + 21 top curated, deduped on `(experiment_id, run_index)`).
- Oracle-sourced entries carry full `execution_config` (reward_factor, max_risk_per_trade, atr_volatility_factor, cooldown_bars, slippage/fee, etc. — everything except `initial_balance`), trigger-derived categories (`trend_following` / `breakout` / `momentum` / `mean_reversion` / `volatility`), and experiment lineage in the `id` + `source` fields. Stored backtest metrics are intentionally excluded — they only applied to the original asset/TF and the library is now portable.
- `build_from_reference` gains `asset_override` alongside `timeframe_override`. A BTC 1h combo can now be retargeted onto AVAX 15m without manual payload editing. MCP tool + REST request model plumb the new parameter through.
- `create-strategy` skill: new **Phase B-bulk** — when ≥2 references match, build each onto the user's `(asset, timeframe)`, backtest all, rank by `threshold_spec`, and present the winner with runners-up. Pick by performance, not by label.
- `trading-bot-workflow` Stage 2 codifies the two invariants: **references are portable**, and **bulk-backtest beats label-pick**.

Pairs with MangroveOracle PR (`feature/reference-strategies-2026-04-24`), which owns the export pipeline for the 21 curated rows.

## Test plan
- [x] `pytest tests/unit/test_reference_strategies_service.py` — 33/33 pass incl. new `asset_override` retarget + preserve-on-absent tests
- [x] Full suite (`pytest tests/ --ignore=tests/e2e`) — 308/308 pass
- [x] `ruff check` on all touched files — clean
- [x] `svc._load_all()` on the new bundle loads all 132 entries cleanly under the pydantic validator
- [x] `svc.search('BTC', '1h', category='momentum')` returns ranked matches mixing `ref-*` hand-curated and `oracle-*` sweep entries
- [x] `svc.build_from_reference(ref.id, asset_override='avax')` produces a payload with `asset="AVAX"` and unmodified signal names/params
- [ ] Smoke-test end-to-end from a fresh `docker compose up -d --build`: search → build with asset+timeframe override → create_strategy_manual → backtest_strategy (owner call)

🤖 Generated with [Claude Code](https://claude.com/claude-code)