### PR TITLE
chore(deps): tighten mangroveai floor to >=1.4.0 (was >=1.0.2)

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -23,7 +23,7 @@ PyJWT>=2.9.0
 # is normal Python packaging (Pillow/PIL, beautifulsoup4/bs4, etc.).
 # An attempted PyPI rename to `mangrove-ai` was rejected by PyPI's
 # similarity check — that's why we kept the dist name as-is.
-mangroveai>=1.0.2,<2.0.0
+mangroveai>=1.4.0,<2.0.0
 # mangrovemarkets 1.0.0 moved EVM wallet keypair generation client-side.
 # The agent's wallet_manager.create_wallet() is unaffected — the SDK
 # call signature is unchanged, only the implementation shifted from


### PR DESCRIPTION
## Summary

Tightens the `mangroveai` SDK pin floor in `server/requirements.txt` from `>=1.0.2,<2.0.0` to `>=1.4.0,<2.0.0`.

The agent's Oracle surface (PR #82) and the planned follow-up for the SDK 1.4 method set (`simulate_*`, `leaderboard`, `list_deployed_strategies`, `exec_config_defaults`, `get_deployed_strategy_state`) depend on methods introduced after 1.0.x. The loose `>=1.0.2` floor was a forward-safety risk if a wire-incompatible older 1.x release ever showed up in the resolve set.

## Behavior

Resolution on a fresh install **today** is unchanged — pip already picks `mangroveai 1.4.0` (latest in `<2.0.0`). This PR just makes that floor explicit.

## Local verification

From the worktree's fresh venv:

```
$ pip install -e server/  # quiet
$ python -c "from importlib.metadata import version; print(version('mangroveai'))"
1.4.0
$ python -c "from mangrove_ai import MangroveAI; c = MangroveAI(api_key='x'); print(type(c.oracle).__name__)"
OracleService
```

Verified the 6 expected SDK 1.4 methods are all present on `client.oracle`:

```
+ exec_config_defaults
+ simulate_run
+ simulate_generate
+ leaderboard
+ list_deployed_strategies
+ get_deployed_strategy_state
```

## Test plan

- [ ] CI green
- [ ] After merge, a fresh `pip install -e server/` from `main` resolves to `mangroveai 1.4.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)