### PR TITLE
fix: refactoring the files plus improving complexity

### DIFF
--- a/server/src/config.py
+++ b/server/src/config.py
@@ -36,7 +36,11 @@ class _Config:
         if not gcp_project_id:
             print("GCP_PROJECT_ID not set. Secret Manager lookups will fail.")
 
-        # Validate and load required keys -- fail if any missing
+        self._load_required_keys(required_keys, gcp_project_id)
+        self._load_full_app_keys(full_app_keys, gcp_project_id)
+
+    def _load_required_keys(self, required_keys: set, gcp_project_id: str) -> None:
+        """Validate and set all required config keys. Exits on missing or null values."""
         for key in required_keys:
             if key not in self._raw_config:
                 print(f"Required configuration key '{key}' missing from config file.")
@@ -46,8 +50,8 @@ class _Config:
                 key_value = None
             setattr(self, key, key_value)
 
-        # Load full_app_keys only if present in config file.
-        # If present, validate they have non-empty values (preflight check).
+    def _load_full_app_keys(self, full_app_keys: set, gcp_project_id: str) -> None:
+        """Load full_app_keys only if present. Exits if present but empty (preflight check)."""
         for key in full_app_keys:
             if key in self._raw_config:
                 value = self._raw_config[key]

--- a/server/src/services/candidate_generator.py
+++ b/server/src/services/candidate_generator.py
@@ -163,6 +163,42 @@ def _fetch_catalog() -> list[Any]:
     return list(client.signals.list_iter(limit_per_page=100))
 
 
