### PR TITLE
feat(on-chain + oracle): expose 5 Nansen + 15 Oracle proxy endpoints (REST + MCP)

### DIFF
--- a/.claude/rules/trading-bot-workflow.md
+++ b/.claude/rules/trading-bot-workflow.md
@@ -17,7 +17,7 @@ MCP tools are deferred. On any session, eagerly load the full core toolset on fi
 
 Required core set:
 ```
-mcp__mangrove-agent__status, list_tools, list_signals, list_wallets, create_wallet, import_wallet, get_balances, list_dex_venues, get_swap_quote, execute_swap, get_ohlcv, get_market_data, kb_search, list_strategies, get_strategy, create_strategy_autonomous, create_strategy_manual, evaluate_strategy, backtest_strategy, update_strategy_status, list_trades, list_all_trades, list_evaluations, get_smart_money_historical_holdings, get_smart_money_dex_trades, get_smart_money_perp_trades, get_token_dex_trades, get_token_flows
+mcp__mangrove-agent__status, list_tools, list_signals, list_wallets, create_wallet, import_wallet, get_balances, list_dex_venues, get_swap_quote, execute_swap, get_ohlcv, get_market_data, kb_search, list_strategies, get_strategy, create_strategy_autonomous, create_strategy_manual, evaluate_strategy, backtest_strategy, update_strategy_status, list_trades, list_all_trades, list_evaluations, get_smart_money_historical_holdings, get_smart_money_dex_trades, get_smart_money_perp_trades, get_token_dex_trades, get_token_flows, oracle_list_datasets, oracle_list_signals, oracle_create_experiment, oracle_validate_experiment, oracle_launch_experiment, oracle_list_results
 ```
 
 ## Operating principles

--- a/.claude/rules/trading-bot-workflow.md
+++ b/.claude/rules/trading-bot-workflow.md
@@ -17,7 +17,7 @@ MCP tools are deferred. On any session, eagerly load the full core toolset on fi
 
 Required core set:
 ```
-mcp__mangrove-agent__status, list_tools, list_signals, list_wallets, create_wallet, import_wallet, get_balances, list_dex_venues, get_swap_quote, execute_swap, get_ohlcv, get_market_data, kb_search, list_strategies, get_strategy, create_strategy_autonomous, create_strategy_manual, evaluate_strategy, backtest_strategy, update_strategy_status, list_trades, list_all_trades, list_evaluations
+mcp__mangrove-agent__status, list_tools, list_signals, list_wallets, create_wallet, import_wallet, get_balances, list_dex_venues, get_swap_quote, execute_swap, get_ohlcv, get_market_data, kb_search, list_strategies, get_strategy, create_strategy_autonomous, create_strategy_manual, evaluate_strategy, backtest_strategy, update_strategy_status, list_trades, list_all_trades, list_evaluations, get_smart_money_historical_holdings, get_smart_money_dex_trades, get_smart_money_perp_trades, get_token_dex_trades, get_token_flows
 ```
 
 ## Operating principles

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -23,7 +23,7 @@ PyJWT>=2.9.0
 # is normal Python packaging (Pillow/PIL, beautifulsoup4/bs4, etc.).
 # An attempted PyPI rename to `mangrove-ai` was rejected by PyPI's
 # similarity check — that's why we kept the dist name as-is.
-mangroveai>=1.0.2,<2.0.0
+mangroveai>=1.4.0,<2.0.0
 # mangrovemarkets 1.0.0 moved EVM wallet keypair generation client-side.
 # The agent's wallet_manager.create_wallet() is unaffected — the SDK
 # call signature is unchanged, only the implementation shifted from

--- a/server/src/api/routes/on_chain.py
+++ b/server/src/api/routes/on_chain.py
@@ -1,9 +1,10 @@
-"""On-chain analytics routes — pass-through to mangroveai.on_chain."""
+"""On-chain analytics routes — pass-through to mangrove_ai.on_chain."""
 from __future__ import annotations
 
 from typing import Any
 
 from fastapi import APIRouter, Depends
+from pydantic import BaseModel, Field
 
 from src.shared.auth.dependency import require_api_key
 from src.shared.clients.mangrove import mangrove_ai_client
