### PR TITLE
feat(oracle): SIEVE + data-query + backtest demo + rename mangroveai to mangrove-ai

### DIFF
--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -86,7 +86,7 @@ Goal: turn the mangrove-agent template into a mangrove-agent shell. After this p
   keyring>=24
   ```
 - [ ] **Step 2:** rebuild Docker image: `docker compose build`. Verify install succeeds.
-- [ ] **Step 3:** import smoke test — start container, exec into it, run `python -c "import mangroveai, mangrovemarkets, apscheduler, cryptography, keyring; print('ok')"`.
+- [ ] **Step 3:** import smoke test — start container, exec into it, run `python -c "import mangrove_ai, mangrovemarkets, apscheduler, cryptography, keyring; print('ok')"`.
 - [ ] **Step 4:** commit: `chore(deps): add SDK + scheduler + crypto + keyring`.
 
 **Acceptance:** All five libraries installable and importable in the container.
@@ -122,26 +122,26 @@ Goal: turn the mangrove-agent template into a mangrove-agent shell. After this p
 - [ ] **Step 1:** in `mangrove.py`, define module-level singletons (lazy):
   ```python
   from functools import lru_cache
-  from mangroveai import MangroveAI
-  from mangrovemarkets import MangroveMarkets
+  from mangrove_ai import MangroveAI
+  from mangrove_markets import MangroveMarkets
   from src.config import app_config
 
   @lru_cache(maxsize=1)
-  def mangroveai_client() -> MangroveAI:
+  def mangrove_ai_client() -> MangroveAI:
       return MangroveAI(api_key=app_config.MANGROVE_API_KEY)
 
   @lru_cache(maxsize=1)
-  def mangrovemarkets_client() -> MangroveMarkets:
+  def mangrove_markets_client() -> MangroveMarkets:
       return MangroveMarkets(
           base_url=app_config.MANGROVEMARKETS_BASE_URL,
           api_key=app_config.MANGROVE_API_KEY,
       )
   ```
 - [ ] **Step 2:** write unit test that calls each accessor twice, asserts the same instance comes back.
-- [ ] **Step 3:** add a smoke test: call `mangroveai_client().status` (or any free SDK call) — confirm a real connection works against dev URL.
+- [ ] **Step 3:** add a smoke test: call `mangrove_ai_client().status` (or any free SDK call) — confirm a real connection works against dev URL.
 - [ ] **Step 4:** commit: `feat(clients): add Mangrove SDK singletons`.
 
-**Acceptance:** Routes and services can `from src.shared.clients.mangrove import mangroveai_client` and call SDK methods.
+**Acceptance:** Routes and services can `from src.shared.clients.mangrove import mangrove_ai_client` and call SDK methods.
 
 ---
 
@@ -234,7 +234,7 @@ Goal: the agent can hold wallets and write to its log tables. After this phase, 
 - [ ] **Step 2:** add `encrypt(plaintext: bytes) -> bytes` and `decrypt(ciphertext: bytes) -> bytes` using Fernet with the master key.
 - [ ] **Step 3:** in `wallet_manager.py`, implement `create_wallet(chain, network, chain_id, label) -> WalletCreateResult`:
   - For chain=`xrpl`: raise `ChainNotSupportedInV1`.
-  - For chain=`evm`: call `mangrovemarkets_client().wallet.create(...)` to get address + secret, encrypt secret, INSERT into `wallets`.
+  - For chain=`evm`: call `mangrove_markets_client().wallet.create(...)` to get address + secret, encrypt secret, INSERT into `wallets`.
   - Return the result with the seed phrase included exactly once + the security warning from the spec.
 - [ ] **Step 4:** implement `list_wallets() -> list[WalletListItem]` (no secrets returned).
 - [ ] **Step 5:** implement `sign(unsigned_tx: dict, wallet_address: str) -> str` — load encrypted seed, decrypt in memory only, sign via web3.py (`eth_account`), zero the secret bytes immediately, return the signed hex string. **The SDK never receives the private key. It only receives `signed_tx` strings for broadcast.**
@@ -336,7 +336,7 @@ Goal: the autonomous strategy creation flow + cron evaluation work end-to-end ag
   ```
 - [ ] **Step 2:** implement `parse_goal(goal: str) -> dict` — detect keywords case-insensitive; default to "momentum" if none match.
 - [ ] **Step 3:** implement `generate(goal, asset, timeframe, n=7) -> list[StrategyCandidate]`:
-  - Fetch signal catalog via `mangroveai_client().signals.list()`
+  - Fetch signal catalog via `mangrove_ai_client().signals.list()`
   - Filter by category buckets from the parsed goal
   - For each of n candidates: random-pick 1 trigger, 0–2 filters for entry; 0–1 trigger + 0+ filters for exit
   - Use sensible default param values from the signal metadata
@@ -359,7 +359,7 @@ Goal: the autonomous strategy creation flow + cron evaluation work end-to-end ag
 - Create: `server/tests/integration/test_backtest_service.py`
 
 - [ ] **Step 1:** implement `quick_backtest_all(candidates, asset, timeframe, lookback_months) -> list[BacktestResult]`:
-  - For each candidate, call `mangroveai_client().backtesting.run(mode="quick", ...)` with the candidate's strategy_json
+  - For each candidate, call `mangrove_ai_client().backtesting.run(mode="quick", ...)` with the candidate's strategy_json
   - Capture per-candidate metrics
 - [ ] **Step 2:** implement `filter_and_rank(results) -> list[BacktestResult]`:
   - Drop any with `win_rate <= 0.51` or `total_trades < 10`
@@ -414,7 +414,7 @@ Goal: the autonomous strategy creation flow + cron evaluation work end-to-end ag
   4. `dex.prepare_swap(quote_id, wallet_address)` → UnsignedTx
   5. `wallet_manager.sign(swap_tx, wallet_address)` (client-side sign) → `dex.broadcast(signed_tx)` → poll `dex.tx_status`
   6. Build `Trade` with `mode="live"`, `tx_hash`, `explorer_url=explorer_url(chain_id, tx_hash)`, `approval_tx_hash`, fill amounts/prices/fees
-- [ ] **Step 4 (paper mode):** fetch current price via `mangroveai_client().crypto_assets.get_market_data(intent.symbol)`, build a `Trade` with `mode="paper"`, `status="simulated"`, `tx_hash=None`, `explorer_url=None`, fill at mid/mark price.
+- [ ] **Step 4 (paper mode):** fetch current price via `mangrove_ai_client().crypto_assets.get_market_data(intent.symbol)`, build a `Trade` with `mode="paper"`, `status="simulated"`, `tx_hash=None`, `explorer_url=None`, fill at mid/mark price.
 - [ ] **Step 5:** call `trade_log.log_trade(trade)` and `trade_log.update_position(...)` based on intent type (enter/exit). Return the `Trade`.
 - [ ] **Step 6:** add `execute_many(intents, mode, wallet_address) -> list[Trade]` — sequential loop, each wrapped in try/except so one failure doesn't stop the batch.
 - [ ] **Step 7:** unit tests with mocked SDK:
@@ -444,21 +444,21 @@ Goal: the autonomous strategy creation flow + cron evaluation work end-to-end ag
   3. `filter_and_rank(...)` → survivors
   4. If empty: raise `StrategyNoViableCandidates` with suggestion
   5. `backtest_service.full_backtest(winner)` → full metrics
-  6. `mangroveai_client().strategies.create(winner)` → mangrove_id
+  6. `mangrove_ai_client().strategies.create(winner)` → mangrove_id
   7. Cache locally in `strategies` table with `generation_report_json`
   8. Return `StrategyDetail`
-- [ ] **Step 2:** implement `create_manual(req)` — validate composition (1 TRIGGER + 0+ FILTERs entry; 0–1 TRIGGER + 0+ FILTERs exit), call `mangroveai_client().strategies.create(...)`, cache locally.
+- [ ] **Step 2:** implement `create_manual(req)` — validate composition (1 TRIGGER + 0+ FILTERs entry; 0–1 TRIGGER + 0+ FILTERs exit), call `mangrove_ai_client().strategies.create(...)`, cache locally.
 - [ ] **Step 3:** implement `list_strategies(status_filter, limit, offset)` and `get_strategy(id)` — read from local cache.
 - [ ] **Step 4:** implement `update_status(id, status, confirm, allocation) -> StrategyDetail`:
   - Validate transition per spec (`StrategyInvalidStatusTransition` if illegal)
   - `confirm=True` required for live activation or live deactivation
-  - On `→ live`: validate allocation block, call `allocation_service.record_allocation()`, call `mangroveai_client().strategies.update_status()`, register cron job via `scheduler_service.register_job(strategy_id, timeframe, "src.services.strategy_service.tick")`
+  - On `→ live`: validate allocation block, call `allocation_service.record_allocation()`, call `mangrove_ai_client().strategies.update_status()`, register cron job via `scheduler_service.register_job(strategy_id, timeframe, "src.services.strategy_service.tick")`
   - On `→ paper`: register cron, no allocation
   - On `→ inactive` or `→ archived`: cancel cron, release allocation if any
 - [ ] **Step 5:** implement `tick(strategy_id) -> Evaluation` — the cron callback. **Runs inside the scheduler threadpool; must never block the request path.** Every tick emits structured logs so external observers can see the fire-and-result sequence:
   1. Generate a `tick_id` (UUID), bind correlation_id to it, emit `strategy.tick.started` with `strategy_id`, `tick_id`, `timeframe`.
   2. Load strategy from local cache to get the `mangrove_id` + mode (`paper` or `live`) + wallet_address (live only).
-  3. Call `mangroveai_client().execution.evaluate(mangrove_id, persist=(mode == "live"))` — the SDK fetches its own market data and applies all signal evaluation, position sizing, and risk gates. Emit `sdk.call.started` / `sdk.call.completed` bracketing. The returned `EvaluateResult` contains any `OrderIntent[]` the strategy generated.
+  3. Call `mangrove_ai_client().execution.evaluate(mangrove_id, persist=(mode == "live"))` — the SDK fetches its own market data and applies all signal evaluation, position sizing, and risk gates. Emit `sdk.call.started` / `sdk.call.completed` bracketing. The returned `EvaluateResult` contains any `OrderIntent[]` the strategy generated.
   4. If order_intents empty: persist evaluation with `status="ok"`, emit `strategy.tick.completed` with `order_count=0`, `duration_ms`.
   5. If order_intents present: dispatch to `order_executor.execute_many(intents, mode, wallet_address)`, persist evaluation with `sdk_response_json` verbatim, emit `strategy.tick.completed` with `order_count=N`, `duration_ms`.
   6. On any exception: persist evaluation with `status="error"`, emit `strategy.tick.errored` with `exception` + `duration_ms`. **Never let the exception propagate out of the tick callback** — that would crash the scheduler worker.
@@ -512,9 +512,9 @@ Goal: every spec endpoint and MCP tool is wired up. After this phase, the agent 
 - [ ] **Step 2:** implement routes:
   - `POST /wallet/create` → `wallet_manager.create_wallet(...)`
   - `GET /wallet/list` → `wallet_manager.list_wallets()`
-  - `GET /wallet/{address}/balances?chain_id` → `mangrovemarkets_client().dex.balances(chain_id, address)` directly
-  - `GET /wallet/{address}/portfolio?chain_id` → `mangrovemarkets_client().portfolio.value/pnl/tokens/defi(...)` directly, aggregate
-  - `GET /wallet/{address}/history?limit` → `mangrovemarkets_client().portfolio.history(...)` directly
+  - `GET /wallet/{address}/balances?chain_id` → `mangrove_markets_client().dex.balances(chain_id, address)` directly
+  - `GET /wallet/{address}/portfolio?chain_id` → `mangrove_markets_client().portfolio.value/pnl/tokens/defi(...)` directly, aggregate
+  - `GET /wallet/{address}/history?limit` → `mangrove_markets_client().portfolio.history(...)` directly
 - [ ] **Step 3:** wire auth via the existing middleware (auth required on all wallet endpoints).
 - [ ] **Step 4:** integration tests for create + list happy paths and `WalletNotFound` error.
 - [ ] **Step 5:** commit: `feat(api): wallet routes`.
@@ -531,9 +531,9 @@ Goal: every spec endpoint and MCP tool is wired up. After this phase, the agent 
 - Create: `server/tests/integration/test_dex_routes.py`
 
 - [ ] **Step 1:** routes that pass through to SDK directly:
-  - `GET /dex/venues` → `mangrovemarkets_client().dex.supported_venues()`
-  - `GET /dex/pairs?venue_id` → `mangrovemarkets_client().dex.supported_pairs(venue_id)`
-  - `POST /dex/quote` → `mangrovemarkets_client().dex.get_quote(...)`
+  - `GET /dex/venues` → `mangrove_markets_client().dex.supported_venues()`
+  - `GET /dex/pairs?venue_id` → `mangrove_markets_client().dex.supported_pairs(venue_id)`
+  - `POST /dex/quote` → `mangrove_markets_client().dex.get_quote(...)`
 - [ ] **Step 2:** `POST /dex/swap`:
   - Require `confirm=True` else raise `ConfirmationRequired`
   - Build `OrderIntent` from request body
@@ -558,19 +558,19 @@ Goal: every spec endpoint and MCP tool is wired up. After this phase, the agent 
 - Create: `server/src/api/routes/kb.py`
 - Create: `server/tests/integration/test_passthrough_routes.py`
 
-- [ ] **Step 1:** market routes — all delegate to `mangroveai_client().crypto_assets.*`:
+- [ ] **Step 1:** market routes — all delegate to `mangrove_ai_client().crypto_assets.*`:
   - `GET /market/ohlcv?symbol&timeframe&lookback_days`
   - `GET /market/data?symbol`
   - `GET /market/trending`
   - `GET /market/global`
-- [ ] **Step 2:** on-chain routes — delegate to `mangroveai_client().on_chain.*`:
+- [ ] **Step 2:** on-chain routes — delegate to `mangrove_ai_client().on_chain.*`:
   - `GET /on-chain/smart-money?symbol&chain`
   - `GET /on-chain/whale-activity?symbol&hours_back`
   - `GET /on-chain/token-holders/{symbol}`
-- [ ] **Step 3:** signals routes — delegate to `mangroveai_client().signals.*`:
+- [ ] **Step 3:** signals routes — delegate to `mangrove_ai_client().signals.*`:
   - `GET /signals?category&search&limit`
   - `GET /signals/{name}`
