### PR TITLE
fix: rename fanout for mangrove-ai + mangrove-markets

### DIFF
--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -86,7 +86,7 @@ Goal: turn the mangrove-agent template into a mangrove-agent shell. After this p
   keyring>=24
   ```
 - [ ] **Step 2:** rebuild Docker image: `docker compose build`. Verify install succeeds.
-- [ ] **Step 3:** import smoke test — start container, exec into it, run `python -c "import mangroveai, mangrovemarkets, apscheduler, cryptography, keyring; print('ok')"`.
+- [ ] **Step 3:** import smoke test — start container, exec into it, run `python -c "import mangrove_ai, mangrovemarkets, apscheduler, cryptography, keyring; print('ok')"`.
 - [ ] **Step 4:** commit: `chore(deps): add SDK + scheduler + crypto + keyring`.
 
 **Acceptance:** All five libraries installable and importable in the container.
@@ -122,8 +122,8 @@ Goal: turn the mangrove-agent template into a mangrove-agent shell. After this p
 - [ ] **Step 1:** in `mangrove.py`, define module-level singletons (lazy):
   ```python
   from functools import lru_cache
-  from mangroveai import MangroveAI
-  from mangrovemarkets import MangroveMarkets
+  from mangrove_ai import MangroveAI
+  from mangrove_markets import MangroveMarkets
   from src.config import app_config
 
   @lru_cache(maxsize=1)

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -506,7 +506,7 @@ class Evaluation(BaseModel):
     strategy_id: str
     timestamp: datetime
     market_snapshot: dict                        # last bar of data passed to SDK
-    sdk_response: dict                           # verbatim response from mangroveai.execution.evaluate()
+    sdk_response: dict                           # verbatim response from mangrove_ai.execution.evaluate()
     order_intents: list[OrderIntent]             # extracted from sdk_response for easy querying
     duration_ms: int
     status: Literal["ok", "error", "skipped"]