@@ -18,6 +19,11 @@ router = APIRouter(
 
 def _dump(obj: Any) -> Any:
     return obj.model_dump() if hasattr(obj, "model_dump") else obj
+
+
+# ---------------------------------------------------------------------------
+# Legacy GET routes (3 endpoints, ship since v0)
+# ---------------------------------------------------------------------------
 
 
 @router.get("/smart-money", summary="Smart money sentiment for a token")
@@ -42,3 +48,109 @@ async def token_holders(symbol: str) -> Any:
         return _dump(mangrove_ai_client().on_chain.get_token_holders(symbol))
     except Exception as e:  # noqa: BLE001
         raise SdkError(f"on_chain.get_token_holders failed: {e}") from e
+
+
+# ---------------------------------------------------------------------------
+# Nansen Pro coverage — 5 POST endpoints added in mangroveai 1.1.0+
+#
+# These take rich JSON filters / order_by passed straight through to
+# Nansen. The agent surfaces them as POST routes (not GET) because the
+# filter shape is too complex for query-string encoding.
+# ---------------------------------------------------------------------------
+
+
+class _SmartMoneyHistoricalHoldingsBody(BaseModel):
+    chains: list[str] | None = Field(default=None, description="Chain filter, e.g. ['ethereum', 'solana']. Default ['ethereum'].")
+    date_from: str | None = Field(default=None, description="ISO date 'YYYY-MM-DD'.")
+    date_to: str | None = Field(default=None, description="ISO date 'YYYY-MM-DD'.")
+    filters: dict[str, Any] | None = Field(default=None, description="Nansen filter dict (include_smart_money_labels, etc.)")
+    order_by: list[dict[str, str]] | None = Field(default=None, description="Sort spec, e.g. [{'field': 'block_timestamp', 'direction': 'DESC'}]")
+    page: int = 1
+    per_page: int = 100
+
+
+@router.post("/smart-money/historical-holdings", summary="Smart Money historical holdings (Nansen)")
+async def smart_money_historical_holdings(body: _SmartMoneyHistoricalHoldingsBody) -> Any:
+    try:
+        return _dump(mangrove_ai_client().on_chain.get_smart_money_historical_holdings(
+            **body.model_dump(exclude_none=True),
+        ))
+    except Exception as e:  # noqa: BLE001
+        raise SdkError(f"on_chain.get_smart_money_historical_holdings failed: {e}") from e
+
+
+class _SmartMoneyDexTradesBody(BaseModel):
+    chains: list[str] | None = None
+    filters: dict[str, Any] | None = None
+    order_by: list[dict[str, str]] | None = None
+    page: int = 1
+    per_page: int = 100
+
+
+@router.post("/smart-money/dex-trades", summary="Smart Money DEX trades (Nansen)")
+async def smart_money_dex_trades(body: _SmartMoneyDexTradesBody) -> Any:
+    try:
+        return _dump(mangrove_ai_client().on_chain.get_smart_money_dex_trades(
+            **body.model_dump(exclude_none=True),
+        ))
+    except Exception as e:  # noqa: BLE001
+        raise SdkError(f"on_chain.get_smart_money_dex_trades failed: {e}") from e
+
+
+class _SmartMoneyPerpTradesBody(BaseModel):
+    filters: dict[str, Any] | None = None
+    order_by: list[dict[str, str]] | None = None
+    page: int = 1
+    per_page: int = 100
+
+
+@router.post("/smart-money/perp-trades", summary="Smart Money Hyperliquid perp trades (Nansen)")
+async def smart_money_perp_trades(body: _SmartMoneyPerpTradesBody) -> Any:
+    """Hyperliquid-only. No chain filter — upstream doesn't accept one."""
+    try:
+        return _dump(mangrove_ai_client().on_chain.get_smart_money_perp_trades(
+            **body.model_dump(exclude_none=True),
+        ))
+    except Exception as e:  # noqa: BLE001
+        raise SdkError(f"on_chain.get_smart_money_perp_trades failed: {e}") from e
+
+
+class _TokenDexTradesBody(BaseModel):
+    chain: str | None = None
+    date_from: str | None = None
+    date_to: str | None = None
+    filters: dict[str, Any] | None = None
+    order_by: list[dict[str, str]] | None = None
+    page: int = 1
+    per_page: int = 100
+
+
+@router.post("/token-dex-trades/{symbol}", summary="DEX trades for a token across all participants (Nansen)")
+async def token_dex_trades(symbol: str, body: _TokenDexTradesBody) -> Any:
+    try:
+        return _dump(mangrove_ai_client().on_chain.get_token_dex_trades(
+            symbol, **body.model_dump(exclude_none=True),
+        ))
+    except Exception as e:  # noqa: BLE001
+        raise SdkError(f"on_chain.get_token_dex_trades failed: {e}") from e
+
+
+class _TokenFlowsBody(BaseModel):
+    chain: str | None = None
+    date_from: str | None = None
+    date_to: str | None = None
+    filters: dict[str, Any] | None = None
+    order_by: list[dict[str, str]] | None = None
+    page: int = 1
+    per_page: int = 100
+
+
+@router.post("/token-flows/{symbol}", summary="Per-wallet-category flow data for a token (Nansen)")
+async def token_flows(symbol: str, body: _TokenFlowsBody) -> Any:
+    """Stablecoins are not supported (Nansen returns 404)."""
+    try:
+        return _dump(mangrove_ai_client().on_chain.get_token_flows(
+            symbol, **body.model_dump(exclude_none=True),
+        ))
+    except Exception as e:  # noqa: BLE001
+        raise SdkError(f"on_chain.get_token_flows failed: {e}") from e

--- a/server/src/api/routes/oracle.py
+++ b/server/src/api/routes/oracle.py
@@ -1,15 +1,35 @@
 """Oracle routes — auth-gated. Thin wrappers over services/oracle.py.
 
-Surface:
-- POST /api/v1/oracle/sieve     score 1-99 strategies through SIEVE
-- POST /api/v1/oracle/data/query query the corpus (results / ohlcv)
-- POST /api/v1/oracle/backtest   run a single backtest synchronously
+Surface (18 endpoints):
+- SIEVE / data / sync backtest (3 legacy):
+  POST   /oracle/sieve
+  POST   /oracle/data/query
+  POST   /oracle/backtest
+- Async + bulk backtest (3):
+  POST   /oracle/backtest/async
+  GET    /oracle/backtest/async/{backtest_id}
+  POST   /oracle/backtest/bulk
+- Experiment lifecycle (8):
+  POST   /oracle/experiments
+  GET    /oracle/experiments
+  GET    /oracle/experiments/{id}
+  PUT    /oracle/experiments/{id}
+  DELETE /oracle/experiments/{id}
+  POST   /oracle/experiments/{id}/validate
+  POST   /oracle/experiments/{id}/launch
+  POST   /oracle/experiments/{id}/pause
+- Results + catalogs (4):
+  GET    /oracle/results
+  GET    /oracle/datasets
+  GET    /oracle/signals
+  GET    /oracle/templates
 """
 from __future__ import annotations
 
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Body, Depends, HTTPException
+from mangrove_ai.exceptions import APIError as SDKAPIError
 
 from src.services import oracle as oracle_service
 from src.services.oracle import (
@@ -19,6 +39,23 @@ from src.services.oracle import (
 )
 from src.shared.auth.dependency import require_api_key
 from src.shared.errors import SdkError
+
+
+def _raise_from_sdk(exc: SDKAPIError) -> "HTTPException":
+    """Translate a mangrove_ai APIError into a FastAPI HTTPException
+    that preserves the upstream status code + code + message. The agent
+    is a transparent proxy here — surfacing the SDK's structured error
+    is more useful to clients than collapsing everything to 400.
+    """
+    return HTTPException(
+        status_code=exc.status_code,
+        detail={
+            "error": exc.error,
+            "message": exc.message,
+            "code": exc.code,
+            "correlation_id": exc.correlation_id,
+        },
+    )
 
 router = APIRouter(
     prefix="/oracle",
@@ -41,8 +78,10 @@ router = APIRouter(
 async def post_sieve_score(payload: SieveScoreInput) -> dict[str, Any]:
     try:
         return oracle_service.sieve_score(payload)
+    except SDKAPIError as exc:
+        raise _raise_from_sdk(exc) from exc
     except SdkError as exc:
-        raise HTTPException(status_code=400, detail=str(exc))
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
 @router.post(
@@ -58,8 +97,10 @@ async def post_sieve_score(payload: SieveScoreInput) -> dict[str, Any]:
 async def post_data_query(payload: DataQueryInput) -> dict[str, Any]:
     try:
         return oracle_service.data_query(payload)
+    except SDKAPIError as exc:
+        raise _raise_from_sdk(exc) from exc
     except SdkError as exc:
-        raise HTTPException(status_code=400, detail=str(exc))
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
 @router.post(
@@ -68,11 +109,271 @@ async def post_data_query(payload: DataQueryInput) -> dict[str, Any]:
     description=(
         "Synchronous backtest. Blocks until the engine finishes (typically "
         "30-120s on multi-month windows). Returns metrics + trade history. "
-        "For batch work, see the async variant via the SDK directly."
+        "For long jobs see ``POST /backtest/async``; for batch see ``POST /backtest/bulk``."
     ),
 )
 async def post_backtest(payload: OracleBacktestInput) -> dict[str, Any]:
     try:
         return oracle_service.backtest(payload)
+    except SDKAPIError as exc:
+        raise _raise_from_sdk(exc) from exc
     except SdkError as exc:
-        raise HTTPException(status_code=400, detail=str(exc))
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+# ---------------------------------------------------------------------------
+# Async + bulk backtests
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/backtest/async",
+    summary="Submit a backtest for async execution",
+    description=(
+        "Returns ``{backtest_id, status}`` immediately. Poll "
+        "``GET /backtest/async/{backtest_id}`` for the full result. Use "
+        "this over the sync variant when the window is long enough that "
+        "blocking the request would exceed the agent's HTTP timeout."
+    ),
+)
+async def post_backtest_async(payload: OracleBacktestInput) -> dict[str, Any]:
+    try:
+        return oracle_service.backtest_async(payload)
+    except SDKAPIError as exc:
+        raise _raise_from_sdk(exc) from exc
+    except SdkError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.get(
+    "/backtest/async/{backtest_id}",
+    summary="Poll the status / result of an async backtest",
+    description="Returns the full backtest payload once the engine finishes.",
+)
+async def get_backtest_poll(backtest_id: str) -> dict[str, Any]:
+    try:
+        return oracle_service.backtest_poll(backtest_id)
+    except SDKAPIError as exc:
+        raise _raise_from_sdk(exc) from exc
+    except SdkError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.post(
+    "/backtest/bulk",
+    summary="Bulk-evaluate many strategies against a shared date range",
+    description=(
+        "Body must include the shared date / risk parameters plus either "
+        "``strategy_ids`` (DB lookup) or ``strategy_configs`` (inline "
+        "dicts) — or both. The server fetches OHLCV once per unique "
+        "``(asset, timeframe)`` and shares it across strategies that "
+        "need it. Per-strategy failures are captured in each result's "
+        "``error`` field without aborting the batch."
+    ),
+)
+async def post_backtest_bulk(payload: dict[str, Any] = Body(...)) -> dict[str, Any]:
+    try:
+        return oracle_service.backtest_bulk(payload)
+    except SDKAPIError as exc:
+        raise _raise_from_sdk(exc) from exc
+    except SdkError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+# ---------------------------------------------------------------------------
+# Experiment lifecycle
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/experiments",
+    summary="Create a draft experiment",
+    description=(
+        "Body is the full experiment config dict (passed through to the "
+        "Oracle ``ExperimentConfig`` shape). Returns ``{experiment_id, "
+        "status: 'draft', created_at, org_id}``."
+    ),
+)
+async def post_create_experiment(config: dict[str, Any] = Body(...)) -> dict[str, Any]:
+    try:
+        return oracle_service.create_experiment(config)
+    except SDKAPIError as exc:
+        raise _raise_from_sdk(exc) from exc
+    except SdkError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.get(
+    "/experiments",
+    summary="List experiments for the calling org",
+    description="Compact summary view: experiment_id, name, status, total_runs, completed, search_mode, created_at.",
+)
+async def get_list_experiments() -> list[dict[str, Any]]:
+    try:
+        return oracle_service.list_experiments()
+    except SDKAPIError as exc:
+        raise _raise_from_sdk(exc) from exc
+    except SdkError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.get(
+    "/experiments/{experiment_id}",
+    summary="Fetch full experiment config + current progress",
+)
+async def get_experiment(experiment_id: str) -> dict[str, Any]:
+    try:
+        return oracle_service.get_experiment(experiment_id)
+    except SDKAPIError as exc:
+        raise _raise_from_sdk(exc) from exc
+    except SdkError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.put(
+    "/experiments/{experiment_id}",
+    summary="Replace a draft experiment's config (PUT semantics)",
+    description=(
+        "Only draft-status experiments can be updated. Validated, "
+        "launched, or paused experiments reject mutation with HTTP 400."
+    ),
+)
+async def put_update_experiment(
+    experiment_id: str, config: dict[str, Any] = Body(...),
+) -> dict[str, Any]:
+    try:
+        return oracle_service.update_experiment(experiment_id, config)
+    except SDKAPIError as exc:
+        raise _raise_from_sdk(exc) from exc
+    except SdkError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.delete(
+    "/experiments/{experiment_id}",
+    summary="Delete an experiment + cancel any in-flight children",
+)
+async def delete_experiment(experiment_id: str) -> dict[str, Any]:
+    try:
+        return oracle_service.delete_experiment(experiment_id)
+    except SDKAPIError as exc:
+        raise _raise_from_sdk(exc) from exc
+    except SdkError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.post(
+    "/experiments/{experiment_id}/validate",
+    summary="Validate a draft experiment (transition draft -> validated)",
+    description="Required before ``launch``. Returns 400 with structured errors if the config is incomplete.",
+)
+async def post_validate_experiment(experiment_id: str) -> dict[str, Any]:
+    try:
+        return oracle_service.validate_experiment(experiment_id)
+    except SDKAPIError as exc:
+        raise _raise_from_sdk(exc) from exc
+    except SdkError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.post(
+    "/experiments/{experiment_id}/launch",
+    summary="Fan out a validated experiment into child backtests",
+    description=(
+        "Up to 99 child backtests per launch. Returns immediately with "
+        "``status: 'launched'`` — the fan-out is asynchronous. Poll "
+        "``GET /experiments/{id}`` for completion progress or "
+        "``GET /results?experiment_id={id}`` for materializing results."
+    ),
+)
+async def post_launch_experiment(experiment_id: str) -> dict[str, Any]:
+    try:
+        return oracle_service.launch_experiment(experiment_id)
+    except SDKAPIError as exc:
+        raise _raise_from_sdk(exc) from exc
+    except SdkError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.post(
+    "/experiments/{experiment_id}/pause",
+    summary="Pause a running experiment",
+    description="Halts the fan-out without losing already-completed results. Resume by relaunching.",
+)
+async def post_pause_experiment(experiment_id: str) -> dict[str, Any]:
+    try:
+        return oracle_service.pause_experiment(experiment_id)
+    except SDKAPIError as exc:
+        raise _raise_from_sdk(exc) from exc
+    except SdkError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+# ---------------------------------------------------------------------------
+# Results pagination
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/results",
+    summary="Read backtest results materializing under an experiment",
+    description=(
+        "``experiment_id`` is required — Oracle rejects unfiltered "
+        "reads at the proxy layer to prevent cross-tenant fan-out."
+    ),
+)
+async def get_list_results(
+    experiment_id: str, limit: int = 100, offset: int = 0,
+) -> dict[str, Any]:
+    try:
+        return oracle_service.list_results(
+            experiment_id, limit=limit, offset=offset,
+        )
+    except SDKAPIError as exc:
+        raise _raise_from_sdk(exc) from exc
+    except SdkError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+# ---------------------------------------------------------------------------
+# Metadata catalogs (free / non-billable)
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/datasets",
+    summary="List the OHLCV datasets experiments can run against",
+)
+async def get_list_datasets() -> list[dict[str, Any]]:
+    try:
+        return oracle_service.list_datasets()
+    except SDKAPIError as exc:
+        raise _raise_from_sdk(exc) from exc
+    except SdkError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.get(
+    "/signals",
+    summary="List signals + typed param specs available to experiments",
+)
+async def get_list_signals() -> list[dict[str, Any]]:
+    try:
+        return oracle_service.list_signals()
+    except SDKAPIError as exc:
+        raise _raise_from_sdk(exc) from exc
+    except SdkError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.get(
+    "/templates",
+    summary="List predefined strategy templates",
+)
+async def get_list_templates() -> list[dict[str, Any]]:
+    try:
+        return oracle_service.list_templates()
+    except SDKAPIError as exc:
+        raise _raise_from_sdk(exc) from exc
+    except SdkError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/server/src/mcp/tools.py
+++ b/server/src/mcp/tools.py
@@ -2624,6 +2624,412 @@ def _register_oracle(server: FastMCP) -> None:
         ],
     ))
 
