### PR TITLE
fix(config): raise SecretResolutionError instead of sys.exit in secret resolver (#69)

### DIFF
--- a/server/src/config.py
+++ b/server/src/config.py
@@ -14,7 +14,7 @@ import json
 import os
 import sys
 
-from src.shared.gcp_secret_utils import SecretUtils
+from src.shared.gcp_secret_utils import SecretResolutionError, SecretUtils
 
 
 class _Config:
@@ -106,7 +106,11 @@ class _Config:
                 sys.exit(1)
             secret_id = parts[1]
             secret_property = parts[2]
-            value = SecretUtils.get_secret(project_id, secret_id, secret_property)
+            try:
+                value = SecretUtils.get_secret(project_id, secret_id, secret_property)
+            except SecretResolutionError as e:
+                print(f"Secret resolution failed for '{key}': {e}")
+                sys.exit(1)
         return value
 
 

--- a/server/src/shared/gcp_secret_utils.py
+++ b/server/src/shared/gcp_secret_utils.py
@@ -1,10 +1,13 @@
 """GCP Secret Manager utilities."""
 import json
-import sys
 from typing import Optional
 
 from google.api_core import exceptions as google_exceptions
 from google.cloud import secretmanager
+
+
+class SecretResolutionError(Exception):
+    """Raised when a GCP secret cannot be resolved."""
 
 
 class SecretUtils:
@@ -16,23 +19,25 @@ class SecretUtils:
         version_id: str = "latest",
     ) -> Optional[str]:
         if not secret_id or not secret_property:
-            print("Secret ID or property not supplied.")
-            sys.exit(1)
+            raise SecretResolutionError("Secret ID or property not supplied.")
+
+        if not project_id:
+            raise SecretResolutionError("GCP project id not supplied.")
 
         try:
             client = secretmanager.SecretManagerServiceClient()
-            if not project_id:
-                print("GCP project id not supplied.")
-                sys.exit(1)
-
             name = f"projects/{project_id}/secrets/{secret_id}/versions/{version_id}"
             response = client.access_secret_version(request={"name": name})
             payload = response.payload.data.decode("UTF-8")
             return json.loads(payload)[secret_property]
 
         except google_exceptions.NotFound:
-            print(f"Secret '{secret_id}' not found in project '{project_id}'.")
-            sys.exit(1)
+            raise SecretResolutionError(
+                f"Secret '{secret_id}' not found in project '{project_id}'."
+            )
+        except SecretResolutionError:
+            raise
         except Exception as e:
-            print(f"Error accessing secret {secret_id}: {e}.")
-            sys.exit(1)
+            raise SecretResolutionError(
+                f"Error accessing secret '{secret_id}': {e}."
+            ) from e