@@ -619,7 +619,7 @@ CREATE TABLE evaluations (
     strategy_id TEXT NOT NULL REFERENCES strategies(id),
     timestamp TEXT NOT NULL,
     market_snapshot_json TEXT NOT NULL,           -- data sent to the SDK
-    sdk_response_json TEXT NOT NULL,              -- verbatim response from mangroveai.execution.evaluate()
+    sdk_response_json TEXT NOT NULL,              -- verbatim response from mangrove_ai.execution.evaluate()
     order_intents_json TEXT NOT NULL,             -- extracted from sdk_response for querying
     duration_ms INTEGER NOT NULL,
     status TEXT NOT NULL,                         -- ok | error | skipped
@@ -758,7 +758,7 @@ Server-side, the agent's FastAPI middleware inspects `X-API-Key` identically for
 
 **Usage:**
 ```python
-from mangroveai import MangroveAI
+from mangrove_ai import MangroveAI
 client = MangroveAI()  # reads env
 ```
 
@@ -778,7 +778,7 @@ client = MangroveAI()  # reads env
 
 **Usage:**
 ```python
-from mangrovemarkets import MangroveMarkets
+from mangrove_markets import MangroveMarkets
 client = MangroveMarkets(base_url=os.environ["MANGROVEMARKETS_BASE_URL"])
 ```
 

--- a/docs/workshop/setup-guide.md
+++ b/docs/workshop/setup-guide.md
@@ -404,8 +404,8 @@ The Mangrove organization on GitHub: **<https://github.com/MangroveTechnologies>
 The packages your workshop bot installs into its virtualenv. Each one is open source — clicking the link below shows the version, the readme, and a link back to the source repo.
 
 - **[`mangrove-kb`](https://pypi.org/project/mangrove-kb/)** — the signal library. `pip install mangrove-kb`
-- **[`mangroveai`](https://pypi.org/project/mangroveai/)** — the AI/intelligence SDK. `pip install mangroveai`
-- **[`mangrovemarkets`](https://pypi.org/project/mangrovemarkets/)** — the markets/execution SDK. `pip install mangrovemarkets`
+- **[`mangroveai`](https://pypi.org/project/mangroveai/)** — the AI/intelligence SDK. `pip install mangrove-ai`
+- **[`mangrovemarkets`](https://pypi.org/project/mangrovemarkets/)** — the markets/execution SDK. `pip install mangrove-markets`
 
 ### Inside the workshop repo (`mangrove-agent`)
 

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -13,17 +13,17 @@ PyJWT>=2.9.0
 # and minor bumps may carry breaking changes. Revisit pins when either
 # stabilizes to 1.0.
 # Note: there is no `mangrove-kb` package pinned here — all KB access
-# flows through mangroveai.kb.*, which the mangroveai SDK already
+# flows through mangrove_ai.kb.*, which the mangrove-ai SDK already
 # transitively provides. A previous `mangrove-kb>=1.0.0` pin was
 # impossible to resolve (upstream tops out at 0.5.0) and blocked fresh
 # pip installs.
-mangroveai>=0.3.0,<0.4.0
-# mangrovemarkets 0.2.0 moved EVM wallet keypair generation client-side.
+mangrove-ai>=1.0.0,<2.0.0
+# mangrove-markets 1.0.0 moved EVM wallet keypair generation client-side.
 # The agent's wallet_manager.create_wallet() is unaffected — the SDK
 # call signature is unchanged, only the implementation shifted from
-# server-side to local. Pinning to 0.2.x guarantees the leak-surface
+# server-side to local. Pinning to >=1.0.0 guarantees the leak-surface
 # fix is in place. See post-mortem: docs/incidents/2026-04-24-eip7702-drain.md
-mangrovemarkets>=0.2.0,<0.3.0
+mangrove-markets>=1.0.0,<2.0.0
 apscheduler[sqlalchemy]>=3.10
 cryptography>=42
 keyring>=24

--- a/server/src/api/routes/signals.py
+++ b/server/src/api/routes/signals.py
@@ -30,7 +30,7 @@ async def list_signals(
     client = mangroveai_client()
     try:
         if search:
-            from mangroveai.models import SearchSignalsRequest
+            from mangrove_ai.models import SearchSignalsRequest
             page = client.signals.search(SearchSignalsRequest(query=search, limit=limit, offset=offset))
         else:
             page = client.signals.list(limit=limit, offset=offset)

--- a/server/src/mcp/tools.py
+++ b/server/src/mcp/tools.py
@@ -1011,7 +1011,7 @@ def _register_signals(server: FastMCP) -> None:
         from src.shared.clients.mangrove import mangroveai_client
         client = mangroveai_client()
         if search:
-            from mangroveai.models import SearchSignalsRequest
+            from mangrove_ai.models import SearchSignalsRequest
             page = client.signals.search(SearchSignalsRequest(query=search, limit=limit))
             items = [_dump(s) for s in getattr(page, "items", [])]
         else:
@@ -1109,7 +1109,7 @@ def _register_signals(server: FastMCP) -> None:
         if not _require(api_key):
             return _auth_error()
         try:
-            from mangroveai.models import SearchSignalsRequest
+            from mangrove_ai.models import SearchSignalsRequest
 
             from src.shared.clients.mangrove import mangroveai_client
             req = SearchSignalsRequest(query=query, limit=limit, offset=offset)

--- a/server/src/services/backtest_service.py
+++ b/server/src/services/backtest_service.py
@@ -20,7 +20,7 @@ import json
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
-from mangroveai.models import BacktestRequest
+from mangrove_ai.models import BacktestRequest
 from pydantic import BaseModel
 
 from src.config import app_config

--- a/server/src/services/strategy_service.py
+++ b/server/src/services/strategy_service.py
@@ -20,7 +20,7 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any, Literal
 
-from mangroveai.models import CreateStrategyRequest
+from mangrove_ai.models import CreateStrategyRequest
 from pydantic import BaseModel, Field
 
 from src.models.domain import Evaluation, OrderIntent

--- a/server/src/shared/clients/mangrove.py
+++ b/server/src/shared/clients/mangrove.py
@@ -15,8 +15,8 @@ from __future__ import annotations
 
 from functools import lru_cache
 
-from mangroveai import MangroveAI
-from mangrovemarkets import MangroveMarkets
+from mangrove_ai import MangroveAI
+from mangrove_markets import MangroveMarkets
 
 
 def _get_config():

--- a/server/src/shared/db/migrations/001_initial.sql
+++ b/server/src/shared/db/migrations/001_initial.sql
@@ -54,7 +54,7 @@ CREATE TABLE IF NOT EXISTS evaluations (
     strategy_id TEXT NOT NULL REFERENCES strategies(id),
     timestamp TEXT NOT NULL,
     market_snapshot_json TEXT NOT NULL,           -- data sent to the SDK
-    sdk_response_json TEXT NOT NULL,              -- verbatim response from mangroveai.execution.evaluate()
+    sdk_response_json TEXT NOT NULL,              -- verbatim response from mangrove_ai.execution.evaluate()
     order_intents_json TEXT NOT NULL,             -- extracted from sdk_response for querying
     duration_ms INTEGER NOT NULL,
     status TEXT NOT NULL,                         -- ok | error | skipped

--- a/server/tests/unit/test_clients.py
+++ b/server/tests/unit/test_clients.py
@@ -5,8 +5,8 @@ import os
 
 os.environ.setdefault("ENVIRONMENT", "test")
 
-from mangroveai import MangroveAI
-from mangrovemarkets import MangroveMarkets
+from mangrove_ai import MangroveAI
+from mangrove_markets import MangroveMarkets
 
 from src.shared.clients.mangrove import (
     mangroveai_client,

--- a/tutorials/trading-app/08-monitor-troubleshoot-extend.md
+++ b/tutorials/trading-app/08-monitor-troubleshoot-extend.md
@@ -313,7 +313,7 @@ If you finished the workshop and want to keep going:
    anything that catches your eye. If you find a signal you want
    to build around, ask the bot: `"Tell me how <signal> works and
    build a strategy around it for ETH."`
-6. **Read the SDK.** `from mangroveai import ...` in a Python REPL
+6. **Read the SDK.** `from mangrove_ai import ...` in a Python REPL
    — the SDK is introspectable and well-typed. You'll find
    capabilities you didn't know the bot had.
 


### PR DESCRIPTION
## Summary

Consumer rename fanout for the parallel Python SDK renames shipping concurrently in MangroveAI-SDK and MangroveMarkets/packages/python-sdk:

- `mangroveai` (PyPI dist) → `mangrove-ai`
- `mangrovemarkets` (PyPI dist) → `mangrove-markets`
- `from mangroveai` → `from mangrove_ai`
- `from mangrovemarkets` → `from mangrove_markets`

12 files touched (server code + docs + 1 tutorial). Pin ceilings widened in `server/requirements.txt`:

- `mangroveai>=0.3.0,<0.4.0` → `mangrove-ai>=1.0.0,<2.0.0`
- `mangrovemarkets>=0.2.0,<0.3.0` → `mangrove-markets>=1.0.0,<2.0.0`

The 0.x → 1.0.0 ceiling jump is a versioning rebase tied to the rename — the new packages start at 1.0.0 and the surface is unchanged (mangrove-ai 1.0.0 adds the new `client.oracle` namespace but doesn't break existing surfaces; mangrove-markets 1.0.0 is the same as 0.2.0 under the new name).

## Depends on

- MangroveAI-SDK `mangrove-ai==1.0.0` published to PyPI (PR-3)
- MangroveMarkets `mangrove-markets==1.0.0` published to PyPI (PR-4)

## Verification

- `git grep -in "from mangroveai\b|import mangroveai\b|from mangrovemarkets\b|import mangrovemarkets\b"` returns only intentional `MangroveAI` brand mentions in comments + a long description string in `reference_strategies.json`.
- Diff scope: 12 files, 25 insertions, 25 deletions.

## Test plan

- [ ] Wait for PR-3 + PR-4 to merge + tags pushed + packages live on PyPI
- [ ] Rebuild the server container with the new pins (`docker compose build`)
- [ ] `cd server && pytest tests/` green inside the rebuilt container
- [ ] Smoke a representative auth-gated route end-to-end (e.g. `POST /api/v1/agent/strategies`) against the rebuilt container

Generated with Claude Code