+    # ----------------------------------------------------------------- #
+    # Async + bulk backtests (3 tools)
+    # ----------------------------------------------------------------- #
+
+    @server.tool()
+    async def oracle_backtest_async(
+        asset: str,
+        interval: str,
+        strategy_json: str,
+        lookback_months: int | None = 12,
+        api_key: str = "",
+    ) -> str:
+        """Submit a backtest for async execution. Returns
+        ``{backtest_id, status}`` immediately; poll
+        ``oracle_backtest_poll(backtest_id)`` for the full result.
+        Use when the window is too long for the sync variant's 30-120s block.
+        """
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            from src.services.oracle import OracleBacktestInput
+            from src.services.oracle import backtest_async as svc
+            result = svc(OracleBacktestInput(
+                asset=asset,
+                interval=interval,
+                strategy_json=strategy_json,
+                lookback_months=lookback_months,
+            ))
+            return json.dumps(result)
+        except AgentError as e:
+            return _handle_agent_error(e)
+
+    register_tool(ToolEntry(
+        name="oracle_backtest_async",
+        description="Submit an Oracle backtest for async execution. Returns backtest_id to poll.",
+        access="auth",
+        parameters=[
+            ToolParam(name="asset", type="string", required=True, description="e.g. BTC, ETH"),
+            ToolParam(name="interval", type="string", required=True, description="e.g. 1h, 4h, 1d"),
+            ToolParam(name="strategy_json", type="string", required=True, description="Strategy JSON (MangroveAI shape)."),
+            ToolParam(name="lookback_months", type="integer", required=False, description="Default 12."),
+            _APIKEY,
+        ],
+    ))
+
+    @server.tool()
+    async def oracle_backtest_poll(backtest_id: str, api_key: str = "") -> str:
+        """Poll the status / result of an async backtest by ID."""
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            from src.services.oracle import backtest_poll as svc
+            result = svc(backtest_id)
+            return json.dumps(result)
+        except AgentError as e:
+            return _handle_agent_error(e)
+
+    register_tool(ToolEntry(
+        name="oracle_backtest_poll",
+        description="Poll the status / full result of an async Oracle backtest.",
+        access="auth",
+        parameters=[
+            ToolParam(name="backtest_id", type="string", required=True, description="ID returned by oracle_backtest_async."),
+            _APIKEY,
+        ],
+    ))
+
+    @server.tool()
+    async def oracle_backtest_bulk(
+        request: dict[str, Any], api_key: str = "",
+    ) -> str:
+        """Bulk-evaluate many strategies against a shared date range.
+
+        ``request`` mirrors ``OracleBulkBacktestRequest`` — supply
+        ``strategy_ids``, ``strategy_configs``, or both, plus the shared
+        risk + date fields. OHLCV is fetched once per unique
+        ``(asset, timeframe)`` and shared across strategies.
+        """
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            from src.services.oracle import backtest_bulk as svc
+            result = svc(request)
+            return json.dumps(result)
+        except AgentError as e:
+            return _handle_agent_error(e)
+
+    register_tool(ToolEntry(
+        name="oracle_backtest_bulk",
+        description="Bulk-evaluate N strategies via Oracle with shared market-data fetches.",
+        access="auth",
+        parameters=[
+            ToolParam(
+                name="request",
+                type="object",
+                required=True,
+                description="OracleBulkBacktestRequest dict (strategy_ids, strategy_configs, shared risk + date fields).",
+            ),
+            _APIKEY,
+        ],
+    ))
+
+    # ----------------------------------------------------------------- #
+    # Experiment lifecycle (8 tools)
+    # ----------------------------------------------------------------- #
+
+    @server.tool()
+    async def oracle_create_experiment(
+        config: dict[str, Any], api_key: str = "",
+    ) -> str:
+        """Create a draft experiment from a config dict.
+
+        ``config`` is passed through to Oracle's ``ExperimentConfig``.
+        At minimum ``name`` is required. Returns
+        ``{experiment_id, status: 'draft', created_at, org_id}``.
+        """
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            from src.services.oracle import create_experiment as svc
+            return json.dumps(svc(config))
+        except AgentError as e:
+            return _handle_agent_error(e)
+
+    register_tool(ToolEntry(
+        name="oracle_create_experiment",
+        description="Create an Oracle sweep experiment in draft status.",
+        access="auth",
+        parameters=[
+            ToolParam(name="config", type="object", required=True, description="ExperimentConfig dict (name required)."),
+            _APIKEY,
+        ],
+    ))
+
+    @server.tool()
+    async def oracle_list_experiments(api_key: str = "") -> str:
+        """List experiments for the calling org (compact summary view).
+
+        Returns one row per experiment with experiment_id, name, status,
+        total_runs, completed, search_mode, created_at. Note: this
+        endpoint can 504 under load — fall back to per-id
+        ``oracle_get_experiment`` if needed.
+        """
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            from src.services.oracle import list_experiments as svc
+            return json.dumps(svc())
+        except AgentError as e:
+            return _handle_agent_error(e)
+
+    register_tool(ToolEntry(
+        name="oracle_list_experiments",
+        description="List Oracle experiments (summary view) for the calling org.",
+        access="auth",
+        parameters=[_APIKEY],
+    ))
+
+    @server.tool()
+    async def oracle_get_experiment(experiment_id: str, api_key: str = "") -> str:
+        """Fetch full experiment config + current progress (completed_runs)."""
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            from src.services.oracle import get_experiment as svc
+            return json.dumps(svc(experiment_id))
+        except AgentError as e:
+            return _handle_agent_error(e)
+
+    register_tool(ToolEntry(
+        name="oracle_get_experiment",
+        description="Get full Oracle experiment config + live progress.",
+        access="auth",
+        parameters=[
+            ToolParam(name="experiment_id", type="string", required=True, description="ID returned by oracle_create_experiment."),
+            _APIKEY,
+        ],
+    ))
+
+    @server.tool()
+    async def oracle_update_experiment(
+        experiment_id: str, config: dict[str, Any], api_key: str = "",
+    ) -> str:
+        """Replace a draft experiment's config (PUT semantics).
+
+        Only ``draft``-status experiments can be updated; validated /
+        launched / paused reject mutation with HTTP 400.
+        """
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            from src.services.oracle import update_experiment as svc
+            return json.dumps(svc(experiment_id, config))
+        except AgentError as e:
+            return _handle_agent_error(e)
+
+    register_tool(ToolEntry(
+        name="oracle_update_experiment",
+        description="Replace a draft Oracle experiment's config (PUT semantics).",
+        access="auth",
+        parameters=[
+            ToolParam(name="experiment_id", type="string", required=True, description="Experiment to update."),
+            ToolParam(name="config", type="object", required=True, description="Full replacement ExperimentConfig."),
+            _APIKEY,
+        ],
+    ))
+
+    @server.tool()
+    async def oracle_delete_experiment(experiment_id: str, api_key: str = "") -> str:
+        """Delete an experiment + cancel any in-flight child backtests."""
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            from src.services.oracle import delete_experiment as svc
+            return json.dumps(svc(experiment_id))
+        except AgentError as e:
+            return _handle_agent_error(e)
+
+    register_tool(ToolEntry(
+        name="oracle_delete_experiment",
+        description="Delete an Oracle experiment and cancel in-flight children.",
+        access="auth",
+        parameters=[
+            ToolParam(name="experiment_id", type="string", required=True, description="Experiment to delete."),
+            _APIKEY,
+        ],
+    ))
+
+    @server.tool()
+    async def oracle_validate_experiment(experiment_id: str, api_key: str = "") -> str:
+        """Validate a draft (required before launch).
+
+        Server returns 400 with structured ``errors`` if the config is
+        incomplete (no datasets, no entry signals, etc.). The
+        agent surfaces those messages verbatim.
+        """
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            from src.services.oracle import validate_experiment as svc
+            return json.dumps(svc(experiment_id))
+        except AgentError as e:
+            return _handle_agent_error(e)
+
+    register_tool(ToolEntry(
+        name="oracle_validate_experiment",
+        description="Validate a draft Oracle experiment (transition draft -> validated).",
+        access="auth",
+        parameters=[
+            ToolParam(name="experiment_id", type="string", required=True, description="Draft experiment to validate."),
+            _APIKEY,
+        ],
+    ))
+
+    @server.tool()
+    async def oracle_launch_experiment(experiment_id: str, api_key: str = "") -> str:
+        """Fan out a validated experiment into child backtests.
+
+        Up to 99 children per launch. Returns immediately with
+        ``status: 'launched'`` — the fan-out is asynchronous. Poll
+        ``oracle_get_experiment(id)`` for progress or
+        ``oracle_list_results(experiment_id=id)`` for materializing rows.
+
+        Bills: 1 unit per HTTP call (children not billed individually).
+        """
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            from src.services.oracle import launch_experiment as svc
+            return json.dumps(svc(experiment_id))
+        except AgentError as e:
+            return _handle_agent_error(e)
+
+    register_tool(ToolEntry(
+        name="oracle_launch_experiment",
+        description="Launch a validated Oracle experiment into up to 99 child backtests.",
+        access="auth",
+        parameters=[
+            ToolParam(name="experiment_id", type="string", required=True, description="Validated experiment to launch."),
+            _APIKEY,
+        ],
+    ))
+
+    @server.tool()
+    async def oracle_pause_experiment(experiment_id: str, api_key: str = "") -> str:
+        """Pause a running experiment. Resume by relaunching."""
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            from src.services.oracle import pause_experiment as svc
+            return json.dumps(svc(experiment_id))
+        except AgentError as e:
+            return _handle_agent_error(e)
+
+    register_tool(ToolEntry(
+        name="oracle_pause_experiment",
+        description="Pause a running Oracle experiment without losing completed results.",
+        access="auth",
+        parameters=[
+            ToolParam(name="experiment_id", type="string", required=True, description="Running experiment to pause."),
+            _APIKEY,
+        ],
+    ))
+
+    # ----------------------------------------------------------------- #
+    # Results pagination (1 tool)
+    # ----------------------------------------------------------------- #
+
+    @server.tool()
+    async def oracle_list_results(
+        experiment_id: str, limit: int = 100, offset: int = 0, api_key: str = "",
+    ) -> str:
+        """Read backtest results materializing under an experiment.
+
+        ``experiment_id`` is required — Oracle rejects unfiltered reads.
+        Returns ``{total, offset, limit, results}``; results are
+        wide-format Oracle backtest result rows.
+        """
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            from src.services.oracle import list_results as svc
+            return json.dumps(svc(experiment_id, limit=limit, offset=offset))
+        except AgentError as e:
+            return _handle_agent_error(e)
+
+    register_tool(ToolEntry(
+        name="oracle_list_results",
+        description="Paginated read of Oracle backtest results under an experiment.",
+        access="auth",
+        parameters=[
+            ToolParam(name="experiment_id", type="string", required=True, description="Experiment whose results to read."),
+            ToolParam(name="limit", type="integer", required=False, description="Default 100; max 1000."),
+            ToolParam(name="offset", type="integer", required=False, description="Default 0."),
+            _APIKEY,
+        ],
+    ))
+
+    # ----------------------------------------------------------------- #
+    # Metadata catalogs (3 tools — free / non-billable)
+    # ----------------------------------------------------------------- #
+
+    @server.tool()
+    async def oracle_list_datasets(api_key: str = "") -> str:
+        """List the OHLCV datasets experiments can run against.
+
+        Each dataset entry carries asset, timeframe, file, hash,
+        start_date, end_date. Curated immutable snapshots.
+        """
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            from src.services.oracle import list_datasets as svc
+            return json.dumps(svc())
+        except AgentError as e:
+            return _handle_agent_error(e)
+
+    register_tool(ToolEntry(
+        name="oracle_list_datasets",
+        description="List curated OHLCV datasets available to Oracle experiments.",
+        access="auth",
+        parameters=[_APIKEY],
+    ))
+
+    @server.tool()
+    async def oracle_list_signals(api_key: str = "") -> str:
+        """List signals with typed param specs available to experiments.
+
+        Each entry carries name, type (TRIGGER/FILTER), params (typed),
+        constraints, description, requires (OHLCV cols), category.
+        Use this to construct ExperimentConfig.entry_signals /
+        exit_signals programmatically with valid signal names + params.
+        """
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            from src.services.oracle import list_signals as svc
+            return json.dumps(svc())
+        except AgentError as e:
+            return _handle_agent_error(e)
+
+    register_tool(ToolEntry(
+        name="oracle_list_signals",
+        description="List signals with typed param specs available to Oracle experiments.",
+        access="auth",
+        parameters=[_APIKEY],
+    ))
+
+    @server.tool()
+    async def oracle_list_templates(api_key: str = "") -> str:
+        """List predefined strategy templates to seed experiments from."""
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            from src.services.oracle import list_templates as svc
+            return json.dumps(svc())
+        except AgentError as e:
+            return _handle_agent_error(e)
+
+    register_tool(ToolEntry(
+        name="oracle_list_templates",
+        description="List predefined strategy templates to seed Oracle experiments.",
+        access="auth",
+        parameters=[_APIKEY],
+    ))
+
 
 # ---------------------------------------------------------------------------
 # x402 demo (unchanged)