-- [ ] **Step 4:** KB routes — delegate to `mangroveai_client().kb.*`:
+- [ ] **Step 4:** KB routes — delegate to `mangrove_ai_client().kb.*`:
   - `GET /kb/search?q&limit`
   - `GET /kb/glossary/{term}`
 - [ ] **Step 5:** one integration test per route that just confirms the SDK call succeeds and the response is well-formed (mock the SDK; we're testing the wiring, not the SDK).

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -506,7 +506,7 @@ class Evaluation(BaseModel):
     strategy_id: str
     timestamp: datetime
     market_snapshot: dict                        # last bar of data passed to SDK
-    sdk_response: dict                           # verbatim response from mangroveai.execution.evaluate()
+    sdk_response: dict                           # verbatim response from mangrove_ai.execution.evaluate()
     order_intents: list[OrderIntent]             # extracted from sdk_response for easy querying
     duration_ms: int
     status: Literal["ok", "error", "skipped"]
@@ -619,7 +619,7 @@ CREATE TABLE evaluations (
     strategy_id TEXT NOT NULL REFERENCES strategies(id),
     timestamp TEXT NOT NULL,
     market_snapshot_json TEXT NOT NULL,           -- data sent to the SDK
-    sdk_response_json TEXT NOT NULL,              -- verbatim response from mangroveai.execution.evaluate()
+    sdk_response_json TEXT NOT NULL,              -- verbatim response from mangrove_ai.execution.evaluate()
     order_intents_json TEXT NOT NULL,             -- extracted from sdk_response for querying
     duration_ms INTEGER NOT NULL,
     status TEXT NOT NULL,                         -- ok | error | skipped
@@ -758,7 +758,7 @@ Server-side, the agent's FastAPI middleware inspects `X-API-Key` identically for
 
 **Usage:**
 ```python
-from mangroveai import MangroveAI
+from mangrove_ai import MangroveAI
 client = MangroveAI()  # reads env
 ```
 
@@ -778,7 +778,7 @@ client = MangroveAI()  # reads env
 
 **Usage:**
 ```python
-from mangrovemarkets import MangroveMarkets
+from mangrove_markets import MangroveMarkets
 client = MangroveMarkets(base_url=os.environ["MANGROVEMARKETS_BASE_URL"])
 ```
 

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -13,17 +13,24 @@ PyJWT>=2.9.0
 # and minor bumps may carry breaking changes. Revisit pins when either
 # stabilizes to 1.0.
 # Note: there is no `mangrove-kb` package pinned here — all KB access
-# flows through mangrove_ai.kb.*, which the mangrove-ai SDK already
+# flows through mangrove_ai.kb.*, which the mangroveai SDK already
 # transitively provides. A previous `mangrove-kb>=1.0.0` pin was
 # impossible to resolve (upstream tops out at 0.5.0) and blocked fresh
 # pip installs.
-mangrove-ai>=1.0.0,<2.0.0
-# mangrove-markets 1.0.0 moved EVM wallet keypair generation client-side.
+#
+# Note: PyPI distribution name is `mangroveai` (no hyphen); the import
+# path is `from mangrove_ai import ...`. Distribution-name-≠-import-name
+# is normal Python packaging (Pillow/PIL, beautifulsoup4/bs4, etc.).
+# An attempted PyPI rename to `mangrove-ai` was rejected by PyPI's
+# similarity check — that's why we kept the dist name as-is.
+mangroveai>=1.0.2,<2.0.0
+# mangrovemarkets 1.0.0 moved EVM wallet keypair generation client-side.
 # The agent's wallet_manager.create_wallet() is unaffected — the SDK
 # call signature is unchanged, only the implementation shifted from
-# server-side to local. Pinning to >=1.0.0 guarantees the leak-surface
+# server-side to local. Pinning to >=1.0.2 guarantees the leak-surface
 # fix is in place. See post-mortem: docs/incidents/2026-04-24-eip7702-drain.md
-mangrove-markets>=1.0.0,<2.0.0
+# Same dist-name-vs-import-name story as mangroveai above.
+mangrovemarkets>=1.0.2,<2.0.0
 apscheduler[sqlalchemy]>=3.10
 cryptography>=42
 keyring>=24

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -17,7 +17,7 @@ PyJWT>=2.9.0
 # transitively provides. A previous `mangrove-kb>=1.0.0` pin was
 # impossible to resolve (upstream tops out at 0.5.0) and blocked fresh
 # pip installs.
-mangroveai>=0.3.0,<0.4.0
+mangrove-ai>=1.0.0,<2.0.0
 # mangrovemarkets 0.2.0 moved EVM wallet keypair generation client-side.
 # The agent's wallet_manager.create_wallet() is unaffected — the SDK
 # call signature is unchanged, only the implementation shifted from

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -13,17 +13,17 @@ PyJWT>=2.9.0
 # and minor bumps may carry breaking changes. Revisit pins when either
 # stabilizes to 1.0.
 # Note: there is no `mangrove-kb` package pinned here — all KB access
-# flows through mangroveai.kb.*, which the mangroveai SDK already
+# flows through mangrove_ai.kb.*, which the mangrove-ai SDK already
 # transitively provides. A previous `mangrove-kb>=1.0.0` pin was
 # impossible to resolve (upstream tops out at 0.5.0) and blocked fresh
 # pip installs.
 mangrove-ai>=1.0.0,<2.0.0
-# mangrovemarkets 0.2.0 moved EVM wallet keypair generation client-side.
+# mangrove-markets 1.0.0 moved EVM wallet keypair generation client-side.
 # The agent's wallet_manager.create_wallet() is unaffected — the SDK
 # call signature is unchanged, only the implementation shifted from
-# server-side to local. Pinning to 0.2.x guarantees the leak-surface
+# server-side to local. Pinning to >=1.0.0 guarantees the leak-surface
 # fix is in place. See post-mortem: docs/incidents/2026-04-24-eip7702-drain.md
-mangrovemarkets>=0.2.0,<0.3.0
+mangrove-markets>=1.0.0,<2.0.0
 apscheduler[sqlalchemy]>=3.10
 cryptography>=42
 keyring>=24

--- a/server/src/api/router.py
+++ b/server/src/api/router.py
@@ -13,6 +13,7 @@ from src.api.routes.kb import router as kb_router
 from src.api.routes.logs import router as logs_router
 from src.api.routes.market import router as market_router
 from src.api.routes.on_chain import router as on_chain_router
+from src.api.routes.oracle import router as oracle_router
 from src.api.routes.reference_strategies import router as reference_strategies_router
 from src.api.routes.signals import router as signals_router
 from src.api.routes.strategies import router as strategies_router
@@ -30,6 +31,7 @@ agent_router.include_router(market_router)
 agent_router.include_router(on_chain_router)
 agent_router.include_router(signals_router)
 agent_router.include_router(strategies_router)
+agent_router.include_router(oracle_router)
 agent_router.include_router(reference_strategies_router)
 agent_router.include_router(logs_router)
 agent_router.include_router(kb_router)

--- a/server/src/api/routes/dex.py
+++ b/server/src/api/routes/dex.py
@@ -19,7 +19,7 @@ from pydantic import BaseModel, Field
 from src.models.domain import OrderIntent
 from src.services.order_executor import execute_one
 from src.shared.auth.dependency import require_api_key
-from src.shared.clients.mangrove import mangrovemarkets_client
+from src.shared.clients.mangrove import mangrove_markets_client
 from src.shared.errors import ConfirmationRequired, SdkError
 
 router = APIRouter(
@@ -32,7 +32,7 @@ router = APIRouter(
 @router.get("/venues", summary="List DEX venues")
 async def dex_venues() -> list[Any]:
     try:
-        venues = mangrovemarkets_client().dex.supported_venues()
+        venues = mangrove_markets_client().dex.supported_venues()
     except Exception as e:  # noqa: BLE001
         raise SdkError(f"dex.supported_venues failed: {e}") from e
     return [v.model_dump() if hasattr(v, "model_dump") else v for v in venues]
@@ -41,7 +41,7 @@ async def dex_venues() -> list[Any]:
 @router.get("/pairs", summary="List trading pairs for a venue")
 async def dex_pairs(venue_id: str) -> list[Any]:
     try:
-        pairs = mangrovemarkets_client().dex.supported_pairs(venue_id=venue_id)
+        pairs = mangrove_markets_client().dex.supported_pairs(venue_id=venue_id)
     except Exception as e:  # noqa: BLE001
         raise SdkError(f"dex.supported_pairs failed: {e}") from e
     return [p.model_dump() if hasattr(p, "model_dump") else p for p in pairs]
@@ -58,7 +58,7 @@ class QuoteRequest(BaseModel):
 @router.post("/quote", summary="Get a swap quote")
 async def dex_quote(req: QuoteRequest) -> dict:
     try:
-        quote = mangrovemarkets_client().dex.get_quote(
+        quote = mangrove_markets_client().dex.get_quote(
             input_token=req.input_token,
             output_token=req.output_token,
             amount=req.amount,
@@ -178,7 +178,7 @@ async def tx_status(
     venue_id: str | None = None,
 ) -> Any:
     try:
-        return _dump(mangrovemarkets_client().dex.tx_status(
+        return _dump(mangrove_markets_client().dex.tx_status(
             tx_hash=tx_hash, chain_id=chain_id, venue_id=venue_id,
         ))
     except Exception as e:  # noqa: BLE001
@@ -196,7 +196,7 @@ async def tx_status(
 )
 async def token_info(chain_id: int, address: str) -> Any:
     try:
-        return _dump(mangrovemarkets_client().dex.token_info(
+        return _dump(mangrove_markets_client().dex.token_info(
             chain_id=chain_id, address=address,
         ))
     except Exception as e:  # noqa: BLE001
@@ -213,7 +213,7 @@ async def token_info(chain_id: int, address: str) -> Any:
 )
 async def spot_price(chain_id: int, tokens: str) -> Any:
     try:
-        return _dump(mangrovemarkets_client().dex.spot_price(
+        return _dump(mangrove_markets_client().dex.spot_price(
             chain_id=chain_id, tokens=tokens,
         ))
     except Exception as e:  # noqa: BLE001
@@ -231,6 +231,6 @@ async def spot_price(chain_id: int, tokens: str) -> Any:
 )
 async def gas_price(chain_id: int) -> Any:
     try:
-        return _dump(mangrovemarkets_client().dex.gas_price(chain_id=chain_id))
+        return _dump(mangrove_markets_client().dex.gas_price(chain_id=chain_id))
     except Exception as e:  # noqa: BLE001
         raise SdkError(f"dex.gas_price failed: {e}") from e

--- a/server/src/api/routes/discovery.py
+++ b/server/src/api/routes/discovery.py
@@ -48,8 +48,8 @@ def _fetch_catalog_counts() -> dict:
         "error": None,
     }
     try:
-        from src.shared.clients.mangrove import mangroveai_client
-        client = mangroveai_client()
+        from src.shared.clients.mangrove import mangrove_ai_client
+        client = mangrove_ai_client()
     except Exception as e:  # noqa: BLE001
         counts["error"] = f"client_init_failed: {str(e)[:200]}"
         return counts

--- a/server/src/api/routes/kb.py
+++ b/server/src/api/routes/kb.py
@@ -6,7 +6,7 @@ from typing import Any
 from fastapi import APIRouter, Depends
 
 from src.shared.auth.dependency import require_api_key
-from src.shared.clients.mangrove import mangroveai_client
+from src.shared.clients.mangrove import mangrove_ai_client
 from src.shared.errors import SdkError
 
 router = APIRouter(
@@ -23,7 +23,7 @@ def _dump(obj: Any) -> Any:
 @router.get("/search", summary="Full-text search the knowledge base")
 async def search(q: str, limit: int = 20) -> Any:
     try:
-        return _dump(mangroveai_client().kb.search.query(q=q, limit=limit))
+        return _dump(mangrove_ai_client().kb.search.query(q=q, limit=limit))
     except Exception as e:  # noqa: BLE001
         raise SdkError(f"kb.search.query failed: {e}") from e
 
@@ -31,7 +31,7 @@ async def search(q: str, limit: int = 20) -> Any:
 @router.get("/glossary/{term}", summary="Glossary term lookup with backlinks")
 async def glossary(term: str) -> Any:
     try:
-        return _dump(mangroveai_client().kb.glossary.get(term))
+        return _dump(mangrove_ai_client().kb.glossary.get(term))
     except Exception as e:  # noqa: BLE001
         raise SdkError(f"kb.glossary.get failed: {e}") from e
 
@@ -39,7 +39,7 @@ async def glossary(term: str) -> Any:
 @router.get("/documents", summary="List all KB documents (summary only)")
 async def documents_list() -> Any:
     try:
-        return [_dump(d) for d in mangroveai_client().kb.documents.list()]
+        return [_dump(d) for d in mangrove_ai_client().kb.documents.list()]
     except Exception as e:  # noqa: BLE001
         raise SdkError(f"kb.documents.list failed: {e}") from e
 
@@ -47,7 +47,7 @@ async def documents_list() -> Any:
 @router.get("/documents/{slug}", summary="Full KB document by slug")
 async def documents_get(slug: str) -> Any:
     try:
-        return _dump(mangroveai_client().kb.documents.get(slug))
+        return _dump(mangrove_ai_client().kb.documents.get(slug))
     except Exception as e:  # noqa: BLE001
         raise SdkError(f"kb.documents.get failed: {e}") from e
 
@@ -58,7 +58,7 @@ async def indicators_list(category: str | None = None) -> Any:
         kwargs: dict[str, Any] = {}
         if category is not None:
             kwargs["category"] = category
-        return [_dump(i) for i in mangroveai_client().kb.indicators.list(**kwargs)]
+        return [_dump(i) for i in mangrove_ai_client().kb.indicators.list(**kwargs)]
     except Exception as e:  # noqa: BLE001
         raise SdkError(f"kb.indicators.list failed: {e}") from e
 
@@ -66,6 +66,6 @@ async def indicators_list(category: str | None = None) -> Any:
 @router.get("/tags", summary="List all KB tags")
 async def tags_list() -> Any:
     try:
-        return [_dump(t) for t in mangroveai_client().kb.tags.list()]
+        return [_dump(t) for t in mangrove_ai_client().kb.tags.list()]
     except Exception as e:  # noqa: BLE001
         raise SdkError(f"kb.tags.list failed: {e}") from e

--- a/server/src/api/routes/market.py
+++ b/server/src/api/routes/market.py
@@ -6,7 +6,7 @@ from typing import Any
 from fastapi import APIRouter, Depends
 
 from src.shared.auth.dependency import require_api_key
-from src.shared.clients.mangrove import mangroveai_client
+from src.shared.clients.mangrove import mangrove_ai_client
 from src.shared.errors import SdkError
 
 router = APIRouter(
@@ -34,7 +34,7 @@ async def ohlcv(
         kwargs: dict[str, Any] = {"symbol": symbol, "days": lookback_days}
         if provider is not None:
             kwargs["provider"] = provider
-        return _dump(mangroveai_client().crypto_assets.get_ohlcv(**kwargs))
+        return _dump(mangrove_ai_client().crypto_assets.get_ohlcv(**kwargs))
     except Exception as e:  # noqa: BLE001
         raise SdkError(f"crypto_assets.get_ohlcv failed: {e}") from e
 
@@ -46,7 +46,7 @@ async def market_data(symbol: str, provider: str | None = None) -> Any:
         kwargs: dict[str, Any] = {"symbol": symbol}
         if provider is not None:
             kwargs["provider"] = provider
-        return _dump(mangroveai_client().crypto_assets.get_market_data(**kwargs))
+        return _dump(mangrove_ai_client().crypto_assets.get_market_data(**kwargs))
     except Exception as e:  # noqa: BLE001
         raise SdkError(f"crypto_assets.get_market_data failed: {e}") from e
 
@@ -54,7 +54,7 @@ async def market_data(symbol: str, provider: str | None = None) -> Any:
 @router.get("/trending", summary="Trending assets")
 async def trending() -> Any:
     try:
-        return _dump(mangroveai_client().crypto_assets.get_trending())
+        return _dump(mangrove_ai_client().crypto_assets.get_trending())
     except Exception as e:  # noqa: BLE001
         raise SdkError(f"crypto_assets.get_trending failed: {e}") from e
 
@@ -62,6 +62,6 @@ async def trending() -> Any:
 @router.get("/global", summary="Global market data (BTC dominance, total cap, 24h change)")
 async def global_market() -> Any:
     try:
-        return _dump(mangroveai_client().crypto_assets.get_global_market())
+        return _dump(mangrove_ai_client().crypto_assets.get_global_market())
     except Exception as e:  # noqa: BLE001
         raise SdkError(f"crypto_assets.get_global_market failed: {e}") from e

--- a/server/src/api/routes/on_chain.py
+++ b/server/src/api/routes/on_chain.py
@@ -6,7 +6,7 @@ from typing import Any
 from fastapi import APIRouter, Depends
 
 from src.shared.auth.dependency import require_api_key
-from src.shared.clients.mangrove import mangroveai_client
+from src.shared.clients.mangrove import mangrove_ai_client
 from src.shared.errors import SdkError
 
 router = APIRouter(
@@ -23,7 +23,7 @@ def _dump(obj: Any) -> Any:
 @router.get("/smart-money", summary="Smart money sentiment for a token")
 async def smart_money(symbol: str, chain: str | None = None) -> Any:
     try:
-        return _dump(mangroveai_client().on_chain.get_smart_money_sentiment(symbol, chain=chain))
+        return _dump(mangrove_ai_client().on_chain.get_smart_money_sentiment(symbol, chain=chain))
     except Exception as e:  # noqa: BLE001
         raise SdkError(f"on_chain.get_smart_money_sentiment failed: {e}") from e
 
@@ -31,7 +31,7 @@ async def smart_money(symbol: str, chain: str | None = None) -> Any:
 @router.get("/whale-activity", summary="Whale activity summary for a token")
 async def whale_activity(symbol: str, hours_back: int = 24) -> Any:
     try:
-        return _dump(mangroveai_client().on_chain.get_whale_activity(symbol, hours_back=hours_back))
+        return _dump(mangrove_ai_client().on_chain.get_whale_activity(symbol, hours_back=hours_back))
     except Exception as e:  # noqa: BLE001
         raise SdkError(f"on_chain.get_whale_activity failed: {e}") from e
 
@@ -39,6 +39,6 @@ async def whale_activity(symbol: str, hours_back: int = 24) -> Any:
 @router.get("/token-holders/{symbol}", summary="Holder distribution + concentration")
 async def token_holders(symbol: str) -> Any:
     try:
-        return _dump(mangroveai_client().on_chain.get_token_holders(symbol))
+        return _dump(mangrove_ai_client().on_chain.get_token_holders(symbol))
     except Exception as e:  # noqa: BLE001
         raise SdkError(f"on_chain.get_token_holders failed: {e}") from e

--- a/server/src/api/routes/oracle.py
+++ b/server/src/api/routes/oracle.py
@@ -1,0 +1,78 @@
+"""Oracle routes — auth-gated. Thin wrappers over services/oracle.py.
+
+Surface:
+- POST /api/v1/oracle/sieve     score 1-99 strategies through SIEVE
+- POST /api/v1/oracle/data/query query the corpus (results / ohlcv)
+- POST /api/v1/oracle/backtest   run a single backtest synchronously
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from src.services import oracle as oracle_service
+from src.services.oracle import (
+    DataQueryInput,
+    OracleBacktestInput,
+    SieveScoreInput,
+)
+from src.shared.auth.dependency import require_api_key
+from src.shared.errors import SdkError
+
+router = APIRouter(
+    prefix="/oracle",
+    dependencies=[Depends(require_api_key)],
+    tags=["oracle"],
+)
+
+
+@router.post(
+    "/sieve",
+    summary="Score strategies through Mangrove SIEVE",
+    description=(
+        "Run candidate strategies through the Mangrove SIEVE classifier "
+        "(binary + 4-class probabilities). Maximum 99 strategies per "
+        "request. Response carries `model_version` (content hash of the "
+        "bundled SIEVE artifacts) and `code_version` (Oracle dependency "
+        "stack) for provenance."
+    ),
+)
+async def post_sieve_score(payload: SieveScoreInput) -> dict[str, Any]:
+    try:
+        return oracle_service.sieve_score(payload)
+    except SdkError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+
+@router.post(
+    "/data/query",
+    summary="Query the Oracle corpus (results / ohlcv)",
+    description=(
+        "Run a whitelisted query against the Oracle corpus. Columns and "
+        "filter operators are enforced server-side. Tenancy is enforced "
+        "via the API key — `WHERE org_id = <caller's org>` is injected "
+        "by Oracle, you can never read another tenant's rows."
+    ),
+)
+async def post_data_query(payload: DataQueryInput) -> dict[str, Any]:
+    try:
+        return oracle_service.data_query(payload)
+    except SdkError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+
+@router.post(
+    "/backtest",
+    summary="Run a single strategy through Oracle's engine",
+    description=(
+        "Synchronous backtest. Blocks until the engine finishes (typically "
+        "30-120s on multi-month windows). Returns metrics + trade history. "
+        "For batch work, see the async variant via the SDK directly."
+    ),
+)
+async def post_backtest(payload: OracleBacktestInput) -> dict[str, Any]:
+    try:
+        return oracle_service.backtest(payload)
+    except SdkError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))

--- a/server/src/api/routes/signals.py
+++ b/server/src/api/routes/signals.py
@@ -6,7 +6,7 @@ from typing import Any
 from fastapi import APIRouter, Depends
 
 from src.shared.auth.dependency import require_api_key
-from src.shared.clients.mangrove import mangroveai_client
+from src.shared.clients.mangrove import mangrove_ai_client
 from src.shared.errors import SdkError
 
 router = APIRouter(
@@ -27,10 +27,10 @@ async def list_signals(
     limit: int = 50,
     offset: int = 0,
 ) -> dict:
-    client = mangroveai_client()
+    client = mangrove_ai_client()
     try:
         if search:
-            from mangroveai.models import SearchSignalsRequest
+            from mangrove_ai.models import SearchSignalsRequest
             page = client.signals.search(SearchSignalsRequest(query=search, limit=limit, offset=offset))
         else:
             page = client.signals.list(limit=limit, offset=offset)
@@ -53,6 +53,6 @@ async def list_signals(
 @router.get("/{name}", summary="Signal detail with parameter spec")
 async def get_signal(name: str) -> Any:
     try:
-        return _dump(mangroveai_client().signals.get(name))
+        return _dump(mangrove_ai_client().signals.get(name))
     except Exception as e:  # noqa: BLE001
         raise SdkError(f"signals.get failed: {e}") from e

--- a/server/src/api/routes/wallet.py
+++ b/server/src/api/routes/wallet.py
@@ -47,7 +47,7 @@ from src.services.wallet_manager import (
     stash_external_secret,
 )
 from src.shared.auth.dependency import require_api_key
-from src.shared.clients.mangrove import mangrovemarkets_client
+from src.shared.clients.mangrove import mangrove_markets_client
 from src.shared.errors import SdkError, SigningError
 
 router = APIRouter(
@@ -226,7 +226,7 @@ async def wallet_list() -> list[WalletListItem]:
 )
 async def wallet_balances(address: str, chain_id: int) -> Any:
     try:
-        result = mangrovemarkets_client().dex.balances(chain_id=chain_id, wallet=address)
+        result = mangrove_markets_client().dex.balances(chain_id=chain_id, wallet=address)
     except Exception as e:  # noqa: BLE001
         raise SdkError(f"dex.balances failed: {e}") from e
     return result.model_dump() if hasattr(result, "model_dump") else result
@@ -238,7 +238,7 @@ async def wallet_balances(address: str, chain_id: int) -> Any:
     description="Combined value + P&L + tokens + DeFi via mangrovemarkets.portfolio.*.",
 )
 async def wallet_portfolio(address: str, chain_id: int | None = None) -> dict:
-    client = mangrovemarkets_client()
+    client = mangrove_markets_client()
     try:
         value = client.portfolio.value(addresses=address, chain_id=chain_id)
         pnl = client.portfolio.pnl(addresses=address, chain_id=chain_id)
@@ -261,7 +261,7 @@ async def wallet_portfolio(address: str, chain_id: int | None = None) -> dict:
 )
 async def wallet_history(address: str, limit: int = 50) -> list[Any]:
     try:
-        items = mangrovemarkets_client().portfolio.history(address=address, limit=limit)
+        items = mangrove_markets_client().portfolio.history(address=address, limit=limit)
     except Exception as e:  # noqa: BLE001
         raise SdkError(f"portfolio.history failed: {e}") from e
     return [i.model_dump() if hasattr(i, "model_dump") else i for i in items]

--- a/server/src/mcp/tools.py
+++ b/server/src/mcp/tools.py
@@ -87,6 +87,7 @@ def register(server: FastMCP):
     _register_strategy(server)
     _register_logs(server)
     _register_kb(server)
+    _register_oracle(server)
     _register_hello_mangrove(server)
 
 
@@ -244,8 +245,8 @@ def _register_wallet(server: FastMCP) -> None:
         if not _require(api_key):
             return _auth_error()
         try:
-            from src.shared.clients.mangrove import mangrovemarkets_client
-            result = mangrovemarkets_client().dex.balances(chain_id=chain_id, wallet=address)
+            from src.shared.clients.mangrove import mangrove_markets_client
+            result = mangrove_markets_client().dex.balances(chain_id=chain_id, wallet=address)
             return json.dumps(_dump(result))
         except AgentError as e:
             return _handle_agent_error(e)
@@ -278,8 +279,8 @@ def _register_wallet(server: FastMCP) -> None:
         if not _require(api_key):
             return _auth_error()
         try:
-            from src.shared.clients.mangrove import mangrovemarkets_client
-            result = mangrovemarkets_client().portfolio.value(
+            from src.shared.clients.mangrove import mangrove_markets_client
+            result = mangrove_markets_client().portfolio.value(
                 addresses=addresses, chain_id=chain_id,
             )
             return json.dumps(_dump(result))
@@ -310,8 +311,8 @@ def _register_wallet(server: FastMCP) -> None:
         if not _require(api_key):
             return _auth_error()
         try:
-            from src.shared.clients.mangrove import mangrovemarkets_client
-            result = mangrovemarkets_client().portfolio.pnl(
+            from src.shared.clients.mangrove import mangrove_markets_client
+            result = mangrove_markets_client().portfolio.pnl(
                 addresses=addresses, chain_id=chain_id,
             )
             return json.dumps(_dump(result))
@@ -341,8 +342,8 @@ def _register_wallet(server: FastMCP) -> None:
         if not _require(api_key):
             return _auth_error()
         try:
-            from src.shared.clients.mangrove import mangrovemarkets_client
-            result = mangrovemarkets_client().portfolio.tokens(
+            from src.shared.clients.mangrove import mangrove_markets_client
+            result = mangrove_markets_client().portfolio.tokens(
                 addresses=addresses, chain_id=chain_id,
             )
             return json.dumps(_dump(result))
@@ -368,8 +369,8 @@ def _register_wallet(server: FastMCP) -> None:
         if not _require(api_key):
             return _auth_error()
         try:
-            from src.shared.clients.mangrove import mangrovemarkets_client
-            result = mangrovemarkets_client().portfolio.defi(
+            from src.shared.clients.mangrove import mangrove_markets_client
+            result = mangrove_markets_client().portfolio.defi(
                 addresses=addresses, chain_id=chain_id,
             )
             return json.dumps(_dump(result))
@@ -400,8 +401,8 @@ def _register_wallet(server: FastMCP) -> None:
         if not _require(api_key):
             return _auth_error()
         try:
-            from src.shared.clients.mangrove import mangrovemarkets_client
-            items = mangrovemarkets_client().portfolio.history(
+            from src.shared.clients.mangrove import mangrove_markets_client
+            items = mangrove_markets_client().portfolio.history(
                 address=address, limit=limit,
             )
             return json.dumps([_dump(i) for i in items])
@@ -431,8 +432,8 @@ def _register_dex(server: FastMCP) -> None:
         """List supported DEX venues."""
         if not _require(api_key):
             return _auth_error()
-        from src.shared.clients.mangrove import mangrovemarkets_client
-        venues = mangrovemarkets_client().dex.supported_venues()
+        from src.shared.clients.mangrove import mangrove_markets_client
+        venues = mangrove_markets_client().dex.supported_venues()
         return json.dumps([_dump(v) for v in venues])
 
     register_tool(ToolEntry(
@@ -459,7 +460,7 @@ def _register_dex(server: FastMCP) -> None:
         if not _require(api_key):
             return _auth_error()
         try:
-            from src.shared.clients.mangrove import mangrovemarkets_client
+            from src.shared.clients.mangrove import mangrove_markets_client
             kwargs: dict[str, Any] = {
                 "input_token": input_token,
                 "output_token": output_token,
@@ -469,7 +470,7 @@ def _register_dex(server: FastMCP) -> None:
             }
             if mode is not None:
                 kwargs["mode"] = mode
-            q = mangrovemarkets_client().dex.get_quote(**kwargs)
+            q = mangrove_markets_client().dex.get_quote(**kwargs)
             return json.dumps(_dump(q))
         except AgentError as e:
             return _handle_agent_error(e)
@@ -576,8 +577,8 @@ def _register_dex(server: FastMCP) -> None:
         if not _require(api_key):
             return _auth_error()
         try:
-            from src.shared.clients.mangrove import mangrovemarkets_client
-            result = mangrovemarkets_client().dex.tx_status(
+            from src.shared.clients.mangrove import mangrove_markets_client
+            result = mangrove_markets_client().dex.tx_status(
                 tx_hash=tx_hash, chain_id=chain_id, venue_id=venue_id,
             )
             return json.dumps(_dump(result))
@@ -618,8 +619,8 @@ def _register_dex(server: FastMCP) -> None:
         if not _require(api_key):
             return _auth_error()
         try:
-            from src.shared.clients.mangrove import mangrovemarkets_client
-            result = mangrovemarkets_client().dex.token_info(
+            from src.shared.clients.mangrove import mangrove_markets_client
+            result = mangrove_markets_client().dex.token_info(
                 chain_id=chain_id, address=address,
             )
             return json.dumps(_dump(result))
@@ -656,8 +657,8 @@ def _register_dex(server: FastMCP) -> None:
         if not _require(api_key):
             return _auth_error()
         try:
-            from src.shared.clients.mangrove import mangrovemarkets_client
-            result = mangrovemarkets_client().dex.spot_price(
+            from src.shared.clients.mangrove import mangrove_markets_client
+            result = mangrove_markets_client().dex.spot_price(
                 chain_id=chain_id, tokens=tokens,
             )
             return json.dumps(_dump(result))
@@ -695,8 +696,8 @@ def _register_dex(server: FastMCP) -> None:
         if not _require(api_key):
             return _auth_error()
         try:
-            from src.shared.clients.mangrove import mangrovemarkets_client
-            result = mangrovemarkets_client().dex.gas_price(chain_id=chain_id)
+            from src.shared.clients.mangrove import mangrove_markets_client
+            result = mangrove_markets_client().dex.gas_price(chain_id=chain_id)
             return json.dumps(_dump(result))
         except Exception as e:  # noqa: BLE001
             return _err("DEX_GAS_PRICE_FAILED", str(e))
@@ -725,8 +726,8 @@ def _register_dex(server: FastMCP) -> None:
         if not _require(api_key):
             return _auth_error()
         try:
-            from src.shared.clients.mangrove import mangrovemarkets_client
-            results = mangrovemarkets_client().dex.token_search(
+            from src.shared.clients.mangrove import mangrove_markets_client
+            results = mangrove_markets_client().dex.token_search(
                 chain_id=chain_id, query=query,
             )
             return json.dumps([_dump(r) for r in results])
@@ -765,8 +766,8 @@ def _register_dex(server: FastMCP) -> None:
         if not _require(api_key):
             return _auth_error()
         try:
-            from src.shared.clients.mangrove import mangrovemarkets_client
-            result = mangrovemarkets_client().dex.chart(
+            from src.shared.clients.mangrove import mangrove_markets_client
+            result = mangrove_markets_client().dex.chart(
                 chain_id=chain_id, token0=token0, token1=token1, period=period,
             )
             return json.dumps([_dump(c) for c in result])
@@ -798,8 +799,8 @@ def _register_dex(server: FastMCP) -> None:
         if not _require(api_key):
             return _auth_error()
         try:
-            from src.shared.clients.mangrove import mangrovemarkets_client
-            result = mangrovemarkets_client().dex.allowances(
+            from src.shared.clients.mangrove import mangrove_markets_client
+            result = mangrove_markets_client().dex.allowances(
                 chain_id=chain_id, wallet=wallet, spender=spender,
             )
             return json.dumps(_dump(result))
@@ -840,11 +841,11 @@ def _register_market(server: FastMCP) -> None:
         """
         if not _require(api_key):
             return _auth_error()
-        from src.shared.clients.mangrove import mangroveai_client
+        from src.shared.clients.mangrove import mangrove_ai_client
         kwargs: dict[str, Any] = {"symbol": symbol, "days": lookback_days}
         if provider is not None:
             kwargs["provider"] = provider
-        result = mangroveai_client().crypto_assets.get_ohlcv(**kwargs)
+        result = mangrove_ai_client().crypto_assets.get_ohlcv(**kwargs)
         return json.dumps(_dump(result))
 
     register_tool(ToolEntry(
@@ -876,11 +877,11 @@ def _register_market(server: FastMCP) -> None:
         """
         if not _require(api_key):
             return _auth_error()
-        from src.shared.clients.mangrove import mangroveai_client
+        from src.shared.clients.mangrove import mangrove_ai_client
         kwargs: dict[str, Any] = {"symbol": symbol}
         if provider is not None:
             kwargs["provider"] = provider
-        return json.dumps(_dump(mangroveai_client().crypto_assets.get_market_data(**kwargs)))
+        return json.dumps(_dump(mangrove_ai_client().crypto_assets.get_market_data(**kwargs)))
 
     register_tool(ToolEntry(
         name="get_market_data",
@@ -903,8 +904,8 @@ def _register_market(server: FastMCP) -> None:
         if not _require(api_key):
             return _auth_error()
         try:
-            from src.shared.clients.mangrove import mangroveai_client
-            return json.dumps(_dump(mangroveai_client().crypto_assets.get_trending()))
+            from src.shared.clients.mangrove import mangrove_ai_client
+            return json.dumps(_dump(mangrove_ai_client().crypto_assets.get_trending()))
         except Exception as e:  # noqa: BLE001
             return _err("CRYPTO_TRENDING_FAILED", str(e))
 
@@ -928,11 +929,11 @@ def _register_market(server: FastMCP) -> None:
         if not _require(api_key):
             return _auth_error()
         try:
-            from src.shared.clients.mangrove import mangroveai_client
+            from src.shared.clients.mangrove import mangrove_ai_client
             kwargs: dict[str, Any] = {"approved_only": True, "limit": limit}
             if min_score is not None:
                 kwargs["min_score"] = min_score
-            items = mangroveai_client().crypto_assets.list(**kwargs)
+            items = mangrove_ai_client().crypto_assets.list(**kwargs)
             return json.dumps([_dump(i) for i in items])
         except Exception as e:  # noqa: BLE001
             return _err("CRYPTO_LIST_FAILED", str(e))
@@ -958,8 +959,8 @@ def _register_market(server: FastMCP) -> None:
         if not _require(api_key):
             return _auth_error()
         try:
-            from src.shared.clients.mangrove import mangroveai_client
-            return json.dumps(_dump(mangroveai_client().crypto_assets.get(symbol)))
+            from src.shared.clients.mangrove import mangrove_ai_client
+            return json.dumps(_dump(mangrove_ai_client().crypto_assets.get(symbol)))
         except Exception as e:  # noqa: BLE001
             return _err("CRYPTO_GET_FAILED", str(e))
 
@@ -983,8 +984,8 @@ def _register_market(server: FastMCP) -> None:
         if not _require(api_key):
             return _auth_error()
         try:
-            from src.shared.clients.mangrove import mangroveai_client
-            return json.dumps(_dump(mangroveai_client().crypto_assets.get_global_market()))
+            from src.shared.clients.mangrove import mangrove_ai_client
+            return json.dumps(_dump(mangrove_ai_client().crypto_assets.get_global_market()))
         except Exception as e:  # noqa: BLE001
             return _err("CRYPTO_GLOBAL_FAILED", str(e))
 
@@ -1008,10 +1009,10 @@ def _register_signals(server: FastMCP) -> None:
         """List available signals (optionally filtered by category or search)."""
         if not _require(api_key):
             return _auth_error()
-        from src.shared.clients.mangrove import mangroveai_client
-        client = mangroveai_client()
+        from src.shared.clients.mangrove import mangrove_ai_client
+        client = mangrove_ai_client()
         if search:
-            from mangroveai.models import SearchSignalsRequest
+            from mangrove_ai.models import SearchSignalsRequest
             page = client.signals.search(SearchSignalsRequest(query=search, limit=limit))
             items = [_dump(s) for s in getattr(page, "items", [])]
         else:
@@ -1044,8 +1045,8 @@ def _register_signals(server: FastMCP) -> None:
         if not _require(api_key):
             return _auth_error()
         try:
-            from src.shared.clients.mangrove import mangroveai_client
-            return json.dumps(_dump(mangroveai_client().signals.get(signal_name)))
+            from src.shared.clients.mangrove import mangrove_ai_client
+            return json.dumps(_dump(mangrove_ai_client().signals.get(signal_name)))
         except Exception as e:  # noqa: BLE001
             return _err("SIGNAL_GET_FAILED", str(e))
 
@@ -1076,8 +1077,8 @@ def _register_signals(server: FastMCP) -> None:
         if not _require(api_key):
             return _auth_error()
         try:
-            from src.shared.clients.mangrove import mangroveai_client
-            r = mangroveai_client().signals.match(
+            from src.shared.clients.mangrove import mangrove_ai_client
+            r = mangrove_ai_client().signals.match(
                 description=description, top_k=top_k,
                 similarity_threshold=similarity_threshold,
             )
@@ -1109,11 +1110,11 @@ def _register_signals(server: FastMCP) -> None:
         if not _require(api_key):
             return _auth_error()
         try:
-            from mangroveai.models import SearchSignalsRequest
+            from mangrove_ai.models import SearchSignalsRequest
 
-            from src.shared.clients.mangrove import mangroveai_client
+            from src.shared.clients.mangrove import mangrove_ai_client
             req = SearchSignalsRequest(query=query, limit=limit, offset=offset)
-            page = mangroveai_client().signals.search(req)
+            page = mangrove_ai_client().signals.search(req)
             items = [_dump(s) for s in getattr(page, "items", [])]
             return json.dumps({
                 "items": items,
@@ -1148,7 +1149,7 @@ def _register_on_chain(server: FastMCP) -> None:
     intelligence" rule — they provide the 'why now' evidence for a
     candidate strategy.
     """
-    from src.shared.clients.mangrove import mangroveai_client
+    from src.shared.clients.mangrove import mangrove_ai_client
 
     @server.tool()
     async def get_whale_activity(
@@ -1158,7 +1159,7 @@ def _register_on_chain(server: FastMCP) -> None:
         if not _require(api_key):
             return _auth_error()
         try:
-            r = mangroveai_client().on_chain.get_whale_activity(
+            r = mangrove_ai_client().on_chain.get_whale_activity(
                 symbol=symbol, hours_back=hours_back,
             )
             return json.dumps(_dump(r))
@@ -1190,7 +1191,7 @@ def _register_on_chain(server: FastMCP) -> None:
             }
             if symbol is not None:
                 kwargs["symbol"] = symbol
-            r = mangroveai_client().on_chain.get_whale_transactions(**kwargs)
+            r = mangrove_ai_client().on_chain.get_whale_transactions(**kwargs)
             return json.dumps(_dump(r))
         except Exception as e:  # noqa: BLE001
             return _err("ONCHAIN_WHALE_TXS_FAILED", str(e))
@@ -1226,7 +1227,7 @@ def _register_on_chain(server: FastMCP) -> None:
             kwargs: dict[str, Any] = {"symbol": symbol}
             if chain is not None:
                 kwargs["chain"] = chain
-            r = mangroveai_client().on_chain.get_smart_money_sentiment(**kwargs)
+            r = mangrove_ai_client().on_chain.get_smart_money_sentiment(**kwargs)
             return json.dumps(_dump(r))
         except Exception as e:  # noqa: BLE001
             return _err("ONCHAIN_SMART_MONEY_FAILED", str(e))
@@ -1254,7 +1255,7 @@ def _register_on_chain(server: FastMCP) -> None:
             kwargs: dict[str, Any] = {"timeframe": timeframe, "limit": limit}
             if chains is not None:
                 kwargs["chains"] = chains
-            r = mangroveai_client().on_chain.screen_smart_money(**kwargs)
+            r = mangrove_ai_client().on_chain.screen_smart_money(**kwargs)
             return json.dumps(_dump(r))
         except Exception as e:  # noqa: BLE001
             return _err("ONCHAIN_SMART_MONEY_SCREEN_FAILED", str(e))
@@ -1277,7 +1278,7 @@ def _register_on_chain(server: FastMCP) -> None:
         if not _require(api_key):
             return _auth_error()
         try:
-            r = mangroveai_client().on_chain.get_token_holders(symbol=symbol)
+            r = mangrove_ai_client().on_chain.get_token_holders(symbol=symbol)
             return json.dumps(_dump(r))
         except Exception as e:  # noqa: BLE001
             return _err("ONCHAIN_HOLDERS_FAILED", str(e))
@@ -1306,7 +1307,7 @@ def _register_on_chain(server: FastMCP) -> None:
             kwargs: dict[str, Any] = {"hours_back": hours_back}
             if symbol is not None:
                 kwargs["symbol"] = symbol
-            r = mangroveai_client().on_chain.get_exchange_flows(**kwargs)
+            r = mangrove_ai_client().on_chain.get_exchange_flows(**kwargs)
             return json.dumps(_dump(r))
         except Exception as e:  # noqa: BLE001
             return _err("ONCHAIN_EXCHANGE_FLOWS_FAILED", str(e))
@@ -1330,7 +1331,7 @@ def _register_on_chain(server: FastMCP) -> None:
 
 def _register_defi(server: FastMCP) -> None:
     """Macro DeFi metrics (TVL, stablecoin supply)."""
-    from src.shared.clients.mangrove import mangroveai_client
+    from src.shared.clients.mangrove import mangrove_ai_client
 
     @server.tool()
     async def get_chain_tvl(chain: str, api_key: str = "") -> str:
@@ -1338,7 +1339,7 @@ def _register_defi(server: FastMCP) -> None:
         if not _require(api_key):
             return _auth_error()
         try:
-            return json.dumps(_dump(mangroveai_client().defi.get_chain_tvl(chain=chain)))
+            return json.dumps(_dump(mangrove_ai_client().defi.get_chain_tvl(chain=chain)))
         except Exception as e:  # noqa: BLE001
             return _err("DEFI_CHAIN_TVL_FAILED", str(e))
 
@@ -1358,7 +1359,7 @@ def _register_defi(server: FastMCP) -> None:
         if not _require(api_key):
             return _auth_error()
         try:
-            return json.dumps(_dump(mangroveai_client().defi.get_protocol_tvl(protocol=protocol)))
+            return json.dumps(_dump(mangrove_ai_client().defi.get_protocol_tvl(protocol=protocol)))
         except Exception as e:  # noqa: BLE001
             return _err("DEFI_PROTOCOL_TVL_FAILED", str(e))
 
@@ -1378,7 +1379,7 @@ def _register_defi(server: FastMCP) -> None:
         if not _require(api_key):
             return _auth_error()
         try:
-            return json.dumps(_dump(mangroveai_client().defi.get_stablecoin_metrics()))
+            return json.dumps(_dump(mangrove_ai_client().defi.get_stablecoin_metrics()))
         except Exception as e:  # noqa: BLE001
             return _err("DEFI_STABLECOIN_FAILED", str(e))
 
@@ -1397,7 +1398,7 @@ def _register_defi(server: FastMCP) -> None:
 
 def _register_social(server: FastMCP) -> None:
     """Twitter/X sentiment + influence + mentions. Experimental context."""
-    from src.shared.clients.mangrove import mangroveai_client
+    from src.shared.clients.mangrove import mangrove_ai_client
 
     @server.tool()
     async def get_sentiment(
@@ -1407,7 +1408,7 @@ def _register_social(server: FastMCP) -> None:
         if not _require(api_key):
             return _auth_error()
         try:
-            r = mangroveai_client().social.get_sentiment(topic=topic, hours_back=hours_back)
+            r = mangrove_ai_client().social.get_sentiment(topic=topic, hours_back=hours_back)
             return json.dumps(_dump(r))
         except Exception as e:  # noqa: BLE001
             return _err("SOCIAL_SENTIMENT_FAILED", str(e))
@@ -1431,7 +1432,7 @@ def _register_social(server: FastMCP) -> None:
         if not _require(api_key):
             return _auth_error()
         try:
-            r = mangroveai_client().social.get_mentions(
+            r = mangrove_ai_client().social.get_mentions(
                 topic=topic, hours_back=hours_back, limit=limit,
             )
             return json.dumps(_dump(r))
@@ -1456,7 +1457,7 @@ def _register_social(server: FastMCP) -> None:
         if not _require(api_key):
             return _auth_error()
         try:
-            r = mangroveai_client().social.get_influence_score(username=username)
+            r = mangrove_ai_client().social.get_influence_score(username=username)
             return json.dumps(_dump(r))
         except Exception as e:  # noqa: BLE001
             return _err("SOCIAL_INFLUENCE_FAILED", str(e))
@@ -1479,7 +1480,7 @@ def _register_social(server: FastMCP) -> None:
 
 def _register_docs(server: FastMCP) -> None:
     """MangroveAI developer docs (API reference + guides)."""
-    from src.shared.clients.mangrove import mangroveai_client
+    from src.shared.clients.mangrove import mangrove_ai_client
 
     @server.tool()
     async def list_docs(api_key: str = "") -> str:
@@ -1493,7 +1494,7 @@ def _register_docs(server: FastMCP) -> None:
         if not _require(api_key):
             return _auth_error()
         try:
-            items = mangroveai_client().docs.list()
+            items = mangrove_ai_client().docs.list()
             return json.dumps([_dump(i) for i in items])
         except Exception as e:  # noqa: BLE001
             return _err("DOCS_LIST_FAILED", str(e))
@@ -1516,7 +1517,7 @@ def _register_docs(server: FastMCP) -> None:
         if not _require(api_key):
             return _auth_error()
         try:
-            return json.dumps(_dump(mangroveai_client().docs.get_content(path=path)))
+            return json.dumps(_dump(mangrove_ai_client().docs.get_content(path=path)))
         except Exception as e:  # noqa: BLE001
             return _err("DOCS_GET_FAILED", str(e))
 
@@ -1908,13 +1909,13 @@ def _register_strategy(server: FastMCP) -> None:
         if not _require(api_key):
             return _auth_error()
         try:
-            from src.shared.clients.mangrove import mangroveai_client
+            from src.shared.clients.mangrove import mangrove_ai_client
             kwargs: dict[str, Any] = {"skip": skip, "limit": limit}
             if account_id is not None:
                 kwargs["account_id"] = account_id
             if status is not None:
                 kwargs["status"] = status
-            items = mangroveai_client().execution.list_positions(**kwargs)
+            items = mangrove_ai_client().execution.list_positions(**kwargs)
             return json.dumps([_dump(i) for i in items])
         except Exception as e:  # noqa: BLE001
             return _err("EXECUTION_POSITIONS_FAILED", str(e))
@@ -1938,8 +1939,8 @@ def _register_strategy(server: FastMCP) -> None:
         if not _require(api_key):
             return _auth_error()
         try:
-            from src.shared.clients.mangrove import mangroveai_client
-            return json.dumps(_dump(mangroveai_client().execution.get_position(position_id)))
+            from src.shared.clients.mangrove import mangrove_ai_client
+            return json.dumps(_dump(mangrove_ai_client().execution.get_position(position_id)))
         except Exception as e:  # noqa: BLE001
             return _err("EXECUTION_POSITION_GET_FAILED", str(e))
 
@@ -1971,7 +1972,7 @@ def _register_strategy(server: FastMCP) -> None:
         if not _require(api_key):
             return _auth_error()
         try:
-            from src.shared.clients.mangrove import mangroveai_client
+            from src.shared.clients.mangrove import mangrove_ai_client
             kwargs: dict[str, Any] = {"skip": skip, "limit": limit}
             if account_id is not None:
                 kwargs["account_id"] = account_id
@@ -1979,7 +1980,7 @@ def _register_strategy(server: FastMCP) -> None:
                 kwargs["asset"] = asset
             if outcome is not None:
                 kwargs["outcome"] = outcome
-            items = mangroveai_client().execution.list_trades(**kwargs)
+            items = mangrove_ai_client().execution.list_trades(**kwargs)
             return json.dumps([_dump(i) for i in items])
         except Exception as e:  # noqa: BLE001
             return _err("EXECUTION_TRADES_FAILED", str(e))
@@ -2013,10 +2014,10 @@ def _register_strategy(server: FastMCP) -> None:
             return _auth_error()
         try:
             from src.services.strategy_service import get_strategy
-            from src.shared.clients.mangrove import mangroveai_client
+            from src.shared.clients.mangrove import mangrove_ai_client
             # Look up the mangrove_id from our local cache.
             detail = get_strategy(strategy_id)
-            r = mangroveai_client().strategies.delete(detail.mangrove_id)
+            r = mangrove_ai_client().strategies.delete(detail.mangrove_id)
             return json.dumps(_dump(r))
         except AgentError as e:
             return _handle_agent_error(e)
@@ -2120,8 +2121,8 @@ def _register_kb(server: FastMCP) -> None:
         """Full-text search the knowledge base."""
         if not _require(api_key):
             return _auth_error()
-        from src.shared.clients.mangrove import mangroveai_client
-        return json.dumps(_dump(mangroveai_client().kb.search.query(q=q, limit=limit)))
+        from src.shared.clients.mangrove import mangrove_ai_client
+        return json.dumps(_dump(mangrove_ai_client().kb.search.query(q=q, limit=limit)))
 
     register_tool(ToolEntry(
         name="kb_search",
@@ -2144,9 +2145,9 @@ def _register_kb(server: FastMCP) -> None:
         """
         if not _require(api_key):
             return _auth_error()
-        from src.shared.clients.mangrove import mangroveai_client
+        from src.shared.clients.mangrove import mangrove_ai_client
         try:
-            return json.dumps(_dump(mangroveai_client().kb.glossary.get(term)))
+            return json.dumps(_dump(mangrove_ai_client().kb.glossary.get(term)))
         except Exception as e:  # noqa: BLE001
             return _err("KB_GLOSSARY_FAILED", str(e))
 
@@ -2172,9 +2173,9 @@ def _register_kb(server: FastMCP) -> None:
         """
         if not _require(api_key):
             return _auth_error()
-        from src.shared.clients.mangrove import mangroveai_client
+        from src.shared.clients.mangrove import mangrove_ai_client
         try:
-            return json.dumps(_dump(mangroveai_client().kb.documents.get(slug)))
+            return json.dumps(_dump(mangrove_ai_client().kb.documents.get(slug)))
         except Exception as e:  # noqa: BLE001
             return _err("KB_DOCUMENT_NOT_FOUND", str(e))
 
@@ -2207,12 +2208,12 @@ def _register_kb(server: FastMCP) -> None:
         """
         if not _require(api_key):
             return _auth_error()
-        from src.shared.clients.mangrove import mangroveai_client
+        from src.shared.clients.mangrove import mangrove_ai_client
         kwargs: dict[str, Any] = {}
         if category is not None:
             kwargs["category"] = category
         try:
-            return json.dumps([_dump(i) for i in mangroveai_client().kb.indicators.list(**kwargs)])
+            return json.dumps([_dump(i) for i in mangrove_ai_client().kb.indicators.list(**kwargs)])
         except Exception as e:  # noqa: BLE001
             return _err("KB_INDICATORS_FAILED", str(e))
 
@@ -2231,9 +2232,9 @@ def _register_kb(server: FastMCP) -> None:
         """List all KB tags — useful for navigation or kb_search filtering."""
         if not _require(api_key):
             return _auth_error()
-        from src.shared.clients.mangrove import mangroveai_client
+        from src.shared.clients.mangrove import mangrove_ai_client
         try:
-            return json.dumps([_dump(t) for t in mangroveai_client().kb.tags.list()])
+            return json.dumps([_dump(t) for t in mangrove_ai_client().kb.tags.list()])
         except Exception as e:  # noqa: BLE001
             return _err("KB_TAGS_FAILED", str(e))
 
@@ -2242,6 +2243,156 @@ def _register_kb(server: FastMCP) -> None:
         description="List KB tags (navigation + kb_search filtering).",
         access="auth",
         parameters=[_APIKEY],
+    ))
+
+
+# ---------------------------------------------------------------------------
+# Oracle (auth) — SIEVE + data query + Oracle backtest
+# ---------------------------------------------------------------------------
+
+
+def _register_oracle(server: FastMCP) -> None:
+    """SIEVE scoring + curated corpus query + Oracle backtest tools.
+
+    All three are auth-gated. The agent forwards to the mangrove-ai SDK's
+    `client.oracle.*` surface, which proxies through MangroveAI's
+    `/api/v1/oracle/*` to MangroveOracle.
+    """
+
+    @server.tool()
+    async def sieve_score(
+        strategies: list[dict[str, Any]],
+        api_key: str = "",
+    ) -> str:
+        """Score up to 99 candidate strategies through the Mangrove SIEVE
+        classifier. Returns binary go/no-go and 4-class outcome
+        probabilities per strategy, with `model_version` + `code_version`
+        for provenance.
+
+        Use BEFORE paying for backtests: SIEVE cheaply rules out
+        strategies the model predicts will produce no trades, win nothing,
+        or lose. Then backtest only the survivors.
+        """
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            from src.services.oracle import SieveScoreInput
+            from src.services.oracle import sieve_score as svc
+            result = svc(SieveScoreInput(strategies=strategies))
+            return json.dumps(result)
+        except AgentError as e:
+            return _handle_agent_error(e)
+
+    register_tool(ToolEntry(
+        name="sieve_score",
+        description=(
+            "Score 1-99 strategies through Mangrove SIEVE before paying for "
+            "backtests. Returns binary + 4-class probabilities per item, "
+            "with model + code provenance."
+        ),
+        access="auth",
+        parameters=[
+            ToolParam(
+                name="strategies",
+                type="array<Strategy>",
+                required=True,
+                description="MangroveAI-shaped Strategy objects (1-99 items).",
+            ),
+            _APIKEY,
+        ],
+    ))
+
+    @server.tool()
+    async def oracle_data_query(
+        table: str,
+        select: list[str],
+        filters: list[dict[str, Any]] | None = None,
+        order_by: list[str] | None = None,
+        limit: int = 100,
+        offset: int = 0,
+        api_key: str = "",
+    ) -> str:
+        """Query the curated Oracle corpus (results / ohlcv) through the
+        BigQuery proxy. Columns and filter operators are whitelisted
+        server-side. Tenancy is enforced: `WHERE org_id = <caller's org>`
+        is injected by Oracle — you can never read another tenant's rows.
+        """
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            from src.services.oracle import DataQueryInput
+            from src.services.oracle import data_query as svc
+            result = svc(DataQueryInput(
+                table=table,
+                select=select,
+                filters=filters or [],
+                order_by=order_by,
+                limit=limit,
+                offset=offset,
+            ))
+            return json.dumps(result)
+        except AgentError as e:
+            return _handle_agent_error(e)
+
+    register_tool(ToolEntry(
+        name="oracle_data_query",
+        description=(
+            "Query the curated Oracle corpus (results / ohlcv). Whitelist-"
+            "enforced columns + filter ops; tenancy injected server-side."
+        ),
+        access="auth",
+        parameters=[
+            ToolParam(name="table", type="string", required=True, description="'results' | 'ohlcv'"),
+            ToolParam(name="select", type="array<string>", required=True, description="Columns to return."),
+            ToolParam(name="filters", type="array<{col,op,value}>", required=False, description="Filter clauses."),
+            ToolParam(name="order_by", type="array<string>", required=False, description="Optional ORDER BY clauses."),
+            ToolParam(name="limit", type="integer", required=False, description="Default 100, max 1000."),
+            ToolParam(name="offset", type="integer", required=False, description="Default 0."),
+            _APIKEY,
+        ],
+    ))
+
+    @server.tool()
+    async def oracle_backtest(
+        asset: str,
+        interval: str,
+        strategy_json: str,
+        lookback_months: int | None = 12,
+        api_key: str = "",
+    ) -> str:
+        """Backtest a single strategy synchronously through Oracle's engine.
+        Blocks until the engine finishes (30-120s on multi-month windows).
+        Returns metrics + trade history. For batch work, prefer the SDK's
+        backtest_async / backtest_bulk directly.
+        """
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            from src.services.oracle import OracleBacktestInput
+            from src.services.oracle import backtest as svc
+            result = svc(OracleBacktestInput(
+                asset=asset,
+                interval=interval,
+                strategy_json=strategy_json,
+                lookback_months=lookback_months,
+            ))
+            return json.dumps(result)
+        except AgentError as e:
+            return _handle_agent_error(e)
+
+    register_tool(ToolEntry(
+        name="oracle_backtest",
+        description=(
+            "Backtest one strategy through Oracle's engine (synchronous)."
+        ),
+        access="auth",
+        parameters=[
+            ToolParam(name="asset", type="string", required=True, description="e.g. BTC, ETH"),
+            ToolParam(name="interval", type="string", required=True, description="e.g. 1h, 4h, 1d"),
+            ToolParam(name="strategy_json", type="string", required=True, description="Strategy JSON (MangroveAI shape)."),
+            ToolParam(name="lookback_months", type="integer", required=False, description="Default 12."),
+            _APIKEY,
+        ],
     ))
 
 

--- a/server/src/services/backtest_service.py
+++ b/server/src/services/backtest_service.py
@@ -20,13 +20,13 @@ import json
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
-from mangroveai.models import BacktestRequest
+from mangrove_ai.models import BacktestRequest
 from pydantic import BaseModel
 
 from src.config import app_config
 from src.services.candidate_generator import StrategyCandidate
 from src.shared import timeframes
-from src.shared.clients.mangrove import mangroveai_client
+from src.shared.clients.mangrove import mangrove_ai_client
 from src.shared.errors import SdkError
 from src.shared.logging import get_logger
 
@@ -111,7 +111,7 @@ def _get_trading_defaults() -> dict[str, Any]:
 
     Cached for the process lifetime after first successful fetch. Falls
     back to the hardcoded snapshot above on ANY of these failure modes:
-      - mangroveai_client() raises (config not loaded, etc.)
+      - mangrove_ai_client() raises (config not loaded, etc.)
       - .config attribute missing (older SDK without ConfigService — pre-0.3.0)
       - .trading_defaults() raises (network down, 5xx, etc.)
       - .trading_defaults() returns empty/non-dict/missing-required-sections
@@ -130,7 +130,7 @@ def _get_trading_defaults() -> dict[str, Any]:
 
     fetched: dict[str, Any] | None = None
     try:
-        client = mangroveai_client()
+        client = mangrove_ai_client()
         config_svc = getattr(client, "config", None)
         if config_svc is None:
             raise AttributeError("mangroveai client has no `config` service (need SDK >= 0.3.0)")
@@ -369,7 +369,7 @@ def quick_backtest_all(
     if lookback_months is None:
         lookback_months = int(app_config.BACKTEST_DEFAULT_LOOKBACK_MONTHS)
 
-    client = mangroveai_client()
+    client = mangrove_ai_client()
     results: list[CandidateBacktestResult] = []
     for c in candidates:
         try:
@@ -466,7 +466,7 @@ def full_backtest(
         end_date=end_date,
     )
 
-    client = mangroveai_client()
+    client = mangrove_ai_client()
     try:
         raw = client.backtesting.run(
             _build_request(

--- a/server/src/services/candidate_generator.py
+++ b/server/src/services/candidate_generator.py
@@ -20,7 +20,7 @@ from typing import Any
 
 from pydantic import BaseModel
 
-from src.shared.clients.mangrove import mangroveai_client
+from src.shared.clients.mangrove import mangrove_ai_client
 from src.shared.errors import StrategyNoViableCandidates
 from src.shared.logging import get_logger
 
@@ -159,7 +159,7 @@ def _bucket_signals(
 
 def _fetch_catalog() -> list[Any]:
     """Pull the full signal catalog via the SDK (paginated)."""
-    client = mangroveai_client()
+    client = mangrove_ai_client()
     return list(client.signals.list_iter(limit_per_page=100))
 
 

--- a/server/src/services/oracle.py
+++ b/server/src/services/oracle.py
@@ -1,0 +1,162 @@
+"""oracle_service — score strategies through SIEVE, query the corpus,
+run backtests against MangroveOracle.
+
+Thin orchestrator over ``client.oracle.*`` from mangrove-ai >= 1.0.
+Routes and MCP tools both call into this single module so business
+logic isn't duplicated.
+
+The Oracle surface lives behind MangroveAI's authenticated reverse
+proxy at ``/api/v1/oracle/*``. Calls require an API key; the SDK
+singleton in ``shared/clients/mangrove.py`` carries the auth header
+forward.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from mangrove_ai.models.oracle import (
+    DataQueryRequest,
+    OracleBacktestRequest,
+    SieveScoreRequest,
+)
+from pydantic import BaseModel, Field
+
+from src.shared.clients.mangrove import mangrove_ai_client
+from src.shared.errors import SdkError
+from src.shared.logging import get_logger
+
+_log = get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Request models — server-facing shapes that wrap the SDK ones
+# ---------------------------------------------------------------------------
+
+class SieveScoreInput(BaseModel):
+    """Score one strategy through the Mangrove SIEVE classifier.
+
+    Server flattens to ``SieveScoreRequest(strategies=[...])`` and forwards.
+    Limit batch size with ``BACKTEST_BATCH_CAP`` if the caller passes more.
+    """
+
+    strategies: list[dict[str, Any]] = Field(default_factory=list)
+
+
+class DataQueryInput(BaseModel):
+    """Query the curated Oracle corpus (results / ohlcv) through the
+    BigQuery proxy. Columns and filter operators are whitelisted
+    server-side; the agent only sees a safe surface.
+    """
+
+    table: str
+    select: list[str]
+    filters: list[dict[str, Any]] = Field(default_factory=list)
+    order_by: list[str] | None = None
+    limit: int = 100
+    offset: int = 0
+
+
+class OracleBacktestInput(BaseModel):
+    """Backtest a single strategy through Oracle's engine.
+
+    Mirrors ``mangrove_ai.models.oracle.OracleBacktestRequest`` but
+    keeps the agent's local validation surface compact.
+    """
+
+    asset: str
+    interval: str
+    strategy_json: str
+    lookback_months: int | None = 12
+    initial_balance: float | None = None
+    max_risk_per_trade: float | None = None
+    execution_config: dict[str, Any] | None = None
+    mode: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Service functions
+# ---------------------------------------------------------------------------
+
+def sieve_score(payload: SieveScoreInput) -> dict[str, Any]:
+    """Score 1-99 strategies through SIEVE; return predictions + provenance.
+
+    Returns the SDK response as a plain dict so the route layer can shape
+    it for downstream consumers. The SDK already enforces the 99-item
+    cap client-side and raises ValueError before sending.
+    """
+    if not payload.strategies:
+        raise SdkError("sieve_score requires at least one strategy")
+
+    client = mangrove_ai_client()
+    try:
+        result = client.oracle.sieve_score(
+            SieveScoreRequest(strategies=payload.strategies)
+        )
+    except ValueError as exc:
+        # Client-side rejection (e.g. >99 items, both/neither input set).
+        raise SdkError(f"sieve_score validation failed: {exc}") from exc
+
+    _log.info(
+        "sieve_score",
+        extra={
+            "count": result.count,
+            "model_version": result.model_version,
+            "code_version": result.code_version,
+        },
+    )
+    return result.model_dump()
+
+
+def data_query(payload: DataQueryInput) -> dict[str, Any]:
+    """Run a whitelisted query against the Oracle corpus."""
+    client = mangrove_ai_client()
+    result = client.oracle.data_query(
+        DataQueryRequest(
+            table=payload.table,
+            select=payload.select,
+            filters=payload.filters,
+            order_by=payload.order_by,
+            limit=payload.limit,
+            offset=payload.offset,
+        )
+    )
+    _log.info(
+        "oracle.data_query",
+        extra={
+            "table": payload.table,
+            "row_count": result.row_count,
+            "code_version": result.code_version,
+        },
+    )
+    return result.model_dump()
+
+
+def backtest(payload: OracleBacktestInput) -> dict[str, Any]:
+    """Run a single-strategy backtest synchronously through Oracle's engine.
+
+    For long-running or many-strategy work, prefer ``backtest_async``
+    (returns a backtest_id you poll). The synchronous variant blocks
+    until the engine finishes; can be 30-120s for multi-month windows.
+    """
+    client = mangrove_ai_client()
+    result = client.oracle.backtest(
+        OracleBacktestRequest(
+            asset=payload.asset,
+            interval=payload.interval,
+            strategy_json=payload.strategy_json,
+            lookback_months=payload.lookback_months,
+            initial_balance=payload.initial_balance,
+            max_risk_per_trade=payload.max_risk_per_trade,
+            execution_config=payload.execution_config,
+            mode=payload.mode,
+        )
+    )
+    _log.info(
+        "oracle.backtest",
+        extra={
+            "asset": payload.asset,
+            "success": result.success,
+            "trade_count": result.trade_count,
+        },
+    )
+    return result.model_dump()

--- a/server/src/services/order_executor.py
+++ b/server/src/services/order_executor.py
@@ -32,7 +32,7 @@ from src.config import app_config
 from src.models.domain import OrderIntent, Trade
 from src.services import trade_log
 from src.services.wallet_manager import sign as wallet_sign
-from src.shared.clients.mangrove import mangroveai_client, mangrovemarkets_client
+from src.shared.clients.mangrove import mangrove_ai_client, mangrove_markets_client
 from src.shared.errors import SdkError, SigningError
 from src.shared.logging import get_logger
 
@@ -45,7 +45,7 @@ _TX_POLL_INTERVAL_S = 2.0
 
 def _fetch_mark_price(symbol: str) -> float:
     """Pull a current mark price via crypto_assets.get_market_data()."""
-    resp = mangroveai_client().crypto_assets.get_market_data(symbol)
+    resp = mangrove_ai_client().crypto_assets.get_market_data(symbol)
     data = getattr(resp, "data", None) or {}
     for key in ("current_price", "price", "usd_price"):
         if key in data and data[key] is not None:
@@ -105,7 +105,7 @@ def _paper_fill(intent: OrderIntent, strategy_id: str, evaluation_id: str | None
 
 def _poll_tx(tx_hash: str, chain_id: int, venue_id: str | None = None) -> dict[str, Any]:
     """Poll dex.tx_status until it's out of 'pending' or timeout."""
-    client = mangrovemarkets_client()
+    client = mangrove_markets_client()
     deadline = time.monotonic() + _TX_POLL_TIMEOUT_S
     last_status: Any = None
     while time.monotonic() < deadline:
@@ -178,7 +178,7 @@ def _live_swap(
             ),
         )
 
-    client = mangrovemarkets_client()
+    client = mangrove_markets_client()
     # Prefer explicit addresses (user-initiated swaps via /dex/swap); fall
     # back to USDC+symbol convention when the intent came from the cron
     # strategy path.

--- a/server/src/services/strategy_service.py
+++ b/server/src/services/strategy_service.py
@@ -20,7 +20,7 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any, Literal
 
-from mangroveai.models import CreateStrategyRequest
+from mangrove_ai.models import CreateStrategyRequest
 from pydantic import BaseModel, Field
 
 from src.models.domain import Evaluation, OrderIntent
@@ -33,7 +33,7 @@ from src.services import (
     trade_log,
 )
 from src.shared import timeframes
-from src.shared.clients.mangrove import mangroveai_client
+from src.shared.clients.mangrove import mangrove_ai_client
 from src.shared.db.sqlite import get_connection
 from src.shared.errors import (
     SdkError,
@@ -264,7 +264,7 @@ def create_autonomous(req: StrategyAutonomousRequest) -> tuple[StrategyDetailRes
 
     # Build the SDK request from the winning candidate.
     try:
-        detail = mangroveai_client().strategies.create(
+        detail = mangrove_ai_client().strategies.create(
             CreateStrategyRequest(
                 name=winner.candidate.name,
                 asset=winner.candidate.asset,
@@ -327,7 +327,7 @@ def create_manual(req: StrategyManualRequest) -> StrategyDetailResponse:
     _validate_composition(req.entry, req.exit)
 
     try:
-        detail = mangroveai_client().strategies.create(
+        detail = mangrove_ai_client().strategies.create(
             CreateStrategyRequest(
                 name=req.name, asset=req.asset,
                 entry=req.entry, exit=req.exit,
@@ -423,7 +423,7 @@ def update_status(strategy_id: str, update: StrategyStatusUpdate) -> StrategyDet
 
     # Sync status upstream.
     try:
-        mangroveai_client().strategies.update_status(row["mangrove_id"], target)
+        mangrove_ai_client().strategies.update_status(row["mangrove_id"], target)
     except Exception as e:  # noqa: BLE001
         # If we already recorded an allocation, roll it back.
         if target == "live":
@@ -490,7 +490,7 @@ def tick(strategy_id: str) -> None:
 
         try:
             persist = mode == "live"
-            sdk_resp = mangroveai_client().execution.evaluate(
+            sdk_resp = mangrove_ai_client().execution.evaluate(
                 row["mangrove_id"], persist=persist,
             )
         except Exception as e:  # noqa: BLE001

--- a/server/src/services/wallet_manager.py
+++ b/server/src/services/wallet_manager.py
@@ -35,7 +35,7 @@ from eth_utils import to_checksum_address
 from pydantic import BaseModel
 
 from src.services.secret_vault import vault
-from src.shared.clients.mangrove import mangrovemarkets_client
+from src.shared.clients.mangrove import mangrove_markets_client
 from src.shared.crypto.fernet import decrypt, encrypt, get_master_key_source
 from src.shared.db.sqlite import get_connection
 from src.shared.errors import (
@@ -341,7 +341,7 @@ def create_wallet(
             suggestion="Supported: evm (with a valid chain_id).",
         )
 
-    result = mangrovemarkets_client().wallet.create(
+    result = mangrove_markets_client().wallet.create(
         chain=chain_normalized, network=network, chain_id=chain_id,
     )
     secret = _extract_secret(result)

--- a/server/src/shared/clients/mangrove.py
+++ b/server/src/shared/clients/mangrove.py
@@ -6,17 +6,17 @@ instantiate clients themselves. That keeps test mocking easy (override the
 @lru_cache'd function) and avoids multiple HTTP pools / auth re-inits.
 
 Usage:
-    from src.shared.clients.mangrove import mangroveai_client, mangrovemarkets_client
+    from src.shared.clients.mangrove import mangrove_ai_client, mangrove_markets_client
 
-    signals = mangroveai_client().signals.list()
-    venues = mangrovemarkets_client().dex.supported_venues()
+    signals = mangrove_ai_client().signals.list()
+    venues = mangrove_markets_client().dex.supported_venues()
 """
 from __future__ import annotations
 
 from functools import lru_cache
 
-from mangroveai import MangroveAI
-from mangrovemarkets import MangroveMarkets
+from mangrove_ai import MangroveAI
+from mangrove_markets import MangroveMarkets
 
 
 def _get_config():
@@ -26,7 +26,7 @@ def _get_config():
 
 
 @lru_cache(maxsize=1)
-def mangroveai_client() -> MangroveAI:
+def mangrove_ai_client() -> MangroveAI:
     """Return the singleton MangroveAI SDK client.
 
     Reads MANGROVE_API_KEY from config. Environment (dev vs prod) is
@@ -49,7 +49,7 @@ def mangroveai_client() -> MangroveAI:
 
 
 @lru_cache(maxsize=1)
-def mangrovemarkets_client() -> MangroveMarkets:
+def mangrove_markets_client() -> MangroveMarkets:
     """Return the singleton MangroveMarkets SDK client.
 
     Reads MANGROVEMARKETS_BASE_URL and MANGROVE_API_KEY from config. The
@@ -65,5 +65,5 @@ def mangrovemarkets_client() -> MangroveMarkets:
 
 def reset_clients() -> None:
     """Clear the cached singletons. Tests use this to re-init with different config."""
-    mangroveai_client.cache_clear()
-    mangrovemarkets_client.cache_clear()
+    mangrove_ai_client.cache_clear()
+    mangrove_markets_client.cache_clear()

--- a/server/src/shared/db/migrations/001_initial.sql
+++ b/server/src/shared/db/migrations/001_initial.sql
@@ -54,7 +54,7 @@ CREATE TABLE IF NOT EXISTS evaluations (
     strategy_id TEXT NOT NULL REFERENCES strategies(id),
     timestamp TEXT NOT NULL,
     market_snapshot_json TEXT NOT NULL,           -- data sent to the SDK
-    sdk_response_json TEXT NOT NULL,              -- verbatim response from mangroveai.execution.evaluate()
+    sdk_response_json TEXT NOT NULL,              -- verbatim response from mangrove_ai.execution.evaluate()
     order_intents_json TEXT NOT NULL,             -- extracted from sdk_response for querying
     duration_ms INTEGER NOT NULL,
     status TEXT NOT NULL,                         -- ok | error | skipped

--- a/server/tests/e2e/test_paper_lifecycle.py
+++ b/server/tests/e2e/test_paper_lifecycle.py
@@ -109,10 +109,10 @@ def client(tmp_path, monkeypatch):
     sdk.crypto_assets.get_market_data.return_value = md
 
     for path in (
-        "src.services.candidate_generator.mangroveai_client",
-        "src.services.backtest_service.mangroveai_client",
-        "src.services.strategy_service.mangroveai_client",
-        "src.services.order_executor.mangroveai_client",
+        "src.services.candidate_generator.mangrove_ai_client",
+        "src.services.backtest_service.mangrove_ai_client",
+        "src.services.strategy_service.mangrove_ai_client",
+        "src.services.order_executor.mangrove_ai_client",
     ):
         monkeypatch.setattr(path, lambda s=sdk: s)
 

--- a/server/tests/e2e/test_smoke.py
+++ b/server/tests/e2e/test_smoke.py
@@ -135,18 +135,18 @@ def client(tmp_path, monkeypatch):
 
     sdk = _stub_sdk()
     for path in (
-        "src.api.routes.market.mangroveai_client",
-        "src.api.routes.on_chain.mangroveai_client",
-        "src.api.routes.signals.mangroveai_client",
-        "src.api.routes.kb.mangroveai_client",
-        "src.api.routes.wallet.mangrovemarkets_client",
-        "src.api.routes.dex.mangrovemarkets_client",
-        "src.services.wallet_manager.mangrovemarkets_client",
-        "src.services.candidate_generator.mangroveai_client",
-        "src.services.backtest_service.mangroveai_client",
-        "src.services.strategy_service.mangroveai_client",
-        "src.services.order_executor.mangrovemarkets_client",
-        "src.services.order_executor.mangroveai_client",
+        "src.api.routes.market.mangrove_ai_client",
+        "src.api.routes.on_chain.mangrove_ai_client",
+        "src.api.routes.signals.mangrove_ai_client",
+        "src.api.routes.kb.mangrove_ai_client",
+        "src.api.routes.wallet.mangrove_markets_client",
+        "src.api.routes.dex.mangrove_markets_client",
+        "src.services.wallet_manager.mangrove_markets_client",
+        "src.services.candidate_generator.mangrove_ai_client",
+        "src.services.backtest_service.mangrove_ai_client",
+        "src.services.strategy_service.mangrove_ai_client",
+        "src.services.order_executor.mangrove_markets_client",
+        "src.services.order_executor.mangrove_ai_client",
     ):
         monkeypatch.setattr(path, lambda s=sdk: s)
     monkeypatch.setattr(

--- a/server/tests/integration/test_dex_routes.py
+++ b/server/tests/integration/test_dex_routes.py
@@ -91,8 +91,8 @@ def client(tmp_path, monkeypatch):
     }
     sdk.dex.gas_price.return_value = gas_price
 
-    monkeypatch.setattr("src.api.routes.dex.mangrovemarkets_client", lambda: sdk)
-    monkeypatch.setattr("src.services.order_executor.mangrovemarkets_client", lambda: sdk)
+    monkeypatch.setattr("src.api.routes.dex.mangrove_markets_client", lambda: sdk)
+    monkeypatch.setattr("src.services.order_executor.mangrove_markets_client", lambda: sdk)
     monkeypatch.setattr(
         "src.services.order_executor.wallet_sign",
         lambda payload, wallet_address, chain_id=None: "0xSIGNED",

--- a/server/tests/integration/test_discovery_routes.py
+++ b/server/tests/integration/test_discovery_routes.py
@@ -112,7 +112,7 @@ def test_status_reports_catalog_counts_when_sdk_reachable(client, monkeypatch):
 
     discovery.reset_catalog_cache()
     monkeypatch.setattr(
-        "src.shared.clients.mangrove.mangroveai_client",
+        "src.shared.clients.mangrove.mangrove_ai_client",
         lambda: _StubClient(),
     )
 
@@ -133,7 +133,7 @@ def test_status_catalog_is_resilient_when_sdk_unreachable(client, monkeypatch):
 
     discovery.reset_catalog_cache()
     monkeypatch.setattr(
-        "src.shared.clients.mangrove.mangroveai_client",
+        "src.shared.clients.mangrove.mangrove_ai_client",
         _raise,
     )
 

--- a/server/tests/integration/test_kb_routes.py
+++ b/server/tests/integration/test_kb_routes.py
@@ -52,7 +52,7 @@ def client(monkeypatch):
     tag.model_dump.return_value = {"name": "momentum", "count": 12}
     sdk.kb.tags.list.return_value = [tag]
 
-    monkeypatch.setattr("src.api.routes.kb.mangroveai_client", lambda: sdk)
+    monkeypatch.setattr("src.api.routes.kb.mangrove_ai_client", lambda: sdk)
 
     from src.app import create_app
     app = create_app()
@@ -108,8 +108,8 @@ def test_indicators_list_with_category_filter(client):
     r = client.get("/api/v1/agent/kb/indicators?category=momentum", headers=_auth())
     assert r.status_code == 200
     # Verify the filter was passed through to the SDK.
-    from src.api.routes.kb import mangroveai_client
-    sdk = mangroveai_client()
+    from src.api.routes.kb import mangrove_ai_client
+    sdk = mangrove_ai_client()
     sdk.kb.indicators.list.assert_called_with(category="momentum")
 
 

--- a/server/tests/integration/test_passthrough_routes.py
+++ b/server/tests/integration/test_passthrough_routes.py
@@ -61,10 +61,10 @@ def client(tmp_path, monkeypatch):
     sdk.kb.glossary.get.return_value = _resp({"term": "rsi", "definition": "relative strength index"})
 
     for path in (
-        "src.api.routes.market.mangroveai_client",
-        "src.api.routes.on_chain.mangroveai_client",
-        "src.api.routes.signals.mangroveai_client",
-        "src.api.routes.kb.mangroveai_client",
+        "src.api.routes.market.mangrove_ai_client",
+        "src.api.routes.on_chain.mangrove_ai_client",
+        "src.api.routes.signals.mangrove_ai_client",
+        "src.api.routes.kb.mangrove_ai_client",
     ):
         monkeypatch.setattr(path, lambda s=sdk: s)
 

--- a/server/tests/integration/test_strategy_routes.py
+++ b/server/tests/integration/test_strategy_routes.py
@@ -60,9 +60,9 @@ def client(tmp_path, monkeypatch):
     sdk.execution.evaluate.return_value = eval_resp
 
     for path in (
-        "src.services.candidate_generator.mangroveai_client",
-        "src.services.backtest_service.mangroveai_client",
-        "src.services.strategy_service.mangroveai_client",
+        "src.services.candidate_generator.mangrove_ai_client",
+        "src.services.backtest_service.mangrove_ai_client",
+        "src.services.strategy_service.mangrove_ai_client",
     ):
         monkeypatch.setattr(path, lambda s=sdk: s)
 

--- a/server/tests/integration/test_strategy_service.py
+++ b/server/tests/integration/test_strategy_service.py
@@ -53,7 +53,7 @@ def temp_db(tmp_path, monkeypatch):
 
 @pytest.fixture
 def mock_ai_sdk(monkeypatch):
-    """Stub mangroveai_client used by strategy_service + candidate_generator + backtest_service."""
+    """Stub mangrove_ai_client used by strategy_service + candidate_generator + backtest_service."""
     from tests.unit.test_candidate_generator import _catalog
 
     client = MagicMock()
@@ -104,9 +104,9 @@ def mock_ai_sdk(monkeypatch):
     client.execution.evaluate.return_value = eval_resp
 
     for path in (
-        "src.services.candidate_generator.mangroveai_client",
-        "src.services.backtest_service.mangroveai_client",
-        "src.services.strategy_service.mangroveai_client",
+        "src.services.candidate_generator.mangrove_ai_client",
+        "src.services.backtest_service.mangrove_ai_client",
+        "src.services.strategy_service.mangrove_ai_client",
     ):
         monkeypatch.setattr(path, lambda c=client: c)
     return client
@@ -316,7 +316,7 @@ def test_tick_paper_mode_logs_simulated_trade(temp_db, mock_ai_sdk, monkeypatch)
     md = MagicMock()
     md.data = {"current_price": 2500.0}
     mock_ai_sdk.crypto_assets.get_market_data.return_value = md
-    monkeypatch.setattr("src.services.order_executor.mangroveai_client",
+    monkeypatch.setattr("src.services.order_executor.mangrove_ai_client",
                         lambda: mock_ai_sdk)
 
     s = create_manual(StrategyManualRequest(

--- a/server/tests/integration/test_wallet_routes.py
+++ b/server/tests/integration/test_wallet_routes.py
@@ -61,8 +61,8 @@ def client(tmp_path, monkeypatch):
         setattr(sdk.portfolio, attr, MagicMock(return_value=m))
     sdk.portfolio.history.return_value = [MagicMock(model_dump=MagicMock(return_value={"tx": "0xabc"}))]
 
-    monkeypatch.setattr("src.services.wallet_manager.mangrovemarkets_client", lambda: sdk)
-    monkeypatch.setattr("src.api.routes.wallet.mangrovemarkets_client", lambda: sdk)
+    monkeypatch.setattr("src.services.wallet_manager.mangrove_markets_client", lambda: sdk)
+    monkeypatch.setattr("src.api.routes.wallet.mangrove_markets_client", lambda: sdk)
 
     from src.app import create_app
     app = create_app()

--- a/server/tests/unit/test_backtest_service.py
+++ b/server/tests/unit/test_backtest_service.py
@@ -56,7 +56,7 @@ def _fake_result(
 def mock_sdk(monkeypatch):
     sdk = MagicMock()
     monkeypatch.setattr(
-        "src.services.backtest_service.mangroveai_client",
+        "src.services.backtest_service.mangrove_ai_client",
         lambda: sdk,
     )
     return sdk

--- a/server/tests/unit/test_candidate_generator.py
+++ b/server/tests/unit/test_candidate_generator.py
@@ -43,7 +43,7 @@ def _catalog() -> list[_FakeSignal]:
 
 @pytest.fixture
 def mock_sdk_catalog(monkeypatch):
-    """Stub mangroveai_client().signals.list_iter() with our fake catalog."""
+    """Stub mangrove_ai_client().signals.list_iter() with our fake catalog."""
     client = MagicMock()
     client.signals.list_iter.return_value = iter(_catalog())
 
@@ -53,7 +53,7 @@ def mock_sdk_catalog(monkeypatch):
     client.signals.list_iter.side_effect = _fresh_iter
 
     monkeypatch.setattr(
-        "src.services.candidate_generator.mangroveai_client",
+        "src.services.candidate_generator.mangrove_ai_client",
         lambda: client,
     )
     return client
@@ -160,7 +160,7 @@ def test_generate_raises_when_no_trigger_signals(monkeypatch):
     empty_client = MagicMock()
     empty_client.signals.list_iter.side_effect = lambda **kw: iter([])
     monkeypatch.setattr(
-        "src.services.candidate_generator.mangroveai_client",
+        "src.services.candidate_generator.mangrove_ai_client",
         lambda: empty_client,
     )
 

--- a/server/tests/unit/test_clients.py
+++ b/server/tests/unit/test_clients.py
@@ -5,35 +5,35 @@ import os
 
 os.environ.setdefault("ENVIRONMENT", "test")
 
-from mangroveai import MangroveAI
-from mangrovemarkets import MangroveMarkets
+from mangrove_ai import MangroveAI
+from mangrove_markets import MangroveMarkets
 
 from src.shared.clients.mangrove import (
-    mangroveai_client,
-    mangrovemarkets_client,
+    mangrove_ai_client,
+    mangrove_markets_client,
     reset_clients,
 )
 
 
 def test_mangroveai_singleton_returns_same_instance():
     reset_clients()
-    a = mangroveai_client()
-    b = mangroveai_client()
+    a = mangrove_ai_client()
+    b = mangrove_ai_client()
     assert a is b
     assert isinstance(a, MangroveAI)
 
 
 def test_mangrovemarkets_singleton_returns_same_instance():
     reset_clients()
-    a = mangrovemarkets_client()
-    b = mangrovemarkets_client()
+    a = mangrove_markets_client()
+    b = mangrove_markets_client()
     assert a is b
     assert isinstance(a, MangroveMarkets)
 
 
 def test_reset_clients_creates_new_instance():
     reset_clients()
-    a = mangroveai_client()
+    a = mangrove_ai_client()
     reset_clients()
-    b = mangroveai_client()
+    b = mangrove_ai_client()
     assert a is not b  # reset caused re-instantiation

--- a/server/tests/unit/test_oracle.py
+++ b/server/tests/unit/test_oracle.py
@@ -1,0 +1,166 @@
+"""Unit tests for oracle_service — SIEVE scoring, data query, backtest.
+
+Mocks `mangrove_ai_client()` so we exercise the orchestration without
+hitting MangroveAI's prod proxy. Integration tests live in
+tests/integration/ and require a real API key + the live proxy.
+"""
+from __future__ import annotations
+
+import os
+from typing import Any
+from unittest.mock import MagicMock
+
+os.environ.setdefault("ENVIRONMENT", "test")
+
+import pytest  # noqa: E402
+
+from src.services.oracle import (  # noqa: E402
+    DataQueryInput,
+    OracleBacktestInput,
+    SieveScoreInput,
+    backtest as svc_backtest,
+    data_query as svc_data_query,
+    sieve_score as svc_sieve_score,
+)
+from src.shared.errors import SdkError  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _strategy() -> dict[str, Any]:
+    return {
+        "asset": "AVAX",
+        "entry": [
+            {
+                "name": "bb_upper_breakout",
+                "signal_type": "TRIGGER",
+                "params": {"window": 95},
+            }
+        ],
+        "exit": [
+            {
+                "name": "macd_bearish_cross",
+                "signal_type": "TRIGGER",
+                "params": {"fast": 12, "slow": 26},
+            }
+        ],
+    }
+
+
+_SIEVE_RESPONSE_MOCK = MagicMock()
+_SIEVE_RESPONSE_MOCK.count = 1
+_SIEVE_RESPONSE_MOCK.model_version = "mangrove-sieve:0b9a2da0d827"
+_SIEVE_RESPONSE_MOCK.code_version = "oracle:v0.14.2 ai:v3.10.2 kb:1.0.5 roots:v0.3.0"
+_SIEVE_RESPONSE_MOCK.model_dump.return_value = {
+    "predictions": [
+        {
+            "binary": {"p_no_trades": 0.0, "p_trades": 0.9999},
+            "four_class": {"losing": 0.24, "no_trades": 0.0, "wash": 0.06, "winning": 0.70},
+        }
+    ],
+    "count": 1,
+    "model_version": "mangrove-sieve:0b9a2da0d827",
+    "code_version": "oracle:v0.14.2 ai:v3.10.2 kb:1.0.5 roots:v0.3.0",
+}
+
+
+_DATA_QUERY_RESPONSE_MOCK = MagicMock()
+_DATA_QUERY_RESPONSE_MOCK.row_count = 1
+_DATA_QUERY_RESPONSE_MOCK.code_version = "oracle:v0.14.2 ai:v3.10.2 kb:1.0.5 roots:v0.3.0"
+_DATA_QUERY_RESPONSE_MOCK.model_dump.return_value = {
+    "rows": [{"asset": "BTC", "irr_annualized": 52.3}],
+    "row_count": 1,
+    "table": "results",
+    "code_version": "oracle:v0.14.2 ai:v3.10.2 kb:1.0.5 roots:v0.3.0",
+}
+
+
+_BACKTEST_RESPONSE_MOCK = MagicMock()
+_BACKTEST_RESPONSE_MOCK.success = True
+_BACKTEST_RESPONSE_MOCK.trade_count = 12
+_BACKTEST_RESPONSE_MOCK.model_dump.return_value = {
+    "success": True,
+    "metrics": {"sharpe_ratio": 1.5, "total_return": 22.3},
+    "trade_count": 12,
+    "strategy_names": ["AVAX bb breakout"],
+}
+
+
+# ---------------------------------------------------------------------------
+# sieve_score
+# ---------------------------------------------------------------------------
+
+class TestSieveScore:
+    def test_returns_predictions_with_provenance(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        client = MagicMock()
+        client.oracle.sieve_score.return_value = _SIEVE_RESPONSE_MOCK
+        monkeypatch.setattr("src.services.oracle.mangrove_ai_client", lambda: client)
+
+        result = svc_sieve_score(SieveScoreInput(strategies=[_strategy()]))
+
+        assert result["count"] == 1
+        assert result["model_version"] == "mangrove-sieve:0b9a2da0d827"
+        assert "oracle:v0.14.2" in result["code_version"]
+        assert result["predictions"][0]["four_class"]["winning"] == pytest.approx(0.70)
+
+    def test_empty_strategies_rejected_locally(self) -> None:
+        with pytest.raises(SdkError, match="at least one strategy"):
+            svc_sieve_score(SieveScoreInput(strategies=[]))
+
+    def test_client_side_99_cap_surfaces_as_sdk_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        client = MagicMock()
+        client.oracle.sieve_score.side_effect = ValueError("Max 99 items per request, got 100")
+        monkeypatch.setattr("src.services.oracle.mangrove_ai_client", lambda: client)
+
+        with pytest.raises(SdkError, match="validation failed"):
+            svc_sieve_score(SieveScoreInput(strategies=[_strategy()] * 100))
+
+
+# ---------------------------------------------------------------------------
+# data_query
+# ---------------------------------------------------------------------------
+
+class TestDataQuery:
+    def test_returns_rows_with_provenance(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        client = MagicMock()
+        client.oracle.data_query.return_value = _DATA_QUERY_RESPONSE_MOCK
+        monkeypatch.setattr("src.services.oracle.mangrove_ai_client", lambda: client)
+
+        result = svc_data_query(
+            DataQueryInput(
+                table="results",
+                select=["asset", "irr_annualized"],
+                filters=[{"col": "irr_annualized", "op": ">=", "value": 50}],
+                limit=5,
+            )
+        )
+
+        assert result["row_count"] == 1
+        assert result["rows"][0]["asset"] == "BTC"
+        assert "oracle:v0.14.2" in result["code_version"]
+
+
+# ---------------------------------------------------------------------------
+# backtest
+# ---------------------------------------------------------------------------
+
+class TestBacktest:
+    def test_returns_metrics(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        client = MagicMock()
+        client.oracle.backtest.return_value = _BACKTEST_RESPONSE_MOCK
+        monkeypatch.setattr("src.services.oracle.mangrove_ai_client", lambda: client)
+
+        result = svc_backtest(
+            OracleBacktestInput(
+                asset="AVAX",
+                interval="1h",
+                strategy_json="{}",
+                lookback_months=6,
+            )
+        )
+
+        assert result["success"] is True
+        assert result["metrics"]["sharpe_ratio"] == pytest.approx(1.5)
+        assert result["trade_count"] == 12

--- a/server/tests/unit/test_order_executor.py
+++ b/server/tests/unit/test_order_executor.py
@@ -51,18 +51,18 @@ def temp_db(tmp_path, monkeypatch):
 
 @pytest.fixture
 def mock_mangroveai(monkeypatch):
-    """Stub mangroveai_client (used by _fetch_mark_price in paper mode)."""
+    """Stub mangrove_ai_client (used by _fetch_mark_price in paper mode)."""
     client = MagicMock()
     market_resp = MagicMock()
     market_resp.data = {"current_price": 2500.0}
     client.crypto_assets.get_market_data.return_value = market_resp
-    monkeypatch.setattr("src.services.order_executor.mangroveai_client", lambda: client)
+    monkeypatch.setattr("src.services.order_executor.mangrove_ai_client", lambda: client)
     return client
 
 
 @pytest.fixture
 def mock_markets(monkeypatch):
-    """Stub mangrovemarkets_client (used in live mode)."""
+    """Stub mangrove_markets_client (used in live mode)."""
     client = MagicMock()
 
     quote = MagicMock()
@@ -91,7 +91,7 @@ def mock_markets(monkeypatch):
     status.error_message = None
     client.dex.tx_status.return_value = status
 
-    monkeypatch.setattr("src.services.order_executor.mangrovemarkets_client", lambda: client)
+    monkeypatch.setattr("src.services.order_executor.mangrove_markets_client", lambda: client)
     return client
 
 

--- a/server/tests/unit/test_wallet_manager.py
+++ b/server/tests/unit/test_wallet_manager.py
@@ -51,7 +51,7 @@ def stub_keyring(monkeypatch):
 
 @pytest.fixture
 def mock_sdk_create(monkeypatch):
-    """Stub mangrovemarkets_client().wallet.create() to return a fixed EVM wallet."""
+    """Stub mangrove_markets_client().wallet.create() to return a fixed EVM wallet."""
     sdk_result = MagicMock()
     sdk_result.address = _TEST_ADDRESS
     sdk_result.private_key = _TEST_PRIVKEY
@@ -62,7 +62,7 @@ def mock_sdk_create(monkeypatch):
     sdk_client.wallet.create.return_value = sdk_result
 
     monkeypatch.setattr(
-        "src.services.wallet_manager.mangrovemarkets_client",
+        "src.services.wallet_manager.mangrove_markets_client",
         lambda: sdk_client,
     )
     return sdk_client

--- a/tutorials/trading-app/00-index.md
+++ b/tutorials/trading-app/00-index.md
@@ -41,8 +41,9 @@ strategy logic, and market data.
 | 06 | [Wallet setup](06-wallet-setup.md) | yes (~$5 USDC) | 15 min |
 | 07 | [Going live](07-going-live.md) | yes | 20 min |
 | 08 | [Monitor, troubleshoot, extend](08-monitor-troubleshoot-extend.md) | no | 20 min |
+| 09 | [Score strategies with SIEVE before backtesting](09-oracle-strategies.md) | no | 20 min |
 
-**Total if you do everything: ~2 hours.**
+**Total if you do everything: ~2 hr 20 min.**
 
 ## Before you start
 

--- a/tutorials/trading-app/08-monitor-troubleshoot-extend.md
+++ b/tutorials/trading-app/08-monitor-troubleshoot-extend.md
@@ -313,7 +313,7 @@ If you finished the workshop and want to keep going:
    anything that catches your eye. If you find a signal you want
    to build around, ask the bot: `"Tell me how <signal> works and
    build a strategy around it for ETH."`
-6. **Read the SDK.** `from mangroveai import ...` in a Python REPL
+6. **Read the SDK.** `from mangrove_ai import ...` in a Python REPL
    — the SDK is introspectable and well-typed. You'll find
    capabilities you didn't know the bot had.
 

--- a/tutorials/trading-app/09-oracle-strategies.md
+++ b/tutorials/trading-app/09-oracle-strategies.md
@@ -1,0 +1,148 @@
+# Chapter 09 — Score strategies with SIEVE before backtesting
+
+*20 minutes. No funds required. New as of mangrove-agent vNEXT
+(depends on mangrove-ai SDK 1.0).*
+
+Chapter 04 walked you through authoring a strategy and Chapter 05
+paper-traded it. But authoring is cheap and backtesting isn't — a
+single Oracle backtest can take 30-120 seconds on a multi-month
+lookback, and you might want to try 50 parameter variations of a
+candidate strategy before committing to one.
+
+This chapter introduces **SIEVE** (Strategy Indicator Embeddings with
+Value Estimation), the Mangrove classifier trained on 1.24M historical
+sweep runs. SIEVE scores a candidate strategy in milliseconds and
+returns:
+
+- A **binary** go/no-go: `P(no_trades)` vs `P(trades)`. If the model
+  thinks your strategy will never fire entries on real data, you can
+  skip the backtest entirely.
+- A **4-class outcome** softmax over `losing` / `no_trades` / `wash` /
+  `winning`. Rank candidates by `P(winning)` and backtest only the top
+  decile.
+
+**5 out of 6 strategies fail a backtest.** SIEVE tells you which 1.
+
+## The pattern
+
+The agent exposes three new auth-gated surfaces (REST + MCP):
+
+| Surface | What it does |
+|---|---|
+| `sieve_score` | Score 1-99 strategies through SIEVE; returns binary + 4-class probabilities per item. |
+| `oracle_data_query` | Query the curated Oracle corpus for high-IRR analogues to learn from. |
+| `oracle_backtest` | Run a single strategy through Oracle's engine synchronously. |
+
+All three forward through MangroveAI's authenticated proxy at
+`/api/v1/oracle/*` to the live MangroveOracle service. Tenancy is
+enforced by the proxy — you never see another customer's rows.
+
+## Score one strategy
+
+In Claude Code:
+
+> "Score this strategy through SIEVE: BTC, 1h, MACD bullish cross + SMA(50) filter on entry, MACD bearish cross on exit."
+
+The bot calls `sieve_score` with one Strategy object. Expected
+response:
+
+```json
+{
+  "predictions": [{
+    "binary": {"p_no_trades": 0.08, "p_trades": 0.92},
+    "four_class": {
+      "losing":    0.11,
+      "no_trades": 0.08,
+      "wash":      0.31,
+      "winning":   0.50
+    }
+  }],
+  "count": 1,
+  "model_version": "mangrove-sieve:0b9a2da0d827",
+  "code_version":  "oracle:v0.14.2 ai:v3.10.2 kb:1.0.5 roots:v0.3.0"
+}
+```
+
+Read it: `P(trades) = 0.92` means SIEVE thinks this strategy will fire
+on real data. `P(winning) = 0.50` is its best guess; not great, not
+terrible. Maybe worth a backtest.
+
+If `P(no_trades)` had been `> 0.5`, you'd kill the strategy here and
+not bother with the next steps.
+
+## Filter a candidate set
+
+The real value comes from scoring **many** at once. Say you're trying
+50 (signal × parameter × timeframe) variations of a MACD-based BTC
+strategy:
+
+> "Generate 50 variations of my MACD strategy with the entry-window
+> sweeping from 8 to 20 and the exit-window from 20 to 40, then score
+> them all through SIEVE in one call."
+
+The bot calls `sieve_score` with all 50 strategies in a single batch
+(SIEVE accepts up to 99 per request). Then it sorts the results by
+`four_class.winning` descending, and keeps only the top 5-10 for the
+expensive backtest step.
+
+## Look at the historical corpus
+
+Before you backtest, look at what already worked. The Oracle corpus
+holds millions of completed sweep runs; you can query it for high-IRR
+analogues of your candidate:
+
+> "Show me the top 5 BTC strategies on 1h with annualized IRR above
+> 35% that traded at least 20 times."
+
+The bot calls `oracle_data_query` with `table=results`, columns
+`experiment_id, asset, timeframe, irr_annualized, total_trades`, and
+filters on `asset=BTC`, `timeframe=1h`, `irr_annualized>=35`,
+`total_trades>=20`. Tenancy is enforced — only rows your org has
+access to come back.
+
+## Backtest the survivors
+
+Pick the highest-`P(winning)` candidate from SIEVE, optionally cross-
+referenced against the corpus pattern, and backtest it:
+
+> "Backtest that BTC MACD candidate over the last 12 months."
+
+The bot calls `oracle_backtest` with the strategy JSON. The Oracle
+engine runs the full simulation against real OHLCV, returning Sharpe,
+Sortino, IRR, max drawdown, trade history, etc.
+
+## Putting it together
+
+The pre-flight workflow:
+
+1. **Author** N candidate strategies (Claude Code generates parameter
+   variations).
+2. **`sieve_score`** all N in one or two batches. Drop anything with
+   `P(no_trades) > 0.5`. Sort by `P(winning)` descending. Keep top 10%.
+3. **`oracle_data_query`** for analogues — what strategies already
+   in the corpus look similar and did well?
+4. **`oracle_backtest`** the surviving candidates. Now you're spending
+   compute on the ones SIEVE and the corpus both endorse.
+
+A 50-strategy search compresses to maybe 5 backtests. Same signal
+quality at 10% the cost.
+
+## What SIEVE is NOT
+
+It is a **fast filter**, not a backtest. Don't paper-trade a strategy
+SIEVE rated 0.7 without backtesting it first — SIEVE's prediction is
+an aggregate over millions of historical runs, but your strategy's
+parameter combination might be in a corner of the distribution where
+the model is overconfident. Always backtest before promoting to paper.
+
+## Going further
+
+- The API reference for `client.oracle.*` lives in the
+  [mangrove-ai SDK docs](https://docs.mangrovedeveloper.ai/sdks/mangroveai).
+- For batch / async / bulk backtest variants (long-running, many-
+  strategy work), see the `backtest_async` / `backtest_bulk` SDK
+  methods — not yet exposed through the agent's MCP surface, but
+  reachable via `client.oracle.backtest_async(...)` if you script
+  against the SDK directly.
+- The full corpus schema (98 fields on the `results` table) is
+  documented at `MangroveOracle/infra/terraform/schemas/results.json`.


### PR DESCRIPTION
Two changes bundled per the repo-per-PR rule:

1. Consumer rename fanout for both Python SDKs:
- mangroveai to mangrove-ai (PyPI), mangroveai to mangrove_ai (import)
- mangrovemarkets to mangrove-markets (PyPI), mangrovemarkets to mangrove_markets (import)
- server/requirements.txt pins bumped to mangrove-ai>=1.0.0,<2.0.0 and mangrove-markets>=1.0.0,<2.0.0
- Client singleton mangroveai_client to mangrove_ai_client (and markets parallel)

2. New Oracle demo surface (auth-gated REST + MCP) over client.oracle.*:
- server/src/services/oracle.py: sieve_score, data_query, backtest
- server/src/api/routes/oracle.py: 3 POST routes
- server/src/mcp/tools.py: 3 MCP tools (sieve_score, oracle_data_query, oracle_backtest)
- server/tests/unit/test_oracle.py: 5 unit tests with mocked client
- tutorials/trading-app/09-oracle-strategies.md: narrative chapter
- 00-index.md: chapter 09 entry

Local verification:
- Fresh venv with local-installed mangrove-ai + mangrove-markets (PyPI hasnt published yet; depends on PR-3 + PR-4 merging + tagging)
- pytest tests/unit/test_oracle.py: 5 / 5 pass
- pytest tests/unit/: 213 / 213 pass (full unit suite)
- Rename gate clean (only intentional brand mentions of MangroveAI remain)

Depends on PR-3 (mangrove-ai v1.0.0 on PyPI) and PR-4 (mangrove-markets v1.0.0 on PyPI). After both publish, pip install -r requirements.txt resolves cleanly.

Release: merge ships a fresh container deploy via the existing mangrove-agent deploy workflow.

Generated with Claude Code
