### PR TITLE
feat(status): expose SDK versions + signal/KB catalog counts

### DIFF
--- a/server/src/api/routes/discovery.py
+++ b/server/src/api/routes/discovery.py
@@ -1,7 +1,7 @@
 """Discovery endpoints — free, no auth.
 
-- GET /api/v1/agent/status: version, wallet count, strategies grouped
-  by status, active cron jobs, db path, uptime.
+- GET /api/v1/agent/status: server + SDK versions, catalog counts, wallet
+  count, strategies grouped by status, active cron jobs, db path, uptime.
 - GET /api/v1/agent/tools: MCP tool catalog (auto-populated by
   src/mcp/tools.py at registration time).
 
@@ -9,8 +9,10 @@
 """
 from __future__ import annotations
 
+import importlib.metadata
 import time
 from collections import Counter
+from datetime import datetime, timezone
 
 from fastapi import APIRouter
 
@@ -23,11 +25,80 @@ router = APIRouter()
 
 _STARTUP_MONOTONIC = time.monotonic()
 
+_CATALOG_CACHE: dict | None = None
+_CATALOG_CACHE_SET_AT: float = 0.0
+_CATALOG_CACHE_TTL_SEC = 600  # 10 min
+
+
+def _pkg_version(name: str) -> str | None:
+    """Return installed package version, or None if not importable."""
+    try:
+        return importlib.metadata.version(name)
+    except importlib.metadata.PackageNotFoundError:
+        return None
+
+
+def _fetch_catalog_counts() -> dict:
+    """Live catalog lookup against the mangroveai SDK. Resilient on failure."""
+    counts: dict = {
+        "signals_total": None,
+        "kb_indicators_total": None,
+        "kb_tags_total": None,
+        "as_of": datetime.now(timezone.utc).isoformat(),
+        "error": None,
+    }
+    try:
+        from src.shared.clients.mangrove import mangroveai_client
+        client = mangroveai_client()
+    except Exception as e:  # noqa: BLE001
+        counts["error"] = f"client_init_failed: {str(e)[:200]}"
+        return counts
+
+    try:
+        counts["signals_total"] = sum(1 for _ in client.signals.list_iter(limit_per_page=100))
+    except Exception as e:  # noqa: BLE001
+        counts["error"] = f"signals_list_failed: {str(e)[:200]}"
+
+    try:
+        counts["kb_indicators_total"] = len(list(client.kb.indicators.list()))
+    except Exception as e:  # noqa: BLE001
+        if counts["error"] is None:
+            counts["error"] = f"kb_indicators_list_failed: {str(e)[:200]}"
+
+    try:
+        counts["kb_tags_total"] = len(list(client.kb.tags.list()))
+    except Exception as e:  # noqa: BLE001
+        if counts["error"] is None:
+            counts["error"] = f"kb_tags_list_failed: {str(e)[:200]}"
+
+    return counts
+
+
+def _catalog_counts() -> dict:
+    """Return cached catalog counts. Refreshes every _CATALOG_CACHE_TTL_SEC."""
+    global _CATALOG_CACHE, _CATALOG_CACHE_SET_AT
+    now = time.monotonic()
+    if _CATALOG_CACHE is not None and (now - _CATALOG_CACHE_SET_AT) < _CATALOG_CACHE_TTL_SEC:
+        return _CATALOG_CACHE
+    _CATALOG_CACHE = _fetch_catalog_counts()
+    _CATALOG_CACHE_SET_AT = now
+    return _CATALOG_CACHE
+
+
+def reset_catalog_cache() -> None:
+    """Clear cached catalog counts. Used by tests."""
+    global _CATALOG_CACHE, _CATALOG_CACHE_SET_AT
+    _CATALOG_CACHE = None
+    _CATALOG_CACHE_SET_AT = 0.0
+
 
 @router.get(
     "/status",
     summary="Agent status",
-    description="Version, wallet count, strategies by status, active cron jobs, db path, uptime. Free, no auth.",
+    description=(
+        "Server + SDK versions, signal/KB catalog counts, wallet count, "
+        "strategies by status, active cron jobs, db path, uptime. Free, no auth."
+    ),
     tags=["discovery"],
 )
 async def status() -> dict:
@@ -38,8 +109,17 @@ async def status() -> dict:
         "SELECT status FROM strategies WHERE id != 'user-initiated'",
     ).fetchall()
     counts = Counter(r["status"] for r in strategy_rows)
+
+    server_version = _pkg_version("app-in-a-box") or "0.1.0"
+
     return {
-        "version": "0.1.0",
+        "version": server_version,
+        "server_version": server_version,
+        "sdk_versions": {
+            "mangroveai": _pkg_version("mangroveai"),
+            "mangrovemarkets": _pkg_version("mangrovemarkets"),
+        },
+        "catalog": _catalog_counts(),
         "wallets_count": wallets_count,
         "strategies": {
             "draft": counts.get("draft", 0),

--- a/server/tests/integration/test_discovery_routes.py
+++ b/server/tests/integration/test_discovery_routes.py
@@ -12,6 +12,7 @@ from fastapi.testclient import TestClient  # noqa: E402
 @pytest.fixture
 def client(tmp_path, monkeypatch):
     db_file = tmp_path / "disc.db"
+    from src.api.routes import discovery
     from src.config import app_config
     from src.services import scheduler_service as ss
     from src.shared.db import sqlite as db_mod
@@ -19,6 +20,7 @@ def client(tmp_path, monkeypatch):
     monkeypatch.setattr(app_config, "DB_PATH", str(db_file))
     db_mod.reset_connection()
     ss.reset_scheduler_cache()
+    discovery.reset_catalog_cache()
 
     from src.app import create_app
     app = create_app()
@@ -26,13 +28,27 @@ def client(tmp_path, monkeypatch):
         yield c
     ss.reset_scheduler_cache()
     db_mod.reset_connection()
+    discovery.reset_catalog_cache()
 
 
 def test_status_returns_expected_shape(client):
     r = client.get("/api/v1/agent/status")
     assert r.status_code == 200
     body = r.json()
-    assert body["version"] == "0.1.0"
+    # Backwards-compat: original `version` field still present.
+    assert "version" in body
+    assert isinstance(body["version"], str)
+    # New: explicit server_version mirrors `version`, plus sdk_versions + catalog.
+    assert body["server_version"] == body["version"]
+    assert set(body["sdk_versions"].keys()) == {"mangroveai", "mangrovemarkets"}
+    assert set(body["catalog"].keys()) == {
+        "signals_total",
+        "kb_indicators_total",
+        "kb_tags_total",
+        "as_of",
+        "error",
+    }
+    # Unchanged fields.
     assert body["wallets_count"] == 0
     assert set(body["strategies"].keys()) == {"draft", "inactive", "paper", "live", "archived"}
     assert body["active_cron_jobs"] == 0
@@ -66,6 +82,74 @@ def test_status_counts_wallets_and_strategies(client):
     assert body["strategies"]["paper"] == 2
     assert body["strategies"]["live"] == 1
     assert body["strategies"]["archived"] == 1
+
+
+def test_status_reports_catalog_counts_when_sdk_reachable(client, monkeypatch):
+    """With a stubbed SDK, catalog counts flow through end-to-end."""
+    from types import SimpleNamespace
+
+    from src.api.routes import discovery
+
+    class _StubSignals:
+        def list_iter(self, *, limit_per_page):
+            yield from (SimpleNamespace(name=f"sig_{i}") for i in range(228))
+
+    class _StubIndicators:
+        def list(self, **_):
+            return [SimpleNamespace(name=f"ind_{i}") for i in range(70)]
+
+    class _StubTags:
+        def list(self):
+            return [SimpleNamespace(tag=f"t_{i}") for i in range(42)]
+
+    class _StubKB:
+        indicators = _StubIndicators()
+        tags = _StubTags()
+
+    class _StubClient:
+        signals = _StubSignals()
+        kb = _StubKB()
+
+    discovery.reset_catalog_cache()
+    monkeypatch.setattr(
+        "src.shared.clients.mangrove.mangroveai_client",
+        lambda: _StubClient(),
+    )
+
+    body = client.get("/api/v1/agent/status").json()
+    assert body["catalog"]["signals_total"] == 228
+    assert body["catalog"]["kb_indicators_total"] == 70
+    assert body["catalog"]["kb_tags_total"] == 42
+    assert body["catalog"]["error"] is None
+    assert body["catalog"]["as_of"] is not None
+
+
+def test_status_catalog_is_resilient_when_sdk_unreachable(client, monkeypatch):
+    """If the SDK client itself raises, catalog fields are null with a truncated error note."""
+    from src.api.routes import discovery
+
+    def _raise():
+        raise RuntimeError("no API key configured")
+
+    discovery.reset_catalog_cache()
+    monkeypatch.setattr(
+        "src.shared.clients.mangrove.mangroveai_client",
+        _raise,
+    )
+
+    body = client.get("/api/v1/agent/status").json()
+    assert body["catalog"]["signals_total"] is None
+    assert body["catalog"]["kb_indicators_total"] is None
+    assert body["catalog"]["kb_tags_total"] is None
+    assert body["catalog"]["error"] is not None
+    assert "client_init_failed" in body["catalog"]["error"]
+
+
+def test_sdk_versions_are_strings_or_null(client):
+    body = client.get("/api/v1/agent/status").json()
+    for sdk in ("mangroveai", "mangrovemarkets"):
+        v = body["sdk_versions"][sdk]
+        assert v is None or (isinstance(v, str) and len(v) > 0)
 
 
 def test_tools_returns_registered_catalog(client):


### PR DESCRIPTION
## Summary

- `/api/v1/agent/status` now returns `server_version`, `sdk_versions.{mangroveai,mangrovemarkets}`, and a `catalog.{signals_total,kb_indicators_total,kb_tags_total,as_of,error}` block.
- Server version resolved dynamically via `importlib.metadata`; SDK versions the same.
- Catalog counts fetched lazily from the `mangroveai` SDK and cached for 10 min. Resilient to SDK/network failures — unpopulated fields go `null` with an `error` note.
- Backwards-compat: the original `version` key is preserved and mirrors `server_version`.

Closes #32.

## Phase

Phase 0.1 of the blocking-issues sweep (plan: `~/.claude/plans/prancy-tumbling-kay.md`).

## Requirements traceability

| ID | Requirement | Verification |
|----|-------------|--------------|
| R1 | `/status` returns dynamic server version | `test_status_returns_expected_shape` asserts `server_version == version` and `version` is a str |
| R2 | Status returns `mangroveai` SDK version | `test_sdk_versions_are_strings_or_null` |
| R3 | Status returns `mangrovemarkets` SDK version | same |
| R4 | Status returns signal catalog total | `test_status_reports_catalog_counts_when_sdk_reachable` — stubbed 228 signals, assertion passes |
| R5 | Status returns KB doc totals (indicators + tags) | same test — stubbed 70 indicators + 42 tags |
| R6 | Existing fields unchanged | `test_status_counts_wallets_and_strategies`, `test_tools_returns_registered_catalog`, `test_discovery_endpoints_do_not_require_api_key` all pass unchanged |
| R7 | Resilient when SDK unreachable | `test_status_catalog_is_resilient_when_sdk_unreachable` |

## Test plan

- [x] 7 unit/integration tests pass (existing 4 + 3 new)
- [x] Full test suite (311 tests, ignore e2e) passes
- [x] `ruff check` clean on both files
- [ ] Post-merge: hit `/api/v1/agent/status` on dev deploy, confirm SDK versions + catalog counts populate

## Notes

- Catalog is cached for 10 min; for fresher counts, restart or reset via the internal `reset_catalog_cache()` hook (used by tests).
- `last-updated timestamp` per-catalog-item from the issue AC is not implemented — the SDK doesn't expose that today. `as_of` is the cache refresh timestamp, which is the nearest proxy.
- Workshop README documentation of expected count (AC4 of #32) is not in this PR — that's a docs change best paired with the workshop content itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)