--- a/server/src/mcp/tools.py
+++ b/server/src/mcp/tools.py
@@ -1323,6 +1323,235 @@ def _register_on_chain(server: FastMCP) -> None:
         ],
     ))
 
+    # ----------------------------------------------------------------- #
+    # Nansen Pro coverage (5 endpoints added in mangroveai 1.1.0)
+    # All take optional `filters` / `order_by` dicts passed straight
+    # through to Nansen — give agents the full Pro plan reach (Fund-
+    # labelled wallets, side-filtered DEX trades, etc.).
+    # ----------------------------------------------------------------- #
+
+    @server.tool()
+    async def get_smart_money_historical_holdings(
+        chains: list[str] | None = None,
+        date_from: str | None = None,
+        date_to: str | None = None,
+        filters: dict[str, Any] | None = None,
+        order_by: list[dict[str, str]] | None = None,
+        page: int = 1,
+        per_page: int = 100,
+        api_key: str = "",
+    ) -> str:
+        """Date-stamped Smart Money holdings snapshots across chains (Nansen).
+
+        Show how Fund/VC/CEX-labelled wallets shifted positions over a
+        window. Use with `filters={"include_smart_money_labels": ["Fund"]}`
+        to restrict to a single label class.
+        """
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            kwargs: dict[str, Any] = {"page": page, "per_page": per_page}
+            for k, v in (("chains", chains), ("date_from", date_from), ("date_to", date_to),
+                         ("filters", filters), ("order_by", order_by)):
+                if v is not None:
+                    kwargs[k] = v
+            r = mangrove_ai_client().on_chain.get_smart_money_historical_holdings(**kwargs)
+            return json.dumps(_dump(r))
+        except Exception as e:  # noqa: BLE001
+            return _err("ONCHAIN_SM_HISTORICAL_HOLDINGS_FAILED", str(e))
+
+    register_tool(ToolEntry(
+        name="get_smart_money_historical_holdings",
+        description="Smart Money historical holdings snapshots across chains (Nansen).",
+        access="auth",
+        parameters=[
+            ToolParam(name="chains", type="array", required=False, description="Chain filter, e.g. ['ethereum', 'solana']. Default ['ethereum']."),
+            ToolParam(name="date_from", type="string", required=False, description="ISO date 'YYYY-MM-DD'."),
+            ToolParam(name="date_to", type="string", required=False, description="ISO date 'YYYY-MM-DD'."),
+            ToolParam(name="filters", type="object", required=False, description="Nansen filter dict (include_smart_money_labels, etc.)"),
+            ToolParam(name="order_by", type="array", required=False, description="Sort spec, e.g. [{'field': 'block_timestamp', 'direction': 'DESC'}]"),
+            ToolParam(name="page", type="integer", required=False, description="Page (default 1)"),
+            ToolParam(name="per_page", type="integer", required=False, description="Items per page (default 100)"),
+            _APIKEY,
+        ],
+    ))
+
+    @server.tool()
+    async def get_smart_money_dex_trades(
+        chains: list[str] | None = None,
+        filters: dict[str, Any] | None = None,
+        order_by: list[dict[str, str]] | None = None,
+        page: int = 1,
+        per_page: int = 100,
+        api_key: str = "",
+    ) -> str:
+        """Recent DEX trades from Smart Money wallets (Nansen).
+
+        Filters accept: ``include_smart_money_labels``, ``token_address``,
+        ``side`` ('buy' | 'sell'), ``min_amount_usd``.
+        """
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            kwargs: dict[str, Any] = {"page": page, "per_page": per_page}
+            for k, v in (("chains", chains), ("filters", filters), ("order_by", order_by)):
+                if v is not None:
+                    kwargs[k] = v
+            r = mangrove_ai_client().on_chain.get_smart_money_dex_trades(**kwargs)
+            return json.dumps(_dump(r))
+        except Exception as e:  # noqa: BLE001
+            return _err("ONCHAIN_SM_DEX_TRADES_FAILED", str(e))
+
+    register_tool(ToolEntry(
+        name="get_smart_money_dex_trades",
+        description="Recent DEX trades from Smart Money wallets (Nansen).",
+        access="auth",
+        parameters=[
+            ToolParam(name="chains", type="array", required=False, description="Chain filter."),
+            ToolParam(name="filters", type="object", required=False, description="Nansen filter dict."),
+            ToolParam(name="order_by", type="array", required=False, description="Sort spec."),
+            ToolParam(name="page", type="integer", required=False, description="Page (default 1)."),
+            ToolParam(name="per_page", type="integer", required=False, description="Items per page (default 100)."),
+            _APIKEY,
+        ],
+    ))
+
+    @server.tool()
+    async def get_smart_money_perp_trades(
+        filters: dict[str, Any] | None = None,
+        order_by: list[dict[str, str]] | None = None,
+        page: int = 1,
+        per_page: int = 100,
+        api_key: str = "",
+    ) -> str:
+        """Perpetual-futures trades from Smart Money on Hyperliquid (Nansen).
+
+        Hyperliquid-only; upstream doesn't accept a chain filter.
+
+        Filters accept: ``action``, ``side`` ('Long' | 'Short'),
+        ``token_symbol``, ``type`` ('Market' | 'Limit'),
+        ``value_usd`` ({min, max}), ``only_new_positions``.
+        """
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            kwargs: dict[str, Any] = {"page": page, "per_page": per_page}
+            for k, v in (("filters", filters), ("order_by", order_by)):
+                if v is not None:
+                    kwargs[k] = v
+            r = mangrove_ai_client().on_chain.get_smart_money_perp_trades(**kwargs)
+            return json.dumps(_dump(r))
+        except Exception as e:  # noqa: BLE001
+            return _err("ONCHAIN_SM_PERP_TRADES_FAILED", str(e))
+
+    register_tool(ToolEntry(
+        name="get_smart_money_perp_trades",
+        description="Smart Money perp trades on Hyperliquid (Nansen).",
+        access="auth",
+        parameters=[
+            ToolParam(name="filters", type="object", required=False, description="Nansen filter dict."),
+            ToolParam(name="order_by", type="array", required=False, description="Sort spec."),
+            ToolParam(name="page", type="integer", required=False, description="Page (default 1)."),
+            ToolParam(name="per_page", type="integer", required=False, description="Items per page (default 100)."),
+            _APIKEY,
+        ],
+    ))
+
+    @server.tool()
+    async def get_token_dex_trades(
+        symbol: str,
+        chain: str | None = None,
+        date_from: str | None = None,
+        date_to: str | None = None,
+        filters: dict[str, Any] | None = None,
+        order_by: list[dict[str, str]] | None = None,
+        page: int = 1,
+        per_page: int = 100,
+        api_key: str = "",
+    ) -> str:
+        """All DEX trades on a single token in a date window (Nansen).
+
+        Token-scoped (not wallet-scoped) — sees every counterparty, not
+        just Smart Money. Useful for liquidity / activity diagnostics.
+        """
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            kwargs: dict[str, Any] = {"page": page, "per_page": per_page}
+            for k, v in (("chain", chain), ("date_from", date_from), ("date_to", date_to),
+                         ("filters", filters), ("order_by", order_by)):
+                if v is not None:
+                    kwargs[k] = v
+            r = mangrove_ai_client().on_chain.get_token_dex_trades(symbol, **kwargs)
+            return json.dumps(_dump(r))
+        except Exception as e:  # noqa: BLE001
+            return _err("ONCHAIN_TOKEN_DEX_TRADES_FAILED", str(e))
+
+    register_tool(ToolEntry(
+        name="get_token_dex_trades",
+        description="All DEX trades for a single token in a date window (Nansen).",
+        access="auth",
+        parameters=[
+            ToolParam(name="symbol", type="string", required=True, description="Token symbol (e.g. 'uniswap')."),
+            ToolParam(name="chain", type="string", required=False, description="Chain (default 'ethereum')."),
+            ToolParam(name="date_from", type="string", required=False, description="ISO 'YYYY-MM-DD'."),
+            ToolParam(name="date_to", type="string", required=False, description="ISO 'YYYY-MM-DD'."),
+            ToolParam(name="filters", type="object", required=False, description="Nansen filter dict."),
+            ToolParam(name="order_by", type="array", required=False, description="Sort spec."),
+            ToolParam(name="page", type="integer", required=False, description="Page (default 1)."),
+            ToolParam(name="per_page", type="integer", required=False, description="Items per page (default 100)."),
+            _APIKEY,
+        ],
+    ))
+
+    @server.tool()
+    async def get_token_flows(
+        symbol: str,
+        chain: str | None = None,
+        date_from: str | None = None,
+        date_to: str | None = None,
+        filters: dict[str, Any] | None = None,
+        order_by: list[dict[str, str]] | None = None,
+        page: int = 1,
+        per_page: int = 100,
+        api_key: str = "",
+    ) -> str:
+        """Per-wallet-category flow data for a token in a date window (Nansen).
+
+        Aggregates trades by trader category (Fund, CEX, Smart Trader,
+        etc.) over each date. **Stablecoins are not supported** — Nansen
+        returns 404.
+        """
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            kwargs: dict[str, Any] = {"page": page, "per_page": per_page}
+            for k, v in (("chain", chain), ("date_from", date_from), ("date_to", date_to),
+                         ("filters", filters), ("order_by", order_by)):
+                if v is not None:
+                    kwargs[k] = v
+            r = mangrove_ai_client().on_chain.get_token_flows(symbol, **kwargs)
+            return json.dumps(_dump(r))
+        except Exception as e:  # noqa: BLE001
+            return _err("ONCHAIN_TOKEN_FLOWS_FAILED", str(e))
+
+    register_tool(ToolEntry(
+        name="get_token_flows",
+        description="Per-wallet-category flow data for a token across a date window (Nansen).",
+        access="auth",
+        parameters=[
+            ToolParam(name="symbol", type="string", required=True, description="Token symbol (non-stablecoin)."),
+            ToolParam(name="chain", type="string", required=False, description="Chain (default 'ethereum')."),
+            ToolParam(name="date_from", type="string", required=False, description="ISO 'YYYY-MM-DD'."),
+            ToolParam(name="date_to", type="string", required=False, description="ISO 'YYYY-MM-DD'."),
+            ToolParam(name="filters", type="object", required=False, description="Nansen filter dict."),
+            ToolParam(name="order_by", type="array", required=False, description="Sort spec."),
+            ToolParam(name="page", type="integer", required=False, description="Page (default 1)."),
+            ToolParam(name="per_page", type="integer", required=False, description="Items per page (default 100)."),
+            _APIKEY,
+        ],
+    ))
+
 
 # ---------------------------------------------------------------------------
 # DeFi (auth)