+def _build_entry(
+    rng: random.Random,
+    trigger_pool: list[Any],
+    filter_pool: list[Any],
+    timeframe: str,
+) -> tuple[list[dict[str, Any]], Any]:
+    """Pick one trigger + 0-2 filters for the entry side. Returns (rules, trigger)."""
+    entry_trigger = rng.choice(trigger_pool)
+    n_filters = rng.randint(0, min(2, len(filter_pool)))
+    filter_picks = rng.sample(filter_pool, n_filters) if n_filters else []
+    rules = [_signal_rule(entry_trigger, timeframe)]
+    rules += [_signal_rule(s, timeframe) for s in filter_picks]
+    return rules, entry_trigger
+
+
+def _build_exit(
+    rng: random.Random,
+    trigger_pool: list[Any],
+    filter_pool: list[Any],
+    timeframe: str,
+    entry_trigger: Any,
+) -> list[dict[str, Any]]:
+    """Pick 0-1 trigger + 0-2 filters for the exit side, avoiding entry trigger duplication."""
+    exit_rules: list[dict[str, Any]] = []
+    if rng.random() < 0.5 and trigger_pool:
+        exit_trigger = rng.choice(trigger_pool)
+        # Avoid picking the exact same signal we used for entry.
+        if exit_trigger.name == entry_trigger.name and len(trigger_pool) > 1:
+            alt_triggers = [s for s in trigger_pool if s.name != entry_trigger.name]
+            exit_trigger = rng.choice(alt_triggers)
+        exit_rules.append(_signal_rule(exit_trigger, timeframe))
+    n_filters = rng.randint(0, min(2, len(filter_pool)))
+    exit_rules += [_signal_rule(s, timeframe) for s in rng.sample(filter_pool, n_filters)] if n_filters else []
+    return exit_rules
+
+
 def generate(
     goal: str,
     asset: str,
@@ -199,24 +235,8 @@ def generate(
 
     candidates: list[StrategyCandidate] = []
     for i in range(n):
-        entry_trigger = rng.choice(trigger_pool)
-        n_entry_filters = rng.randint(0, min(2, len(filter_pool)))
-        entry_filter_picks = rng.sample(filter_pool, n_entry_filters) if n_entry_filters else []
-
-        entry = [_signal_rule(entry_trigger, timeframe)]
-        entry += [_signal_rule(s, timeframe) for s in entry_filter_picks]
-
-        # Exit is shorter — 50% chance of an exit trigger, 0-2 filters.
-        exit_rules: list[dict[str, Any]] = []
-        if rng.random() < 0.5 and trigger_pool:
-            exit_trigger = rng.choice(trigger_pool)
-            # Avoid picking the exact same signal we used for entry.
-            if exit_trigger.name == entry_trigger.name and len(trigger_pool) > 1:
-                candidates_t = [s for s in trigger_pool if s.name != entry_trigger.name]
-                exit_trigger = rng.choice(candidates_t)
-            exit_rules.append(_signal_rule(exit_trigger, timeframe))
-        n_exit_filters = rng.randint(0, min(2, len(filter_pool)))
-        exit_rules += [_signal_rule(s, timeframe) for s in rng.sample(filter_pool, n_exit_filters)] if n_exit_filters else []
+        entry, entry_trigger = _build_entry(rng, trigger_pool, filter_pool, timeframe)
+        exit_rules = _build_exit(rng, trigger_pool, filter_pool, timeframe, entry_trigger)
 
         candidates.append(StrategyCandidate(
             name=f"auto-{goal[:20].replace(' ', '-')}-{i+1}",

--- a/server/src/services/order_executor.py
+++ b/server/src/services/order_executor.py
@@ -128,6 +128,83 @@ def _poll_tx(tx_hash: str, chain_id: int, venue_id: str | None = None) -> dict[s
     }
 
 
+def _validate_slippage(slippage_pct: float | None) -> None:
+    """Raise SigningError if slippage_pct is missing or out of range."""
+    if slippage_pct is None:
+        raise SigningError(
+            "slippage_pct is required for live swaps.",
+            suggestion=(
+                "Direct swap callers pass slippage_pct in the request body "
+                "(decimal, e.g. 0.002 = 0.2%). Cron-driven swaps pull it "
+                "from the active allocation — re-promote the strategy to "
+                "live with an allocation block that includes slippage_pct."
+            ),
+        )
+    if slippage_pct <= 0 or slippage_pct > 0.0025:
+        raise SigningError(
+            f"slippage_pct {slippage_pct} outside allowed range (0, 0.0025].",
+            suggestion=(
+                "Max allowed slippage is 0.25% (0.0025 decimal). Tighter "
+                "values trade off fewer fills for better prices; looser "
+                "values are refused to prevent rekt-on-illiquid-pair "
+                "execution."
+            ),
+        )
+
+
+def _resolve_tokens(intent: OrderIntent) -> tuple[str, str, float]:
+    """Determine input/output token addresses and amount from an OrderIntent.
+
+    Prefers explicit token addresses (user-initiated swaps via /dex/swap);
+    falls back to USDC+symbol convention for cron strategy intents.
+    """
+    if intent.input_token_address and intent.output_token_address:
+        return intent.input_token_address, intent.output_token_address, intent.amount
+    if intent.side == "buy":
+        return "USDC", intent.symbol, intent.amount
+    return intent.symbol, "USDC", intent.amount
+
+
+def _handle_approval(
+    client: Any,
+    input_token: str,
+    chain_id: int,
+    wallet_address: str,
+    venue_id: str | None,
+) -> str | None:
+    """Steps 2-3: approve token + sign/broadcast + poll. Returns approval tx_hash or None."""
+    try:
+        approval_tx = client.dex.approve_token(
+            token_address=input_token,
+            chain_id=chain_id,
+            wallet_address=wallet_address,
+        )
+    except Exception as e:  # noqa: BLE001
+        raise SdkError(f"dex.approve_token failed: {e}") from e
+
+    if approval_tx is None:
+        return None
+
+    signed_approval = wallet_sign(
+        getattr(approval_tx, "payload", {}), wallet_address, chain_id=chain_id,
+    )
+    _log.info("order.live.signed", kind="approval", wallet=wallet_address)
+    try:
+        broadcast_result = client.dex.broadcast(signed_tx=signed_approval, chain_id=chain_id, venue_id=venue_id)
+    except Exception as e:  # noqa: BLE001
+        raise SdkError(f"dex.broadcast(approval) failed: {e}") from e
+
+    approval_tx_hash = getattr(broadcast_result, "tx_hash", None)
+    _log.info("order.live.broadcast", kind="approval", tx_hash=approval_tx_hash)
+    if approval_tx_hash:
+        poll_result = _poll_tx(approval_tx_hash, chain_id, venue_id)
+        if poll_result["status"] not in ("confirmed", "success"):
+            raise SdkError(
+                f"Approval tx did not confirm: {poll_result['status']} ({poll_result.get('error')})",
+            )
+    return approval_tx_hash
+
+
 def _live_swap(
     intent: OrderIntent,
     strategy_id: str,
@@ -157,41 +234,10 @@ def _live_swap(
             suggestion="Pass chain_id in the OrderIntent metadata or strategy config.",
         )
 
-    if slippage_pct is None:
-        raise SigningError(
-            "slippage_pct is required for live swaps.",
-            suggestion=(
-                "Direct swap callers pass slippage_pct in the request body "
-                "(decimal, e.g. 0.002 = 0.2%). Cron-driven swaps pull it "
-                "from the active allocation — re-promote the strategy to "
-                "live with an allocation block that includes slippage_pct."
-            ),
-        )
-    if slippage_pct <= 0 or slippage_pct > 0.0025:
-        raise SigningError(
-            f"slippage_pct {slippage_pct} outside allowed range (0, 0.0025].",
-            suggestion=(
-                "Max allowed slippage is 0.25% (0.0025 decimal). Tighter "
-                "values trade off fewer fills for better prices; looser "
-                "values are refused to prevent rekt-on-illiquid-pair "
-                "execution."
-            ),
-        )
+    _validate_slippage(slippage_pct)
 
     client = mangrove_markets_client()
-    # Prefer explicit addresses (user-initiated swaps via /dex/swap); fall
-    # back to USDC+symbol convention when the intent came from the cron
-    # strategy path.
-    if intent.input_token_address and intent.output_token_address:
-        input_token = intent.input_token_address
-        output_token = intent.output_token_address
-        input_amount = intent.amount
-    elif intent.side == "buy":
-        input_token, output_token = "USDC", intent.symbol
-        input_amount = intent.amount  # treat as USDC notional for now
-    else:
-        input_token, output_token = intent.symbol, "USDC"
-        input_amount = intent.amount
+    input_token, output_token, input_amount = _resolve_tokens(intent)
 
     # 1. Quote
     try:
@@ -215,35 +261,8 @@ def _live_swap(
         "price_impact_percent": getattr(quote, "price_impact_percent", 0.0),
     }
 
-    # 2. Conditional token approval
-    approval_tx_hash: str | None = None
-    try:
-        approval_tx = client.dex.approve_token(
-            token_address=input_token,
-            chain_id=chain_id,
-            wallet_address=wallet_address,
-        )
-    except Exception as e:  # noqa: BLE001
-        raise SdkError(f"dex.approve_token failed: {e}") from e
-
-    if approval_tx is not None:
-        # 3. Sign + broadcast the approval
-        signed_approval = wallet_sign(
-            getattr(approval_tx, "payload", {}), wallet_address, chain_id=chain_id,
-        )
-        _log.info("order.live.signed", kind="approval", wallet=wallet_address)
-        try:
-            broadcast_result = client.dex.broadcast(signed_tx=signed_approval, chain_id=chain_id, venue_id=venue_id)
-        except Exception as e:  # noqa: BLE001
-            raise SdkError(f"dex.broadcast(approval) failed: {e}") from e
-        approval_tx_hash = getattr(broadcast_result, "tx_hash", None)
-        _log.info("order.live.broadcast", kind="approval", tx_hash=approval_tx_hash)
-        if approval_tx_hash:
-            poll_result = _poll_tx(approval_tx_hash, chain_id, venue_id)
-            if poll_result["status"] not in ("confirmed", "success"):
-                raise SdkError(
-                    f"Approval tx did not confirm: {poll_result['status']} ({poll_result.get('error')})",
-                )
+    # 2-3. Conditional token approval
+    approval_tx_hash = _handle_approval(client, input_token, chain_id, wallet_address, venue_id)
 
     # 4. Prepare swap
     # Upstream `dex.prepare_swap` takes slippage as a PERCENTAGE
@@ -251,7 +270,7 @@ def _live_swap(
     # Our API convention is DECIMAL (0.005 = 0.5%) to match the rest of
     # the trading stack (trading_defaults.backtest_defaults.slippage_pct
     # = 0.004 = 0.4%). Convert at the boundary.
-    sdk_slippage = slippage_pct * 100.0
+    sdk_slippage = slippage_pct * 100.0  # type: ignore[operator]
     try:
         swap_tx = client.dex.prepare_swap(
             quote_id=quote.quote_id,

--- a/server/src/services/reference_strategies_service.py
+++ b/server/src/services/reference_strategies_service.py
@@ -91,23 +91,60 @@ def _load_all() -> list[ReferenceStrategy]:
     return parsed
 
 
+_CATEGORY_KEYWORDS: list[tuple[str, tuple[str, ...]]] = [
+    ("mean_reversion", ("mean revers", "bollinger", "oversold", "bounce", "buy the dip")),
+    ("breakout",       ("breakout", "donchian", "channel", "range expansion", "ichimoku")),
+    ("momentum",       ("momentum", "macd", "roc", "stochastic", "rsi cross")),
+    ("volatility",     ("volatility", "atr", "squeeze", "high vol", "vol expansion")),
+    ("trend_following", ("trend", "ema cross", "sma cross", "golden cross", "adx", "supertrend")),
+]
+
+
 def _detect_category(text: str) -> str | None:
     """Auto-detect intended strategy category from a user-supplied goal/style string.
 
     Mirrors ai_copilot's `_detect_strategy_type` in shape.
     """
     t = (text or "").lower()
-    if any(k in t for k in ("mean revers", "bollinger", "oversold", "bounce", "buy the dip")):
-        return "mean_reversion"
-    if any(k in t for k in ("breakout", "donchian", "channel", "range expansion", "ichimoku")):
-        return "breakout"
-    if any(k in t for k in ("momentum", "macd", "roc", "stochastic", "rsi cross")):
-        return "momentum"
-    if any(k in t for k in ("volatility", "atr", "squeeze", "high vol", "vol expansion")):
-        return "volatility"
-    if any(k in t for k in ("trend", "ema cross", "sma cross", "golden cross", "adx", "supertrend")):
-        return "trend_following"
+    for category, keywords in _CATEGORY_KEYWORDS:
+        if any(k in t for k in keywords):
+            return category
     return None
+
+
+def _score_reference(
+    r: ReferenceStrategy,
+    asset_u: str,
+    tf: str | None,
+    cat: str | None,
+) -> int:
+    """Score a reference strategy by how specifically it matches the filters.
+
+    Higher = better match. Used for ranking in search().
+    """
+    s = 0
+    if asset_u and r.asset.upper() == asset_u:
+        s += 8
+    if tf and timeframes.canonicalize_timeframe(r.timeframe) == tf:
+        s += 4
+    if cat and r.category.lower() == cat:
+        s += 2
+    return s
+
+
+def _pad_results(
+    ranked: list[ReferenceStrategy],
+    top: list[ReferenceStrategy],
+    limit: int,
+) -> list[ReferenceStrategy]:
+    """Fill `top` with lower-scored entries from `ranked` until `limit` is reached."""
+    seen = {r.id for r in top}
+    for r in ranked:
+        if r.id not in seen:
+            top.append(r)
+            if len(top) >= limit:
+                break
+    return top[:limit]
 
 
 def search(
@@ -137,31 +174,13 @@ def search(
 
     all_refs = _load_all()
 
-    # Score each ref by specificity. Higher = better match.
-    def score(r: ReferenceStrategy) -> int:
-        s = 0
-        if asset_u and r.asset.upper() == asset_u:
-            s += 8
-        if tf and timeframes.canonicalize_timeframe(r.timeframe) == tf:
-            s += 4
-        if cat and r.category.lower() == cat:
-            s += 2
-        return s
-
-    ranked = sorted(all_refs, key=lambda r: (-score(r), r.id))
+    ranked = sorted(all_refs, key=lambda r: (-_score_reference(r, asset_u, tf, cat), r.id))
     # Drop any with score 0 ONLY if we have better matches; otherwise fall
     # through to show something rather than nothing.
-    top = [r for r in ranked if score(r) > 0]
+    top = [r for r in ranked if _score_reference(r, asset_u, tf, cat) > 0]
     if len(top) >= limit:
         return top[:limit]
-    # Pad with the rest (preserves ordering).
-    seen = {r.id for r in top}
-    for r in ranked:
-        if r.id not in seen:
-            top.append(r)
-            if len(top) >= limit:
-                break
-    return top[:limit]
+    return _pad_results(ranked, top, limit)
 
 
 def get(reference_id: str) -> ReferenceStrategy | None:

--- a/server/src/services/strategy_service.py
+++ b/server/src/services/strategy_service.py
@@ -59,6 +59,87 @@ _TRANSITIONS: dict[str, set[str]] = {
 _VALID_STATUSES = {"draft", "inactive", "paper", "live", "archived"}
 
 
+def _validate_status_transition(current: str, target: str) -> None:
+    """Raise StrategyInvalidStatusTransition if the transition is not in _TRANSITIONS."""
+    if target not in _TRANSITIONS.get(current, set()):
+        raise StrategyInvalidStatusTransition(
+            f"Cannot transition from {current} to {target}.",
+            suggestion=f"Valid transitions from {current}: {sorted(_TRANSITIONS.get(current, set()))}",
+        )
+
+
+def _apply_scheduler_effects(strategy_id: str, row: dict, target: str, current: str) -> None:
+    """Register or cancel the cron job and release allocation based on target status."""
+    if target in {"paper", "live"}:
+        scheduler_service.register_job(
+            strategy_id, row["timeframe"],
+            "src.services.strategy_service:tick",
+        )
+    else:
+        scheduler_service.cancel_job(strategy_id)
+        if current == "live":
+            allocation_service.release_allocation(strategy_id)
+
+
+def _extract_order_intents(
+    sdk_resp: Any, *, strategy_id: str, tick_id: str
+) -> list[OrderIntent]:
+    """Pull OrderIntents out of an SDK evaluate response.
+
+    The shape varies by SDK / upstream version — be defensive. Current
+    canonical key is `new_orders`; older variants used `order_intents` or
+    `orders`. Missing this key is a silent data loss: every tick logs an
+    evaluation but zero orders, which looks like "strategy didn't fire"
+    when in fact it did.
+
+    A malformed intent dict is skipped, but never silently: we emit a
+    structured `strategy.tick.order_intent.skipped` warning (keys only,
+    no values — see PR #87) so a dropped trade is diagnosable instead of
+    looking identical to "strategy didn't fire". `strategy_id`/`tick_id`
+    make the warning correlatable.
+    """
+    raw_orders = (
+        getattr(sdk_resp, "new_orders", None)
+        or getattr(sdk_resp, "order_intents", None)
+        or getattr(sdk_resp, "orders", None)
+        or (sdk_resp.model_dump().get("new_orders") if hasattr(sdk_resp, "model_dump") else None)
+        or (sdk_resp.model_dump().get("order_intents") if hasattr(sdk_resp, "model_dump") else None)
+        or []
+    )
+    order_intents: list[OrderIntent] = []
+    for o in raw_orders:
+        if isinstance(o, OrderIntent):
+            order_intents.append(o)
+        elif isinstance(o, dict):
+            try:
+                order_intents.append(OrderIntent.model_validate(o))
+            except Exception as e:  # noqa: BLE001
+                _log.warning(
+                    "strategy.tick.order_intent.skipped",
+                    strategy_id=strategy_id,
+                    tick_id=tick_id,
+                    reason=str(e),
+                    payload_keys=sorted(o.keys()),
+                )
+                continue
+    return order_intents
+
+
+def _get_live_allocation(strategy_id: str) -> tuple[str | None, int | None, float | None]:
+    """Return (wallet_address, chain_id, slippage_pct) from the active allocation, or Nones."""
+    active_alloc = allocation_service.get_active_allocation(strategy_id)
+    if not active_alloc:
+        return None, None, None
+    wallet_address = active_alloc.wallet_address
+    slippage_pct = active_alloc.slippage_pct
+    wrow = get_connection().execute(
+        "SELECT chain_id FROM wallets WHERE address = ?",
+        (wallet_address,),
+    ).fetchone()
+    chain_id = wrow["chain_id"] if wrow else None
+    return wallet_address, chain_id, slippage_pct
+
+
 # -- Pydantic request/response models ---------------------------------------
 
 
@@ -382,11 +463,7 @@ def update_status(strategy_id: str, update: StrategyStatusUpdate) -> StrategyDet
         raise StrategyInvalidStatusTransition(f"Unknown status '{target}'.")
     if target == current:
         return _row_to_response(row)  # no-op
-    if target not in _TRANSITIONS.get(current, set()):
-        raise StrategyInvalidStatusTransition(
-            f"Cannot transition from {current} to {target}.",
-            suggestion=f"Valid transitions from {current}: {sorted(_TRANSITIONS.get(current, set()))}",
-        )
+    _validate_status_transition(current, target)
 
     # Gate transitions that move real money or stop live execution.
     needs_confirm = (
@@ -430,17 +507,7 @@ def update_status(strategy_id: str, update: StrategyStatusUpdate) -> StrategyDet
             allocation_service.release_allocation(strategy_id)
         raise SdkError(f"strategies.update_status failed: {e}") from e
 
-    # Side effects by target.
-    if target in {"paper", "live"}:
-        scheduler_service.register_job(
-            strategy_id, row["timeframe"],
-            "src.services.strategy_service:tick",
-        )
-    else:  # inactive, archived
-        scheduler_service.cancel_job(strategy_id)
-        if current == "live":
-            allocation_service.release_allocation(strategy_id)
-
+    _apply_scheduler_effects(strategy_id, row, target, current)
     _set_status(strategy_id, target)
     new_row = _get_row(strategy_id)
     _log.info("strategy.status_changed",
@@ -508,55 +575,18 @@ def tick(strategy_id: str) -> None:
                        exception=str(e), duration_ms=duration_ms)
             return
 
-        # Extract OrderIntents from SDK response. The shape varies by SDK
-        # / upstream version — be defensive. Current canonical key is
-        # `new_orders` (MangroveAI SDK `EvaluateResult.new_orders` +
-        # upstream `managers/services.py` response payload). Older
-        # variants used `order_intents` or `orders`; keep both as
-        # fallbacks for cross-version compatibility. Missing this key is
-        # a silent data loss: every tick logs an evaluation but zero
-        # orders, which looks like "strategy didn't fire" when in fact
-        # it did.
-        raw_orders = (
-            getattr(sdk_resp, "new_orders", None)
-            or getattr(sdk_resp, "order_intents", None)
-            or getattr(sdk_resp, "orders", None)
-            or (sdk_resp.model_dump().get("new_orders") if hasattr(sdk_resp, "model_dump") else None)
-            or (sdk_resp.model_dump().get("order_intents") if hasattr(sdk_resp, "model_dump") else None)
-            or []
+        # Extract OrderIntents from the SDK response (defensive about
+        # response shape; logs — never silently drops — malformed intents).
+        order_intents = _extract_order_intents(
+            sdk_resp, strategy_id=strategy_id, tick_id=tick_id
         )
-        order_intents: list[OrderIntent] = []
-        for o in raw_orders:
-            if isinstance(o, OrderIntent):
-                order_intents.append(o)
-            elif isinstance(o, dict):
-                try:
-                    order_intents.append(OrderIntent.model_validate(o))
-                except Exception as e:  # noqa: BLE001
-                    _log.warning(
-                        "strategy.tick.order_intent.skipped",
-                        strategy_id=strategy_id,
-                        tick_id=tick_id,
-                        reason=str(e),
-                        payload_keys=sorted(o.keys()),
-                    )
-                    continue
 
         # Find the wallet + chain_id for live execution (allocation provides it).
         wallet_address = None
         chain_id = None
         slippage_pct = None
         if mode == "live":
-            active_alloc = allocation_service.get_active_allocation(strategy_id)
-            if active_alloc:
-                wallet_address = active_alloc.wallet_address
-                slippage_pct = active_alloc.slippage_pct
-                # We don't track chain_id on allocation; pull from wallet row.
-                wrow = get_connection().execute(
-                    "SELECT chain_id FROM wallets WHERE address = ?",
-                    (wallet_address,),
-                ).fetchone()
-                chain_id = wrow["chain_id"] if wrow else None
+            wallet_address, chain_id, slippage_pct = _get_live_allocation(strategy_id)
 
         # Log the evaluation FIRST so trades can FK-reference it. The
         # evaluation describes the SDK call outcome, not the downstream

--- a/server/src/services/wallet_manager.py
+++ b/server/src/services/wallet_manager.py
@@ -682,6 +682,21 @@ _INT_FIELDS = {
 }
 
 
+def _apply_tx_type(out: dict) -> None:
+    """Mutate `out` to enforce consistent EIP-1559 vs legacy tx type fields."""
+    has_eip1559 = (
+        out.get("maxFeePerGas") is not None
+        and out.get("maxPriorityFeePerGas") is not None
+    )
+    if has_eip1559:
+        out.setdefault("type", 2)
+        out.pop("gasPrice", None)
+    elif "gasPrice" in out:
+        out.pop("maxFeePerGas", None)
+        out.pop("maxPriorityFeePerGas", None)
+        out.pop("type", None)
+
+
 def _normalize_payload(payload: dict, chain_id: int | None = None) -> dict:
     out: dict = {}
     for k, v in payload.items():
@@ -697,18 +712,7 @@ def _normalize_payload(payload: dict, chain_id: int | None = None) -> dict:
     if chain_id is not None and "chainId" not in out:
         out["chainId"] = chain_id
 
-    has_eip1559 = (
-        out.get("maxFeePerGas") is not None
-        and out.get("maxPriorityFeePerGas") is not None
-    )
-    if has_eip1559:
-        out.setdefault("type", 2)
-        out.pop("gasPrice", None)
-    elif "gasPrice" in out:
-        out.pop("maxFeePerGas", None)
-        out.pop("maxPriorityFeePerGas", None)
-        out.pop("type", None)
-
+    _apply_tx_type(out)
     return out
 
 


### PR DESCRIPTION
## Summary

  Pure structural refactoring — zero logic changes, zero behavior changes. Closes audit finding NF-5 which flagged 8 functions rated complexity C (CC
  11–20) across 6 files. Each was split into smaller, named helpers to make the code easier to read, test, and maintain safely.

  ## Files Changed

  - **`server/src/config.py`** — extracted `_load_required_keys()` and `_load_full_app_keys()` out of `load_configuration()`
  - **`server/src/services/reference_strategies_service.py`** — replaced 5 chained `if` statements in `_detect_category()` with a `_CATEGORY_KEYWORDS`
  lookup table; lifted nested `score()` to module-level `_score_reference()`; extracted `_pad_results()` from `search()`
  - **`server/src/services/candidate_generator.py`** — extracted `_build_entry()` and `_build_exit()` from the loop inside `generate()`. RNG call order
   preserved — deterministic seed behavior unchanged
  - **`server/src/services/order_executor.py`** — extracted `_validate_slippage()`, `_resolve_tokens()`, and `_handle_approval()` from `_live_swap()`
  - **`server/src/services/wallet_manager.py`** — extracted `_apply_tx_type()` from `_normalize_payload()`
  - **`server/src/services/strategy_service.py`** — extracted `_validate_status_transition()`, `_apply_scheduler_effects()`, 
  `_extract_order_intents()`, and `_get_live_allocation()` from `update_status()` and `tick()`. Original check order preserved exactly

  ## What Was NOT Changed

  - No logic, no reordering of checks, no renames of existing public functions
  - No new features or endpoints

  ## Complexity Improvement

  | Function | File | Before | After |
  |---|---|---|---|
  | `load_configuration` | config.py | C | **A** |
  | `_detect_category` | reference_strategies_service | C | **A** |
  | `generate` | candidate_generator | C | **A**  |
  | `_live_swap` | order_executor | C | **B**  |
  | `tick` | strategy_service | C | **B**  |
  | `search` | reference_strategies_service | C (14) | **B** |
  | `update_status` | strategy_service | C | C (11) |
  | `_normalize_payload` | wallet_manager | C | C (11) |


  ## Test Plan

  - [x] `cd server && python -m pytest tests/ --ignore=tests/e2e -v` → 332 passed, 0 failed
  - [x] `curl http://localhost:9080/health` → `{"status":"ok"}`
  - [x] `curl -H "X-API-Key: dev-key-1" "http://localhost:9080/api/v1/agent/reference-strategies/search?asset=ETH&goal_hint=macd+crossover"` → momentum
   strategies ranked first, count 5
  - [x] `curl -H "X-API-Key: dev-key-1" "http://localhost:9080/api/v1/agent/reference-strategies/search?asset=DOGE"` → fallback 5 cross-asset results 
  via `_pad_results`, no empty list
  - [x] `curl -H "X-API-Key: wrong-key" "http://localhost:9080/api/v1/agent/reference-strategies/search?asset=ETH"` → `401 AUTH_INVALID_API_KEY`