--- a/server/tests/unit/test_gcp_secret_utils.py
+++ b/server/tests/unit/test_gcp_secret_utils.py
@@ -1,0 +1,220 @@
+"""Unit tests for shared/gcp_secret_utils.py.
+
+Each test documents:
+  - what inputs were passed
+  - what exception type and message is expected
+
+Covers every raise path in SecretUtils.get_secret plus the happy path.
+"""
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from google.api_core import exceptions as google_exceptions
+
+from src.shared.gcp_secret_utils import SecretResolutionError, SecretUtils
+
+
+# ---------------------------------------------------------------------------
+# Input validation — checked before any GCP call is made
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.fast
+def test_empty_secret_id_raises():
+    # passed: project_id="my-project", secret_id="", secret_property="api_key"
+    # expected: SecretResolutionError("Secret ID or property not supplied.")
+    with pytest.raises(SecretResolutionError, match="Secret ID or property not supplied."):
+        SecretUtils.get_secret("my-project", "", "api_key")
+
+
+@pytest.mark.fast
+def test_none_secret_id_raises():
+    # passed: project_id="my-project", secret_id=None, secret_property="api_key"
+    # expected: SecretResolutionError("Secret ID or property not supplied.")
+    with pytest.raises(SecretResolutionError, match="Secret ID or property not supplied."):
+        SecretUtils.get_secret("my-project", None, "api_key")
+
+
+@pytest.mark.fast
+def test_empty_secret_property_raises():
+    # passed: project_id="my-project", secret_id="my-secret", secret_property=""
+    # expected: SecretResolutionError("Secret ID or property not supplied.")
+    with pytest.raises(SecretResolutionError, match="Secret ID or property not supplied."):
+        SecretUtils.get_secret("my-project", "my-secret", "")
+
+
+@pytest.mark.fast
+def test_none_secret_property_raises():
+    # passed: project_id="my-project", secret_id="my-secret", secret_property=None
+    # expected: SecretResolutionError("Secret ID or property not supplied.")
+    with pytest.raises(SecretResolutionError, match="Secret ID or property not supplied."):
+        SecretUtils.get_secret("my-project", "my-secret", None)
+
+
+@pytest.mark.fast
+def test_both_secret_id_and_property_empty_raises():
+    # passed: project_id="my-project", secret_id="", secret_property=""
+    # expected: SecretResolutionError("Secret ID or property not supplied.")
+    with pytest.raises(SecretResolutionError, match="Secret ID or property not supplied."):
+        SecretUtils.get_secret("my-project", "", "")
+
+
+@pytest.mark.fast
+def test_empty_project_id_raises():
+    # passed: project_id="", secret_id="my-secret", secret_property="api_key"
+    # expected: SecretResolutionError("GCP project id not supplied.")
+    with pytest.raises(SecretResolutionError, match="GCP project id not supplied."):
+        SecretUtils.get_secret("", "my-secret", "api_key")
+
+
+@pytest.mark.fast
+def test_none_project_id_raises():
+    # passed: project_id=None, secret_id="my-secret", secret_property="api_key"
+    # expected: SecretResolutionError("GCP project id not supplied.")
+    with pytest.raises(SecretResolutionError, match="GCP project id not supplied."):
+        SecretUtils.get_secret(None, "my-secret", "api_key")
+
+
+# ---------------------------------------------------------------------------
+# GCP API failures
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.fast
+def test_not_found_raises_with_secret_and_project_in_message():
+    # passed: project_id="prod-project", secret_id="db-password", secret_property="value"
+    # expected: SecretResolutionError("Secret 'db-password' not found in project 'prod-project'.")
+    with patch("src.shared.gcp_secret_utils.secretmanager.SecretManagerServiceClient") as mock_cls:
+        mock_cls.return_value.access_secret_version.side_effect = google_exceptions.NotFound("404")
+
+        with pytest.raises(SecretResolutionError) as exc_info:
+            SecretUtils.get_secret("prod-project", "db-password", "value")
+
+        assert str(exc_info.value) == "Secret 'db-password' not found in project 'prod-project'."
+
+
+@pytest.mark.fast
+def test_generic_api_error_raises_with_secret_id_in_message():
+    # passed: project_id="prod-project", secret_id="api-keys", secret_property="mangrove"
+    # expected: SecretResolutionError("Error accessing secret 'api-keys': network timeout.")
+    with patch("src.shared.gcp_secret_utils.secretmanager.SecretManagerServiceClient") as mock_cls:
+        mock_cls.return_value.access_secret_version.side_effect = RuntimeError("network timeout")
+
+        with pytest.raises(SecretResolutionError) as exc_info:
+            SecretUtils.get_secret("prod-project", "api-keys", "mangrove")
+
+        assert str(exc_info.value) == "Error accessing secret 'api-keys': network timeout."
+
+
+@pytest.mark.fast
+def test_generic_exception_chains_original_cause():
+    # passed: project_id="prod-project", secret_id="my-secret", secret_property="key"
+    # expected: SecretResolutionError.__cause__ is the original RuntimeError
+    original = RuntimeError("connection refused")
+    with patch("src.shared.gcp_secret_utils.secretmanager.SecretManagerServiceClient") as mock_cls:
+        mock_cls.return_value.access_secret_version.side_effect = original
+
+        with pytest.raises(SecretResolutionError) as exc_info:
+            SecretUtils.get_secret("prod-project", "my-secret", "key")
+
+        assert exc_info.value.__cause__ is original
+
+
+# ---------------------------------------------------------------------------
+# Payload parsing failures
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.fast
+def test_property_missing_from_json_payload_raises():
+    # passed: project_id="prod-project", secret_id="my-secret", secret_property="missing_key"
+    # payload contains: {"api_key": "abc"} — "missing_key" is not present
+    # expected: SecretResolutionError wrapping the KeyError
+    payload = json.dumps({"api_key": "abc"}).encode("UTF-8")
+
+    with patch("src.shared.gcp_secret_utils.secretmanager.SecretManagerServiceClient") as mock_cls:
+        mock_response = MagicMock()
+        mock_response.payload.data = payload
+        mock_cls.return_value.access_secret_version.return_value = mock_response
+
+        with pytest.raises(SecretResolutionError, match="Error accessing secret 'my-secret'"):
+            SecretUtils.get_secret("prod-project", "my-secret", "missing_key")
+
+
+@pytest.mark.fast
+def test_malformed_json_payload_raises():
+    # passed: project_id="prod-project", secret_id="bad-secret", secret_property="key"
+    # payload is not valid JSON: b"not-json"
+    # expected: SecretResolutionError wrapping the JSONDecodeError
+    with patch("src.shared.gcp_secret_utils.secretmanager.SecretManagerServiceClient") as mock_cls:
+        mock_response = MagicMock()
+        mock_response.payload.data = b"not-json"
+        mock_cls.return_value.access_secret_version.return_value = mock_response
+
+        with pytest.raises(SecretResolutionError, match="Error accessing secret 'bad-secret'"):
+            SecretUtils.get_secret("prod-project", "bad-secret", "key")
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.fast
+def test_returns_correct_property_from_multi_property_payload():
+    # passed: project_id="prod-project", secret_id="app-secrets", secret_property="db_password"
+    # payload contains: {"api_key": "abc123", "db_password": "hunter2", "webhook": "xyz"}
+    # expected: returns "hunter2" (the exact property requested, not the others)
+    payload = json.dumps({
+        "api_key": "abc123",
+        "db_password": "hunter2",
+        "webhook": "xyz",
+    }).encode("UTF-8")
+
+    with patch("src.shared.gcp_secret_utils.secretmanager.SecretManagerServiceClient") as mock_cls:
+        mock_response = MagicMock()
+        mock_response.payload.data = payload
+        mock_cls.return_value.access_secret_version.return_value = mock_response
+
+        result = SecretUtils.get_secret("prod-project", "app-secrets", "db_password")
+
+        assert result == "hunter2"
+
+
+@pytest.mark.fast
+def test_default_version_id_is_latest():
+    # passed: project_id="prod-project", secret_id="my-secret", secret_property="key" (no version_id)
+    # expected: GCP is called with name ending in "/versions/latest"
+    payload = json.dumps({"key": "value"}).encode("UTF-8")
+
+    with patch("src.shared.gcp_secret_utils.secretmanager.SecretManagerServiceClient") as mock_cls:
+        mock_response = MagicMock()
+        mock_response.payload.data = payload
+        mock_cls.return_value.access_secret_version.return_value = mock_response
+
+        SecretUtils.get_secret("prod-project", "my-secret", "key")
+
+        expected_name = "projects/prod-project/secrets/my-secret/versions/latest"
+        mock_cls.return_value.access_secret_version.assert_called_once_with(
+            request={"name": expected_name}
+        )
+
+
+@pytest.mark.fast
+def test_custom_version_id_is_passed_to_gcp():
+    # passed: project_id="prod-project", secret_id="my-secret", secret_property="key", version_id="42"
+    # expected: GCP is called with name ending in "/versions/42"
+    payload = json.dumps({"key": "value"}).encode("UTF-8")
+
+    with patch("src.shared.gcp_secret_utils.secretmanager.SecretManagerServiceClient") as mock_cls:
+        mock_response = MagicMock()
+        mock_response.payload.data = payload
+        mock_cls.return_value.access_secret_version.return_value = mock_response
+
+        SecretUtils.get_secret("prod-project", "my-secret", "key", version_id="42")
+
+        expected_name = "projects/prod-project/secrets/my-secret/versions/42"
+        mock_cls.return_value.access_secret_version.assert_called_once_with(
+            request={"name": expected_name}
+        )