--- a/server/src/services/oracle.py
+++ b/server/src/services/oracle.py
@@ -17,6 +17,7 @@ from typing import Any
 from mangrove_ai.models.oracle import (
     DataQueryRequest,
     OracleBacktestRequest,
+    OracleBulkBacktestRequest,
     SieveScoreRequest,
 )
 from pydantic import BaseModel, Field
@@ -160,3 +161,185 @@ def backtest(payload: OracleBacktestInput) -> dict[str, Any]:
         },
     )
     return result.model_dump()
+
+
+# ---------------------------------------------------------------------------
+# Async + bulk backtest wrappers
+# ---------------------------------------------------------------------------
+
+
+def backtest_async(payload: OracleBacktestInput) -> dict[str, Any]:
+    """Submit a backtest for async execution.
+
+    Returns ``{backtest_id, status}`` immediately. Customers poll
+    ``backtest_poll(backtest_id)`` to retrieve the full result once
+    the engine finishes. Use this for long windows / heavy parameters
+    where the 30-120s sync block is unworkable.
+    """
+    client = mangrove_ai_client()
+    result = client.oracle.backtest_async(
+        OracleBacktestRequest(
+            asset=payload.asset,
+            interval=payload.interval,
+            strategy_json=payload.strategy_json,
+            lookback_months=payload.lookback_months,
+            initial_balance=payload.initial_balance,
+            max_risk_per_trade=payload.max_risk_per_trade,
+            execution_config=payload.execution_config,
+            mode=payload.mode,
+        )
+    )
+    _log.info("oracle.backtest_async", extra={"backtest_id": result.backtest_id})
+    return result.model_dump()
+
+
+def backtest_poll(backtest_id: str) -> dict[str, Any]:
+    """Poll status / result of an async backtest."""
+    client = mangrove_ai_client()
+    result = client.oracle.backtest_poll(backtest_id)
+    _log.info(
+        "oracle.backtest_poll",
+        extra={"backtest_id": backtest_id, "status": result.status},
+    )
+    return result.model_dump()
+
+
+def backtest_bulk(payload: dict[str, Any]) -> dict[str, Any]:
+    """Evaluate many strategies over a shared date range in one call.
+
+    Payload mirrors ``mangrove_ai.models.oracle.OracleBulkBacktestRequest``
+    — supply ``strategy_ids`` (DB lookups), ``strategy_configs`` (inline
+    dicts), or both, plus the shared date range / risk parameters. The
+    server fetches OHLCV once per unique ``(asset, timeframe)`` and
+    re-uses it across all strategies that need it.
+    """
+    client = mangrove_ai_client()
+    result = client.oracle.backtest_bulk(OracleBulkBacktestRequest(**payload))
+    _log.info(
+        "oracle.backtest_bulk",
+        extra={
+            "success": result.success,
+            "data_fetches": result.data_fetches,
+            "n_results": len(result.results),
+        },
+    )
+    return result.model_dump()
+
+
+# ---------------------------------------------------------------------------
+# Experiment lifecycle wrappers
+# ---------------------------------------------------------------------------
+
+def create_experiment(config: dict[str, Any]) -> dict[str, Any]:
+    """Create a draft experiment from a config dict. Returns experiment_id."""
+    client = mangrove_ai_client()
+    result = client.oracle.create_experiment(config)
+    _log.info("oracle.create_experiment", extra={"experiment_id": result.experiment_id})
+    return result.model_dump()
+
+
+def list_experiments() -> list[dict[str, Any]]:
+    """List all experiments for the calling org (summary view)."""
+    client = mangrove_ai_client()
+    items = client.oracle.list_experiments()
+    return [item.model_dump() for item in items]
+
+
+def get_experiment(experiment_id: str) -> dict[str, Any]:
+    """Fetch full experiment config including current progress."""
+    client = mangrove_ai_client()
+    return client.oracle.get_experiment(experiment_id)
+
+
+def update_experiment(experiment_id: str, config: dict[str, Any]) -> dict[str, Any]:
+    """Replace a draft experiment's config (PUT semantics).
+
+    Only ``draft``-status experiments can be updated; validated /
+    launched / paused experiments reject mutation with HTTP 400.
+    """
+    client = mangrove_ai_client()
+    result = client.oracle.update_experiment(experiment_id, config)
+    _log.info("oracle.update_experiment", extra={"experiment_id": experiment_id})
+    return result.model_dump()
+
+
+def delete_experiment(experiment_id: str) -> dict[str, Any]:
+    """Delete an experiment + cancel any in-flight child backtests."""
+    client = mangrove_ai_client()
+    result = client.oracle.delete_experiment(experiment_id)
+    _log.info("oracle.delete_experiment", extra={"experiment_id": experiment_id})
+    return result.model_dump()
+
+
+def validate_experiment(experiment_id: str) -> dict[str, Any]:
+    """Validate a draft → required before launch."""
+    client = mangrove_ai_client()
+    result = client.oracle.validate_experiment(experiment_id)
+    _log.info(
+        "oracle.validate_experiment",
+        extra={"experiment_id": experiment_id, "status": result.status},
+    )
+    return result.model_dump()
+
+
+def launch_experiment(experiment_id: str) -> dict[str, Any]:
+    """Fan out a validated experiment into up to 99 child backtests."""
+    client = mangrove_ai_client()
+    result = client.oracle.launch_experiment(experiment_id)
+    _log.info(
+        "oracle.launch_experiment",
+        extra={"experiment_id": experiment_id, "status": result.status},
+    )
+    return result.model_dump()
+
+
+def pause_experiment(experiment_id: str) -> dict[str, Any]:
+    """Halt a running experiment without losing completed results."""
+    client = mangrove_ai_client()
+    result = client.oracle.pause_experiment(experiment_id)
+    _log.info(
+        "oracle.pause_experiment",
+        extra={"experiment_id": experiment_id, "status": result.status},
+    )
+    return result.model_dump()
+
+
+# ---------------------------------------------------------------------------
+# Results pagination
+# ---------------------------------------------------------------------------
+
+def list_results(
+    experiment_id: str, *, limit: int = 100, offset: int = 0,
+) -> dict[str, Any]:
+    """Read backtest results materializing under an experiment, paginated.
+
+    ``experiment_id`` is required — Oracle rejects unfiltered reads at
+    the proxy layer to prevent cross-tenant fan-out.
+    """
+    client = mangrove_ai_client()
+    result = client.oracle.list_results(
+        experiment_id=experiment_id, limit=limit, offset=offset,
+    )
+    return result.model_dump()
+
+
+# ---------------------------------------------------------------------------
+# Metadata catalogs (free / non-billable)
+# ---------------------------------------------------------------------------
+
+def list_datasets() -> list[dict[str, Any]]:
+    """List the OHLCV datasets the engine can run experiments against."""
+    client = mangrove_ai_client()
+    return client.oracle.list_datasets()
+
+
+def list_signals() -> list[dict[str, Any]]:
+    """List signals with typed param specs available to experiments."""
+    client = mangrove_ai_client()
+    return client.oracle.list_signals()
+
+
+def list_templates() -> list[dict[str, Any]]:
+    """List predefined strategy templates to seed experiments from."""
+    client = mangrove_ai_client()
+    return client.oracle.list_templates()


