### PR TITLE
fix(nf-2): narrow bare except and log warnings on shutdown failures

### DIFF
--- a/server/src/services/scheduler_service.py
+++ b/server/src/services/scheduler_service.py
@@ -87,8 +87,8 @@ def reset_scheduler_cache() -> None:
         sched = get_scheduler()
         if sched.running:
             sched.shutdown(wait=False)
-    except Exception:
-        pass
+    except Exception as exc:
+        _log.warning("scheduler.shutdown.failed", error=str(exc))
     get_scheduler.cache_clear()
 
 

--- a/server/src/shared/db/sqlite.py
+++ b/server/src/shared/db/sqlite.py
@@ -57,8 +57,8 @@ def reset_connection() -> None:
     """Close + clear the cached connection. Used by tests to flip DB_PATH."""
     try:
         get_connection().close()
-    except Exception:
-        pass
+    except sqlite3.Error as exc:
+        _log.warning("db.connection.close_failed", error=str(exc))
     get_connection.cache_clear()
 
 

--- a/server/tests/integration/test_sqlite.py
+++ b/server/tests/integration/test_sqlite.py
@@ -118,3 +118,28 @@ def test_insert_and_query_roundtrip(temp_db):
     assert row["address"] == "0xabc"
     assert row["encrypted_secret"] == b"ciphertext"
     assert row["chain"] == "evm"
+
+
+def test_reset_connection_logs_warning_on_close_failure(monkeypatch):
+    """If close() raises a sqlite3.Error, a warning is logged and cache_clear still runs."""
+    import sqlite3
+    from unittest.mock import MagicMock
+
+    from src.shared.db import sqlite as db_mod
+
+    mock_conn = MagicMock()
+    mock_conn.close.side_effect = sqlite3.Error("forced close failure")
+
+    mock_get_connection = MagicMock(return_value=mock_conn)
+    mock_get_connection.cache_clear = MagicMock()
+    monkeypatch.setattr(db_mod, "get_connection", mock_get_connection)
+
+    mock_log = MagicMock()
+    monkeypatch.setattr(db_mod, "_log", mock_log)
+
+    db_mod.reset_connection()
+
+    mock_log.warning.assert_called_once_with(
+        "db.connection.close_failed", error="forced close failure"
+    )
+    mock_get_connection.cache_clear.assert_called_once()

--- a/server/tests/unit/test_scheduler_service.py
+++ b/server/tests/unit/test_scheduler_service.py
@@ -102,3 +102,28 @@ def test_event_listener_emits_scheduler_job_errored_on_failure():
     event.job_id = "eval-abc-123"
     event.exception = RuntimeError("boom")
     _on_job_event(event)  # should not raise
+
+
+def test_reset_scheduler_cache_logs_warning_on_shutdown_failure(monkeypatch):
+    """If shutdown raises, a warning is logged and cache_clear still runs."""
+    from unittest.mock import MagicMock
+
+    from src.services import scheduler_service as ss
+
+    mock_sched = MagicMock()
+    mock_sched.running = True
+    mock_sched.shutdown.side_effect = RuntimeError("forced shutdown failure")
+
+    mock_get_scheduler = MagicMock(return_value=mock_sched)
+    mock_get_scheduler.cache_clear = MagicMock()
+    monkeypatch.setattr(ss, "get_scheduler", mock_get_scheduler)
+
+    mock_log = MagicMock()
+    monkeypatch.setattr(ss, "_log", mock_log)
+
+    ss.reset_scheduler_cache()
+
+    mock_log.warning.assert_called_once_with(
+        "scheduler.shutdown.failed", error="forced shutdown failure"
+    )
+    mock_get_scheduler.cache_clear.assert_called_once()


### PR DESCRIPTION
## Summary

  Fixes two silent exception swallows in the scheduler and SQLite shutdown paths. Both had bare `except Exception: pass` — meaning a hung scheduler thread or a failed DB connection close would disappear with zero trace in the logs. Closes #70.

  ## What changed
  
  **`scheduler_service.py` — `reset_scheduler_cache()`**
  - `except Exception: pass` → `except Exception as exc` + `_log.warning("scheduler.shutdown.failed", error=str(exc))`
  - Shutdown still completes after the warning — no behaviour change
  
  **`sqlite.py` — `reset_connection()`**
  - Narrowed from `Exception` to `sqlite3.Error` — the correct base type for all SQLite errors
  - Added `_log.warning("db.connection.close_failed", error=str(exc))`
  - Cache still clears after the warning — no behaviour change

  **Tests** 
  - Added `test_reset_scheduler_cache_logs_warning_on_shutdown_failure` in `tests/unit/test_scheduler_service.py` — forces shutdown to raise,
  asserts warning fires with correct event name + message, asserts cache_clear still runs
  - Added `test_reset_connection_logs_warning_on_close_failure` in `tests/integration/test_sqlite.py` — forces close to raise sqlite3.Error,
  same assertions
  
  ## Test plan
  - [x] 2 new targeted tests added and passing
  - [x] Full suite: 358 passed, 2 skipped (was 356 before this PR)
  - [x] Closes #70