### PR TITLE
chore(deps): pin mangrovemarkets >= 0.2.0 (client-side EVM keygen)

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -18,7 +18,12 @@ PyJWT>=2.9.0
 # impossible to resolve (upstream tops out at 0.5.0) and blocked fresh
 # pip installs.
 mangroveai>=0.3.0,<0.4.0
-mangrovemarkets>=0.1.2,<0.2.0
+# mangrovemarkets 0.2.0 moved EVM wallet keypair generation client-side.
+# The agent's wallet_manager.create_wallet() is unaffected — the SDK
+# call signature is unchanged, only the implementation shifted from
+# server-side to local. Pinning to 0.2.x guarantees the leak-surface
+# fix is in place. See post-mortem: docs/incidents/2026-04-24-eip7702-drain.md
+mangrovemarkets>=0.2.0,<0.3.0
 apscheduler[sqlalchemy]>=3.10
 cryptography>=42
 keyring>=24


### PR DESCRIPTION
## Summary

Bumps the \`mangrovemarkets\` pin past the architectural fix that moves EVM wallet keypair generation client-side. Closes the leak surface that contributed to the 2026-04-24 EIP-7702 drain.

## What changed

\`\`\`
-mangrovemarkets>=0.1.2,<0.2.0
+mangrovemarkets>=0.2.0,<0.3.0
\`\`\`

Plus a comment in requirements.txt explaining the why with a pointer to the post-mortem.

## Why

Pre-0.2 SDKs called the upstream \`wallet_create\` tool to generate keypairs server-side; the plaintext returned in the HTTPS response body (then in any logging tap on it) was the leak surface. \`mangrovemarkets\` 0.2.0 generates EVM keypairs locally with \`eth_account.Account.create()\`; the private key never traverses the wire.

Companion PRs:
- \`MangroveTechnologies/MangroveMarkets#34\` — the SDK 0.2.0 release
- \`MangroveTechnologies/MangroveMarkets-MCP-Server#70\` — server returns \`NOT_IMPLEMENTED\` from \`wallet_create\` for all chains

## Caller compatibility

\`WalletCreateResult\` shape is unchanged — \`wallet_manager._extract_secret()\` continues to read \`.private_key\` / \`.seed_phrase\` / \`.secret\` exactly as before, just locally now. **No code change in \`server/src/services/wallet_manager.py\` is required.** All 39 existing \`tests/unit/test_wallet_manager.py\` tests pass with the new pin.

## Deploy order

1. PR #34 merges + publishes \`mangrovemarkets==0.2.0\` to PyPI
2. **This PR merges** (pin advances)
3. THEN PR #70 deploys to Cloud Run

Pre-0.2 SDK callers (older clones, forks) will see \`NOT_IMPLEMENTED\` from \`wallet_create\` with an upgrade message after Cloud Run deploys. app-in-a-box users on this pin won't be affected — they don't hit the deprecated endpoint at all.

## Test plan

- [x] \`pytest tests/unit/test_wallet_manager.py -q\` → 39 passed
- [ ] After PR #34 publishes, run a fresh-clone smoke test: \`./scripts/setup.sh\` → create wallet → verify the SDK doesn't make a \`/api/v1/tools/wallet_create\` call (capture via \`bare.log\` or transport spy)
- [ ] Verify the recreation plan from the post-mortem still works end-to-end (create new wallet → fund → swap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)