### PR DESCRIPTION
## Summary

Wires the SDK's full Nansen Pro + Oracle proxy surface (20 methods total) through the agent's REST mirror + MCP tool registry. Closes the gap where the SDK had typed methods but the agent didn't expose them — customers using the agent's surface can now reach all five Nansen Pro endpoints landed in mangroveai 1.1.0 AND all 15 Oracle proxy endpoints landed in mangroveai 1.3.0.

The agent's Oracle exposure jumps from 3 endpoints (sieve_score / data_query / sync backtest from PR #79) to 18 — full coverage of the customer-facing `/api/v1/oracle/*` surface MangroveAI exposes.

## What's new

### Nansen Pro (5 REST + 5 MCP)

REST (POST under `/api/v1/agent/on-chain/`):
- `/smart-money/historical-holdings`
- `/smart-money/dex-trades`
- `/smart-money/perp-trades` (Hyperliquid-only)
- `/token-dex-trades/{symbol}`
- `/token-flows/{symbol}` (stablecoins not supported)

MCP: `get_smart_money_historical_holdings`, `get_smart_money_dex_trades`, `get_smart_money_perp_trades`, `get_token_dex_trades`, `get_token_flows`.

### Oracle (15 REST + 15 MCP)

REST (added under `/api/v1/agent/oracle/`):
- **Async + bulk backtests**: `POST /backtest/async`, `GET /backtest/async/{id}`, `POST /backtest/bulk`
- **Experiment lifecycle**: `POST /experiments`, `GET /experiments`, `GET /experiments/{id}`, `PUT /experiments/{id}`, `DELETE /experiments/{id}`, `POST /experiments/{id}/validate`, `POST /experiments/{id}/launch`, `POST /experiments/{id}/pause`
- **Results + catalogs**: `GET /results`, `GET /datasets`, `GET /signals`, `GET /templates`