### PR DESCRIPTION
## Summary
  This PR fixes a layering violation in `gcp_secret_utils.py` where 5 `sys.exit(1)` calls coupled the secret resolver to the process lifecycle. Error paths were untestable without spawning a subprocess, and callers had no way to recover gracefully when GCP wasn't reachable (e.g. dev mode).

  ## What changed
  - Introduced `SecretResolutionError(Exception)` in `gcp_secret_utils.py`
  - Replaced all 5 `sys.exit(1)` calls with `raise SecretResolutionError(...)`
  - `_Config.get_key_value` in `config.py` is now the single exit boundary — catches the exception, logs, and exits cleanly
  - Removed `import sys` from `gcp_secret_utils.py` (no longer needed)
  - Added 15 unit tests in `tests/unit/test_gcp_secret_utils.py` covering all failure paths

  ## Test plan
  - [x] Run `pytest tests/unit/test_gcp_secret_utils.py -v` — all 15 pass
  - [x] Run full unit suite `pytest tests/unit/ -v` — no regressions

  | Scenario | Input | Expected |
  |---|---|---|
  | GCP secret not found | `secret_id="db-password"`, GCP returns `NotFound` | `SecretResolutionError: "Secret 'db-password' not found in project
  'prod-project'."` |
  | Property missing from payload | `secret_property="missing_key"`, payload has `{"api_key": "abc"}` | `SecretResolutionError` wrapping `KeyError` |
  | Malformed JSON payload | payload is `b"not-json"` | `SecretResolutionError` wrapping `JSONDecodeError` |
  | Generic API error | GCP raises `RuntimeError("network timeout")` | `SecretResolutionError: "Error accessing secret 'api-keys': network timeout."` |
  | Empty / None inputs | `secret_id=""` or `None`, `project_id=""` or `None` | `SecretResolutionError` before any GCP call is made |