MCP tools: all 15 above with `oracle_*` prefix.

### Misc

- `.claude/rules/trading-bot-workflow.md` core-set extended with 11 of 20 new tool names (5 Nansen + 6 high-value Oracle: `oracle_list_datasets`, `oracle_list_signals`, `oracle_create_experiment`, `oracle_validate_experiment`, `oracle_launch_experiment`, `oracle_list_results`) so the agent eagerly loads them on session start.
- Route handlers now catch `mangrove_ai.exceptions.APIError` and translate to FastAPI `HTTPException` preserving the upstream status code + structured detail envelope (`error / message / code / correlation_id`). Closes a real bug: empty 500 responses on Oracle server-side validation errors now surface as proper 4xx with the engine's structured payload.

## Test plan

- [x] 356 unit tests pass + 2 skip (matches baseline)
- [x] Live-verified all 5 Nansen routes against `api.mangrovedeveloper.ai` prod with real Nansen Pro data
- [x] Live-verified all 15 Oracle routes against `api.mangrovedeveloper.ai` prod through the agent → SDK 1.3.0 → proxy chain:
  - `list_datasets`: 2246 real datasets
  - `list_signals`: 223 real signals (88 trend / 42 momentum / 40 patterns / 33 volume / 20 volatility)
  - `list_templates`: `[]`
  - `create + get + delete experiment`: full round-trip, real `exp_<timestamp>` IDs
  - `validate / launch` on empty config: proper 400 with structured `errors: ["No datasets selected", ...]` and `"Experiment must be validated before launch"` — confirms exception translation works
  - `list_results`: `total=0` for empty experiment
  - `backtest_async`: structured 400 listing missing required fields

## Sibling KB PR

A separate KB PR lands at `MangroveKnowledgeBase` to update `docs/mangrove-agent/mcp-tools.mdx`, which currently has zero mentions of `nansen`, `sieve`, `oracle`, or `experiment` tools. That doc PR catalogs all 23 newly-exposed agent tools (5 Nansen + 3 pre-existing Oracle from PR #79 + 15 new Oracle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)