### PR TITLE
feat(skills): /sieve + /sweep + getting-started; fix validate_experiment SDK contract

### DIFF
--- a/.claude/rules/trading-bot-workflow.md
+++ b/.claude/rules/trading-bot-workflow.md
@@ -5,7 +5,7 @@ The agent is a Mangrove-powered trading bot. Product is **strategy-driven automa
 ## Core loop
 
 1. **Author** a strategy (autonomous goal -> candidates, or manual rules).
-2. **Backtest** candidates in bulk, rank by performance.
+2. **Search** when there are many candidates: `/sieve` scores up to 99 cheaply and prunes, `/sweep` fans the survivors into a ranked experiment. **Backtest** the winner(s) to verdict.
 3. **Promote** winner: `draft -> paper -> live` with allocation block.
 4. **Schedule**: going live registers a cron that calls `evaluate_strategy` on the strategy timeframe.
 5. **Execute**: scheduled evaluations route through 1inch via `mangrovemarkets` SDK. Automatic; user does not click "swap."
@@ -17,8 +17,10 @@ MCP tools are deferred. On any session, eagerly load the full core toolset on fi
 
 Required core set:
 ```
-mcp__mangrove-agent__status, list_tools, list_signals, list_wallets, create_wallet, import_wallet, get_balances, list_dex_venues, get_swap_quote, execute_swap, get_ohlcv, get_market_data, kb_search, list_strategies, get_strategy, create_strategy_autonomous, create_strategy_manual, evaluate_strategy, backtest_strategy, update_strategy_status, list_trades, list_all_trades, list_evaluations, get_smart_money_historical_holdings, get_smart_money_dex_trades, get_smart_money_perp_trades, get_token_dex_trades, get_token_flows, oracle_list_datasets, oracle_list_signals, oracle_create_experiment, oracle_validate_experiment, oracle_launch_experiment, oracle_list_results
+mcp__mangrove-agent__status, list_tools, list_signals, list_wallets, create_wallet, import_wallet, get_balances, list_dex_venues, get_swap_quote, execute_swap, get_ohlcv, get_market_data, kb_search, list_strategies, get_strategy, create_strategy_autonomous, create_strategy_manual, evaluate_strategy, backtest_strategy, update_strategy_status, list_trades, list_all_trades, list_evaluations, get_smart_money_historical_holdings, get_smart_money_dex_trades, get_smart_money_perp_trades, get_token_dex_trades, get_token_flows, sieve_score, oracle_list_datasets, oracle_list_signals, oracle_create_experiment, oracle_validate_experiment, oracle_launch_experiment, oracle_get_experiment, oracle_list_results
 ```
+
+`sieve_score` and the `oracle_*` experiment tools are first-class, not optional. They power the **scaled search** path (Stage 2.5): score many candidates cheaply with SIEVE, sweep the survivors, rank, promote. Lazy-loading without them makes the agent forget it can search a parameter space at all and fall back to one-strategy-at-a-time.
 
 ## Operating principles
 
@@ -46,13 +48,14 @@ Greet as the persona in `CLAUDE.md`'s Project Context, or default to a concise, 
 3. `get_market_data` on a liquid asset (ETH on Base default) -- "Live price/volume/24h, pulled now from Mangrove markets API. Every backtest/evaluation prices off this."
 4. `kb_search` on a real concept (e.g. `"MACD crossover"`, `"Bollinger squeeze"`) -- "Knowledge base. Every recommendation cites entries here -- no vibes."
 5. `search_reference_strategies` with just an asset -- "Reference library. We start from already-backtested templates, not blank slate."
+6. `sieve_score` on one sample strategy (e.g. BTC 1h MACD cross + SMA filter) -- "This is **SIEVE**: a model trained on 1.24M historical runs that scores a strategy in milliseconds. 5 of 6 strategies fail a backtest -- SIEVE tells you which 1 to bother testing. Score 99 ideas for the cost of one. Pair it with a **sweep** (`/sweep`) and we search a whole parameter space, ranked, in one experiment." Show the real `four_class` probabilities + `model_version` from the response.
 
 If any beat fails (bad key, unreachable URL, empty KB), surface the error and stop -- don't proceed on a broken setup.
 
 ### 0.3 Set the hook
 > "You can author, backtest, and paper-trade strategies without a wallet. Paper mode simulates fills at current market price -- nothing on-chain, no funds at risk. You only need a wallet when ready to go live, and we'll connect one then."
 >
-> "Want me to build you a strategy? Tell me asset and vibe -- trend, mean reversion, breakout, momentum -- or say 'pick for me.'"
+> "Two ways in: tell me an asset + vibe (trend, mean reversion, breakout, momentum) and I'll **build you one strategy**, or say 'find me the best X' and I'll **search a whole space** -- score dozens of variations through SIEVE, sweep the survivors, and hand you the ranked winner. Or just say 'pick for me.'"
 
 ### 0.4 Transitions
 - Strategy idea -> Stage 1/2.
@@ -75,6 +78,18 @@ Use the `/create-strategy` skill. It covers Phase A (search references first), P
 Two invariants:
 1. Reference strategies are portable. Asset/timeframe on a reference are provenance, not constraints. `build_strategy_from_reference` accepts overrides -- retarget freely; let backtest decide.
 2. Bulk-backtest beats label-pick. Multiple references match -> build + backtest all before presenting. Don't ask user to pick by name; that's a KB-grounding regression.
+
+## Stage 2.5 -- Scale the search (SIEVE + sweep)
+
+**Trigger:** the user's goal implies *many* configs, not one -- "find me the best ETH momentum strategy", "try a bunch of RSI windows", "what's the optimal MACD config", or `/create-strategy` autonomous mode just emitted a candidate set. This is the high-value path; reach for it instead of backtesting variations one at a time.
+
+The cheap-before-expensive loop:
+
+1. **`/sieve`** -- score up to 99 candidates in one millisecond-cheap call. Drop the dead-on-arrival ones (`p_no_trades > 0.5`), rank the rest by `P(winning)`. A backtest is 30-120s and 5 of 6 strategies fail it; SIEVE tells you which to bother with. (Beginner tier ~10 SIEVE calls/month; one call scores 99 for the price of 1 -- batch them.)
+2. **`/sweep`** -- take the survivors (or a parameter grid) and run a managed Oracle experiment: `create -> validate -> launch -> poll -> ranked results`, up to 99 backtests fanned out and ranked in one experiment. (Beginner tier ~2 sweep launches/month.)
+3. **Confirm the winner** -- register the top result (`create_strategy_manual`) and send it through Stage 3 (`/backtest`) for a full single-strategy verdict before any promotion.
+
+Both skills cite the same Mangrove intelligence (`oracle_list_signals`, the KB) and surface real provenance (`model_version`, `code_version`). Never present a SIEVE score as a backtest result -- it's a filter, not a verdict. Full SDK + API detail lives in the KB guides (`sieve-end-to-end-workflow`, `using-sieve-prefilter`, `experiments`) and tutorial chapter 09.
 
 ## Stage 3 -- Review backtest
 

--- a/.claude/skills/sieve/SKILL.md
+++ b/.claude/skills/sieve/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: sieve
+description: >-
+  Use when the user has MANY candidate strategies (or wants to try many
+  parameter variations) and needs to know which are worth the cost of a
+  backtest — "score these", "which of these should I test", "pre-filter
+  my candidates", "rank these MACD variations". Also the natural next
+  step after /create-strategy or /custom-signal produces a candidate
+  set. Scores up to 99 candidates in ONE millisecond-cheap call through
+  the Mangrove SIEVE classifier, drops the dead-on-arrival ones, and
+  ranks the survivors by P(winning) before any expensive backtest.
+  Wraps `sieve_score` + `oracle_list_signals`, hands off to /backtest
+  (one winner) or /sweep (managed many).
+---
+
+# SIEVE Skill
+
+This skill exists because **a backtest is expensive and most strategies
+fail it.** A single Oracle backtest takes 30–120s on a multi-month
+window, and roughly **5 of every 6 candidate strategies fail** — they
+never fire a trade, or they wash, or they lose. Paying for 99 backtests
+to find the 1 good one is wasteful.
+
+**SIEVE** ("Strategy Indicator Embeddings with Value Estimation") is a
+classifier trained on 1.24M historical Mangrove sweep runs. It scores a
+candidate in milliseconds and returns two things:
+
+- **binary** — `{p_no_trades, p_trades}`. The go/no-go gate: if SIEVE
+  thinks the strategy will never fire on real data, you skip the
+  backtest entirely.
+- **four_class** — `{losing, no_trades, wash, winning}`. A softmax over
+  outcomes. Rank survivors by `P(winning)` and only spend backtest
+  compute on the top slice.
+
+A 99-candidate search compresses to ~5 backtests. Same signal quality at
+~10% of the cost. **SIEVE is a fast filter, not a backtest** — it never
+replaces the real thing (see Prohibited).
+
+## Trigger
+
+Activate when the user:
+
+- Has many candidate strategies and asks which to test ("score these",
+  "which of these is worth backtesting", "rank these")
+- Wants to explore parameter variations cheaply ("try 50 variations of
+  my MACD strategy and tell me the good ones")
+- Just produced a candidate set via `/create-strategy` (autonomous mode
+  emits N candidates) or `/custom-signal` and needs to prune before
+  backtesting
+- Asks to "pre-filter", "screen", or "narrow down" strategies
+
+Do NOT activate for:
+
+- A single known strategy the user wants to evaluate → `/backtest`
+- A managed, ranked sweep over a parameter grid with persisted results
+  → `/sweep` (SIEVE feeds it; this skill is the cheap pre-screen)
+- Authoring new strategies from scratch → `/create-strategy`
+
+## Phase A — Assemble candidates (≤ 99)
+
+A candidate is a MangroveAI-shaped Strategy object:
+
+```json
+{
+  "asset": "BTC",
+  "entry": [
+    {"name": "macd_bullish_cross", "signal_type": "TRIGGER", "timeframe": "1h",
+     "params": {"window_fast": 12, "window_slow": 26, "window_sign": 9}},
+    {"name": "is_above_sma", "signal_type": "FILTER", "timeframe": "1h",
+     "params": {"window": 50}}
+  ],
+  "exit": [
+    {"name": "macd_bearish_cross", "signal_type": "TRIGGER", "timeframe": "1h",
+     "params": {"window_fast": 12, "window_slow": 26, "window_sign": 9}}
+  ],
+  "execution_config": {"reward_factor": 2.0, "max_risk_per_trade": 0.01}
+}
+```
+
+Where the candidates come from:
+
+- **From `/create-strategy` or `/custom-signal`** — the candidate set is
+  already built; carry it straight in.
+- **From a parameter sweep the user describes** — generate the
+  variations yourself. "Sweep entry-window 8→20, exit-window 20→40"
+  means build the cross-product of those param values into N candidate
+  objects.
+
+**Get the signal names + param specs right.** Call `oracle_list_signals`
+once and use it to validate every `name`, `signal_type` (`TRIGGER` /
+`FILTER`), and `params` key against the real catalog (223 signals across
+momentum / trend / volume / volatility / patterns). A typo in a signal
+name or param key produces a useless score, not an error.
+
+**The 99 cap is hard.** `sieve_score` accepts 1–99 items per call. If the
+user's grid is larger, chunk it into batches of 99 and score each batch
+— don't silently truncate. Tell the user how many batches it took.
+
+## Phase B — Score
+
+One `sieve_score(strategies=[...])` call per batch. It returns one
+prediction per candidate (input order preserved), plus `model_version`
+and `code_version`.
+
+Read a prediction in plain language for the user the first time:
+
+> `p_trades = 0.92` → SIEVE expects this one to fire on real data.
+> `P(winning) = 0.50` → its best guess at a profitable outcome — not
+> great, not terrible, worth a backtest. If `p_no_trades` were `> 0.5`,
+> we'd drop it here and not pay to backtest it.
+
+**Tier + cost note:** each `sieve_score` call is ONE billable unit
+regardless of batch size (Beginner ≈ 10 calls/month). Pack batches as
+close to 99 as you can — scoring 99 costs the same as scoring 1.
+
+## Phase C — Filter + rank
+
+1. **Binary filter.** Drop every candidate with `binary.p_no_trades > 0.5`.
+   These won't fire entries; a backtest would just confirm zero trades.
+2. **Rank survivors** by `four_class.winning` descending.
+3. **Keep the top slice** — top 5–10, or the top ~10% for large sets.
+   That's the shortlist worth real backtest compute.
+
+Report it as: "Scored N. M survive the binary filter. Top K by
+P(winning): …" with the K shortlist and their `P(winning)` /
+`P(no_trades)`.
+
+**Soft-failure mode to watch:** `p_no_trades` close to `1.0` across the
+whole batch usually means the TRIGGER thresholds are unreachable (e.g.
+RSI < 5). The fix is to **widen the parameter ranges and re-score**, not
+to delete the strategy. Say so rather than reporting "everything died."
+
+## Phase D — Handoff
+
+The shortlist is now ready for real evaluation. Route it:
+
+- **One clear winner, or the user wants a careful single verdict** →
+  `/backtest` on that candidate (register it first with
+  `create_strategy_manual` if it isn't a strategy yet).
+- **Several survivors worth comparing head-to-head with ranked,
+  persisted results** → `/sweep` — feed the shortlist as the experiment's
+  signal mix.
+
+Always carry the provenance forward: log `model_version` +
+`code_version` next to the shortlist, so when SIEVE is retrained you can
+tell which snapshot produced the ranking.
+
+## Prohibited
+
+- **Never** promote a strategy to paper or live on a SIEVE score alone.
+  SIEVE is an aggregate prediction over millions of runs; your exact
+  parameter combo may sit in a corner where the model is overconfident.
+  A real `backtest_strategy` / Oracle backtest ALWAYS gates paper/live.
+- **Never** send more than 99 items in one `sieve_score` call — chunk,
+  don't truncate.
+- **Never** invent probabilities or "round up" a borderline score.
+  Report what the model returned.
+- **Never** treat a high `P(winning)` as a backtest result in a verdict.
+  It's a filter signal, full stop.
+- **Never** delete a whole batch because `p_no_trades ≈ 1.0` — that's a
+  "widen the params and re-score" signal, not a dead end.
+
+## Summary — Decision Tree
+
+```
+User has many candidates / wants to try many variations
+│
+├─ Phase A: assemble ≤99 candidate Strategy objects
+│     → validate names + params against oracle_list_signals
+│     → chunk into batches of 99 if larger
+│
+├─ Phase B: sieve_score(each batch)
+│     → record model_version + code_version
+│     → explain binary vs 4-class once, in plain language
+│
+├─ Phase C: filter + rank
+│     → drop p_no_trades > 0.5
+│     → rank survivors by P(winning), keep top 5–10 / top ~10%
+│     → p_no_trades ≈ 1.0 everywhere → widen params, re-score
+│
+└─ Phase D: handoff (NEVER promote from here)
+      → one winner / careful verdict → /backtest
+      → several to compare, ranked + persisted → /sweep
+```

--- a/.claude/skills/sweep/SKILL.md
+++ b/.claude/skills/sweep/SKILL.md
@@ -1,0 +1,272 @@
+---
+name: sweep
+description: >-
+  Use when the user wants to search a parameter SPACE at scale rather
+  than test one config — "sweep the RSI window from 7 to 21", "try every
+  MACD variation on BTC 1h and rank them", "what's the best config for
+  X", "run an experiment". Drives the managed Oracle experiment
+  lifecycle (create → validate → launch → poll → results), fanning a
+  strategy template out into up to 99 ranked backtests in one
+  experiment. Pair it with /sieve to prune the grid cheaply first. Wraps
+  `oracle_list_datasets` + `oracle_list_signals` + `oracle_create_experiment`
+  + `oracle_validate_experiment` + `oracle_launch_experiment` +
+  `oracle_get_experiment` + `oracle_list_results`; hands the winner to
+  /backtest for a confirming verdict before paper/live.
+---
+
+# Sweep Skill
+
+This skill exists because **finding a good strategy is a search problem,
+not a single guess.** `/backtest` answers "is THIS config good?" A sweep
+answers "of these 99 configs, which is best?" — it takes a strategy
+template plus a parameter grid (or random search) over signal params,
+fans it out into up to 99 individual backtests against one or more
+datasets, and ranks the results. You author once and let the engine do
+the search.
+
+The lifecycle is intentionally explicit — **validate before launch,
+separate from create** — so you (and Oracle) can confirm the config and
+its run-count before paying for the fan-out:
+
+```
+create ──▶ [update]* ──▶ validate ──▶ launch ──▶ (running) ──▶ completed
+  draft        draft      validated    launched      │
+                                                      ├─▶ pause ─▶ relaunch
+                                                      └─▶ delete (cancels children)
+```
+
+**Always prune with `/sieve` first** when the grid is large: SIEVE
+scores 99 candidates in one cheap call, so you spend sweep compute only
+on the configs it doesn't already predict will die.
+
+## Trigger
+
+Activate when the user:
+
+- Wants to search a parameter range ("sweep RSI window 7→21",
+  "try entry-window 8 to 20 and exit-window 20 to 40")
+- Wants the best of many variations, ranked ("try every MACD config on
+  BTC 1h and tell me the best", "compare these across timeframes")
+- Has a shortlist from `/sieve` worth a managed, persisted, ranked run
+- Says "run an experiment" / "do a sweep" / "hyperparameter search"
+
+Do NOT activate for:
+
+- A single known config the user wants evaluated → `/backtest`
+- Cheaply scoring/screening candidates without persisting → `/sieve`
+  (use it first, then come here with the survivors)
+- Authoring a single strategy from a loose goal → `/create-strategy`
+
+## Phase A — Orient with the catalog
+
+Three free (non-billable) metadata calls. Always start here — building a
+config from memory produces names the validator rejects.
+
+1. `oracle_list_datasets` — the curated OHLCV snapshots the engine runs
+   against. Each carries `asset`, `timeframe`, `file`, `rows`,
+   `start_date`, `end_date`. **You reference datasets by their `file`
+   value** in the config. Pick the dataset(s) matching the user's asset +
+   timeframe; show the date range so they know what window they're
+   sweeping.
+2. `oracle_list_signals` — the 223 signals with typed param specs.
+   Each: `name`, `type` (`TRIGGER` / `FILTER`), `params` (tunable spec +
+   ranges), `requires`, `category`. This is the source of truth for valid
+   signal names and which params are sweepable.
+3. `oracle_list_templates` (optional) — predefined strategy templates you
+   can seed the experiment from instead of building entry/exit by hand.
+
+## Phase B — Build the experiment config
+
+Build the config dict in the real Oracle `ExperimentConfig` shape (this
+is the executable SDK shape, not the older curl-doc shape):
+
+```json
+{
+  "name": "BTC 1h MACD momentum sweep",
+  "description": "Grid over MACD windows; one entry trigger, one exit trigger.",
+  "search_mode": "grid",
+  "kind": "single",
+  "datasets": [ <whole dataset OBJECT from oracle_list_datasets, not the filename> ],
+  "entry_signals": {
+    "triggers": [
+      {"name": "macd_bullish_cross", "signal_type": "TRIGGER",
+       "params": {"window_fast": 12, "window_slow": 26}}
+    ],
+    "filters": [
+      {"name": "is_above_sma", "signal_type": "FILTER", "params": {"window": 50}}
+    ],
+    "min_filters": 1,
+    "max_filters": 1
+  },
+  "exit_signals": {
+    "triggers": [
+      {"name": "macd_bearish_cross", "signal_type": "TRIGGER",
+       "params": {"window_fast": 12, "window_slow": 26}}
+    ],
+    "filters": []
+  },
+  "execution_config": {"base": {}, "sweep_axes": []}
+}
+```
+
+> **These four details are server-enforced — verified live against Oracle
+> v0.15.3. Get them wrong and `create`/`validate` reject the config:**
+>
+> 1. **`datasets` holds the whole dataset OBJECTS** returned by
+>    `oracle_list_datasets` (the dicts with `asset`/`timeframe`/`file`/
+>    `hash`/…), NOT bare filename strings. (A bare string → HTTP 422.)
+> 2. **Every signal needs `signal_type`** (`"TRIGGER"` or `"FILTER"`) —
+>    the value of the catalog's `type` field. Omitting it → HTTP 422.
+> 3. **`entry_signals` requires at least one filter** and `min_filters ≥ 1`.
+>    An empty entry-filter list → validate fails with
+>    `"No entry filter signals selected"`.
+> 4. The catalog's `rows` field is often `0`/unpopulated — **don't filter
+>    datasets on `rows`**; sort by `end_date` to pick a recent window.
+
+Config rules of thumb:
+
+- **`search_mode`** — `"grid"` enumerates every parameter combination
+  (deterministic, exhaustive). `"random"` samples N combos (set
+  `n_random`) — use it when the full grid would exceed 99.
+- **`kind`** — `"single"` (one asset) is the default. `"pair"` is
+  continuous two-asset rotation (needs `pairs` + `rotation_params`,
+  random mode only) — only reach for it if the user explicitly wants
+  pair rotation.
+- **Keep the grid ≤ 99.** The engine refuses grids larger than 99
+  strategies. If the user's ranges blow past that, either narrow the
+  ranges, switch to `"random"` with `n_random ≤ 99`, or **pre-prune with
+  `/sieve`** and seed the sweep from the survivors.
+- **SIEVE pre-filter.** If supported by the config (`pre_filter` block),
+  enabling it lets the engine skip runs it predicts will produce no
+  trades — a free compute saving. Default it on for large grids.
+- **`execution_config`** — `{"base": {}, "sweep_axes": []}` uses canonical
+  trading defaults. Only populate `base` (from `oracle_list_signals`'
+  sibling exec-config defaults) if the user wants specific risk settings,
+  and only add `sweep_axes` if they want to sweep an execution parameter
+  too.
+
+Do NOT ask the user to hand-write this. Translate their intent ("sweep
+MACD fast 8→16, slow 20→30 on BTC 1h") into the config yourself, citing
+the dataset + signals you pulled in Phase A.
+
+## Phase C — create → validate → launch
+
+1. `oracle_create_experiment(config)` → returns `experiment_id`
+   (`exp_<timestamp>`), `status: "draft"`.
+2. `oracle_validate_experiment(experiment_id)` — **read the response.**
+   It returns `{"valid": bool, "total_runs": int, "errors": [...],
+   "warnings": [...]}`. Check `valid` and report `total_runs` to the user
+   before paying to launch. If `valid` is `false`, the `errors` list says
+   why (bad signal name, params out of range, no entry filter, grid >
+   cap); fix the config with `oracle_update_experiment(experiment_id,
+   config)` (**only `draft` experiments are mutable**) and re-validate.
+   Surface the error verbatim — don't paper over it.
+   - *(Note: `oracle_validate_experiment` returns this validation result,
+     not a `status` field — the agent reads it straight from the server.)*
+3. `oracle_launch_experiment(experiment_id)` — fans the validated grid
+   out asynchronously; returns `{"status": "preparing", "experiment_id":
+   ..., "total_runs": ...}`.
+
+**Two different caps — know which surfaces where (verified live):**
+
+- **Per-sweep size** (max backtests in one grid) — tier-dependent;
+  rejected at **validate** (HTTP 403 / `valid: false`). Shrink the grid,
+  switch to `random`, or pre-prune with `/sieve`.
+- **Concurrent sweeps in flight** — **plan-dependent, often just 1** on
+  the free tier; rejected at **launch** (HTTP 429, *"Concurrent sweep
+  limit reached: you have N sweep(s) already in flight; your plan allows
+  up to M"*). You can only run one sweep at a time — wait for the current
+  one to finish (poll Phase D), then launch the next. Relay the message
+  plainly and offer to wait or upgrade.
+
+**Cost note:** `create` + `launch` each count as a billable Oracle
+experiment call (1 unit; the fan-out children are NOT billed
+individually). Tell the user before launching.
+
+## Phase D — Poll
+
+The fan-out runs in the background. Track it without hammering the API:
+
+- `oracle_get_experiment(experiment_id)` → `status` + `completed_runs`
+  (live progress against total).
+- `oracle_list_results(experiment_id=...)` → results as they materialize,
+  paginated.
+
+**Poll with patience, not a tight loop.** `oracle_list_results` is
+billable per call — prefer a larger page every several seconds over
+rapid small polls. Tell the user it's a background job and roughly how
+many runs to expect.
+
+**If `oracle_list_results` returns a BigQuery / Parquet schema error**
+(e.g. *"column 'X' has type INT32 which does not match … BOOL"*), that is
+a **server-side corpus issue, not your config** — `get_experiment` still
+shows progress. Surface it as an Oracle-side problem, note the experiment
+ran, and don't blame the user's sweep. (Graceful downgrade, per
+`trading-bot-workflow.md`.)
+
+## Phase E — Rank + verdict + handoff
+
+1. **Rank.** Pull `oracle_list_results(experiment_id=...)`, sort by
+   `sortino_ratio` (downside-aware), tie-break on `sharpe_ratio`.
+2. **Verdict against the same thresholds `/backtest` uses** (the 6 in
+   `server/src/services/data/threshold_spec.json`: sortino ≥ 1.5,
+   sharpe ≥ 1.2, calmar ≥ 1.0, irr_annualized ≥ 0.15, max_drawdown ≤ 0.7,
+   win_rate ≥ 0.25). A sweep result with `total_trades < 10` is
+   `INSUFFICIENT_TRADES`, not a winner — same rule as `/backtest`.
+3. **Benchmark-relative line.** Each result row carries
+   `benchmark_asset_return` / `benchmark_btc_return`. Report whether the
+   top strategy beat buy-and-hold, not just its absolute return.
+4. **Present the leaderboard** — top 5 by sortino, with the threshold
+   pass/fail and benchmark deltas — so the user can see the search, not
+   just the winner.
+5. **Confirm the winner before promotion.** Sweep runs are fast/coarse;
+   register the winning config (`create_strategy_manual`) and hand to
+   `/backtest` for a full single-strategy verdict on a properly sized
+   window. Only after that PASS does it go to paper (and live is further
+   gated on allocation + backup — see `trading-bot-workflow.md`).
+
+## Lifecycle housekeeping
+
+- `oracle_pause_experiment(id)` stops a running fan-out without losing
+  completed results; relaunch to resume.
+- `oracle_delete_experiment(id)` removes it and cancels in-flight
+  children. Offer cleanup once the user has their winner.
+
+## Prohibited
+
+- **Never** call `launch` without a successful `validate` — the engine
+  rejects it, and you'd waste the round-trip.
+- **Never** try to mutate a non-draft experiment — `update` only works on
+  `draft`. Create a new one instead.
+- **Never** build a grid > 99 and hope — narrow it, switch to random, or
+  pre-prune with `/sieve`.
+- **Never** promote a sweep winner straight to paper/live on the sweep
+  metrics alone — confirm with a full `/backtest` first.
+- **Never** tight-poll `oracle_list_results` — it's billable per call.
+- **Never** invent a metric or a run count; report what
+  `oracle_validate_experiment` / `oracle_list_results` returned.
+
+## Summary — Decision Tree
+
+```
+User wants to search a parameter space / rank many configs
+│
+├─ Phase A: catalog — oracle_list_datasets + oracle_list_signals (+templates)
+│     → pick dataset(s) by file; confirm valid signal names + params
+│
+├─ Phase B: build the ExperimentConfig from the user's intent
+│     → grid vs random; keep ≤99; enable SIEVE pre-filter on big grids
+│     → pre-prune with /sieve if the grid would exceed 99
+│
+├─ Phase C: oracle_create_experiment → oracle_validate_experiment → oracle_launch_experiment
+│     → READ validate response (total_runs / errors / tier caps)
+│     → fix-and-revalidate on error (drafts only); surface caps plainly
+│
+├─ Phase D: poll oracle_get_experiment + oracle_list_results
+│     → background job; large pages, not tight loops (results reads bill)
+│
+└─ Phase E: rank by sortino → verdict vs threshold_spec → benchmark line
+      → present top-5 leaderboard
+      → register winner (create_strategy_manual) → /backtest to confirm
+      → then paper (live further gated); offer delete to clean up
+```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,121 @@
+# Getting Started
+
+A clear, no-jargon walkthrough from "I just cloned this" to "I have a
+ranked, backtested strategy paper-trading." **No wallet and no real money
+are needed for any of this** — paper trading simulates fills at live
+market prices.
+
+You don't run commands or write code. You **talk to the bot** (Sage) in
+plain English, and it drives the Mangrove tools for you. The examples
+below are things you literally type into the chat.
+
+---
+
+## The 60-second mental model
+
+A trading strategy is a set of rules: *when to buy* (entry signals) and
+*when to sell* (exit signals). The hard part isn't writing one rule —
+it's finding the rule (and the parameter values) that actually works.
+
+Mangrove gives you three tools for that, cheapest first:
+
+| Tool | What it does | When |
+|---|---|---|
+| **SIEVE** | Scores up to 99 strategy ideas in milliseconds and tells you which are worth testing. | You have *many* ideas and want to skip the duds. |
+| **Sweep** | Runs up to 99 backtests in one managed experiment and ranks them. | You want the *best* config out of many. |
+| **Backtest** | Carefully simulates *one* strategy over real history. | You want a trustworthy verdict on a single config. |
+
+**Why this order matters:** a real backtest takes 30–120 seconds, and
+about **5 of every 6 strategies fail it**. SIEVE finds the 1 worth
+testing — so you score 99 ideas for the cost of one, sweep the handful
+that survive, and only spend a careful backtest on the finalists.
+
+---
+
+## Two ways to start
+
+### Path A — "Build me one strategy"
+
+Best when you have a specific idea.
+
+> **You:** "Build me a momentum strategy for ETH on the 1-hour chart."
+
+Sage searches the reference library and the knowledge base, builds a
+strategy with evidence-backed parameters, and backtests it. You get a
+PASS/FAIL verdict against six performance thresholds plus a "did it beat
+buy-and-hold?" line. (This is the `/create-strategy` → `/backtest` flow.)
+
+### Path B — "Find me the best one" (this is the powerful one)
+
+Best when you don't know the right parameters yet — which is usually.
+
+> **You:** "Find me the best MACD strategy for BTC on 1h. Try a bunch of
+> window settings."
+
+Here's what Sage does for you, automatically:
+
+1. **Generates the variations** — e.g. 50 combinations of MACD fast/slow
+   windows.
+2. **Runs them through SIEVE** (`/sieve`) — one cheap call scores all 50,
+   drops the ones predicted to never trade, and ranks the rest by their
+   probability of winning.
+3. **Sweeps the survivors** (`/sweep`) — fans the top handful into a
+   managed Oracle experiment (`create → validate → launch → results`),
+   backtests them all, and ranks by risk-adjusted return (Sortino).
+4. **Confirms the winner** — runs the top result through a full backtest
+   for a trustworthy verdict.
+5. **Shows you the leaderboard** — the top configs with their metrics and
+   how they compare to just holding the asset.
+
+You end up with a ranked winner you can promote to paper, having tested
+dozens of ideas for a fraction of the compute.
+
+---
+
+## Then: paper-trade it (still no wallet)
+
+> **You:** "Promote the winner to paper."
+
+Paper mode schedules the strategy to evaluate on its timeframe and
+simulates trades at live market prices. Nothing touches a blockchain and
+no funds are at risk. Watch it with:
+
+> **You:** "Show me the paper evaluations and trades so far."
+
+## Later: go live (this one needs a wallet)
+
+Live trading executes real swaps and is gated for your safety — it needs
+a funded wallet with a confirmed backup, an allocation block, and an
+explicit confirmation. Sage walks you through connecting a wallet
+**only when you ask to go live**, never before. Your private key never
+enters the chat (a safety hook blocks it); you back it up in your own
+terminal. See [`wallet-presentation.md`](../.claude/rules/wallet-presentation.md).
+
+---
+
+## What to say — a cheat sheet
+
+| You want to… | Say something like… | Skill |
+|---|---|---|
+| See what the bot can do | "Give me a tour." | — |
+| Build one specific strategy | "Build a mean-reversion strategy for SOL 15m." | `/create-strategy` |
+| Screen many ideas cheaply | "Score these 40 variations and tell me which are worth testing." | `/sieve` |
+| Search for the best config | "Sweep the RSI window from 7 to 21 on BTC 1h and rank them." | `/sweep` |
+| Verdict on one strategy | "Backtest that one over the last year." | `/backtest` |
+| Start paper trading | "Promote it to paper." | — |
+| Check on a strategy | "How are my paper strategies doing?" | — |
+
+You don't need to name the skills — Sage picks the right one from what
+you ask. They're listed so you know what's happening under the hood.
+
+---
+
+## Go deeper
+
+- **SIEVE, in depth** — tutorial [chapter 09](../tutorials/trading-app/09-oracle-strategies.md),
+  and the KB guides [Filtering with SIEVE](https://docs.mangrovedeveloper.ai/guides/using-sieve-prefilter)
+  and [SIEVE end-to-end](https://docs.mangrovedeveloper.ai/guides/sieve-end-to-end-workflow).
+- **Sweeps / experiments** — KB [Experiments reference](https://docs.mangrovedeveloper.ai/api-reference/experiments).
+- **The full trading workflow** the bot follows — [`trading-bot-workflow.md`](../.claude/rules/trading-bot-workflow.md).
+- **The SDK** behind it all (if you want to script directly) — the
+  `mangroveai` Python package, `client.oracle.*`.

--- a/server/src/services/oracle.py
+++ b/server/src/services/oracle.py
@@ -310,14 +310,27 @@ def launch_experiment(experiment_id: str) -> dict[str, Any]:
 
 
 def pause_experiment(experiment_id: str) -> dict[str, Any]:
-    """Halt a running experiment without losing completed results."""
+    """Halt a running experiment without losing completed results.
+
+    Returns the server's `{"status": "paused"}` body.
+
+    NOTE — same SDK contract bug as `validate_experiment` (mangroveai
+    <= 1.5.0): the pause endpoint returns `{"status": "paused"}` with NO
+    `experiment_id`, but the SDK types it as `ExperimentStatus`
+    (`experiment_id` + `status`, both required), so
+    `client.oracle.pause_experiment` raises a pydantic `ValidationError`
+    on an otherwise-successful 200. We call the transport directly until
+    the SDK ships a tolerant model. Tracked: MangroveAI-SDK contract fix.
+    """
     client = mangrove_ai_client()
-    result = client.oracle.pause_experiment(experiment_id)
+    raw = client.oracle._core.request(
+        "POST", f"/oracle/experiments/{experiment_id}/pause"
+    ).json()
     _log.info(
         "oracle.pause_experiment",
-        extra={"experiment_id": experiment_id, "status": result.status},
+        extra={"experiment_id": experiment_id, "status": raw.get("status")},
     )
-    return result.model_dump()
+    return raw
 
 
 # ---------------------------------------------------------------------------

--- a/server/src/services/oracle.py
+++ b/server/src/services/oracle.py
@@ -272,14 +272,30 @@ def delete_experiment(experiment_id: str) -> dict[str, Any]:
 
 
 def validate_experiment(experiment_id: str) -> dict[str, Any]:
-    """Validate a draft → required before launch."""
+    """Validate a draft → required before launch.
+
+    Returns the server's validation result:
+        {"valid": bool, "total_runs": int, "errors": [...], "warnings": [...]}
+
+    NOTE — SDK contract bug (mangroveai <= 1.5.0): the SDK types this
+    endpoint's response as ``ExperimentStatus`` (``experiment_id`` +
+    ``status``), but the server returns the ``{valid, total_runs,
+    errors, warnings}`` shape above. ``client.oracle.validate_experiment``
+    therefore raises a pydantic ``ValidationError`` while parsing an
+    otherwise-successful 200. We call the transport directly and return
+    the raw validation result until the SDK ships a correct
+    ``ExperimentValidation`` model. Tracked: MangroveAI-SDK contract fix.
+    """
     client = mangrove_ai_client()
-    result = client.oracle.validate_experiment(experiment_id)
+    raw = client.oracle._core.request(
+        "POST", f"/oracle/experiments/{experiment_id}/validate"
+    ).json()
     _log.info(
         "oracle.validate_experiment",
-        extra={"experiment_id": experiment_id, "status": result.status},
+        extra={"experiment_id": experiment_id, "valid": raw.get("valid"),
+               "total_runs": raw.get("total_runs")},
     )
-    return result.model_dump()
+    return raw
 
 
 def launch_experiment(experiment_id: str) -> dict[str, Any]:

--- a/server/tests/unit/test_oracle.py
+++ b/server/tests/unit/test_oracle.py
@@ -26,6 +26,9 @@ from src.services.oracle import (
     data_query as svc_data_query,
 )
 from src.services.oracle import (
+    pause_experiment as svc_pause_experiment,
+)
+from src.services.oracle import (
     sieve_score as svc_sieve_score,
 )
 from src.services.oracle import (
@@ -223,3 +226,29 @@ class TestValidateExperiment:
 
         assert result["valid"] is False
         assert "No entry filter signals selected" in result["errors"]
+
+
+# ---------------------------------------------------------------------------
+# pause_experiment — same SDK contract bug as validate: the server returns
+# {"status": "paused"} with NO experiment_id, but the SDK types it as
+# ExperimentStatus (experiment_id required) and crashes. The service must
+# read the body via the transport directly.
+# ---------------------------------------------------------------------------
+
+class TestPauseExperiment:
+    def test_returns_raw_status_via_transport(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        client = MagicMock()
+        client.oracle._core.request.return_value.json.return_value = {"status": "paused"}
+        monkeypatch.setattr("src.services.oracle.mangrove_ai_client", lambda: client)
+
+        result = svc_pause_experiment("exp_20260606T011615775405Z")
+
+        # Must NOT route through the mistyped SDK method...
+        client.oracle.pause_experiment.assert_not_called()
+        # ...and must POST straight to the pause endpoint via the transport.
+        client.oracle._core.request.assert_called_once_with(
+            "POST", "/oracle/experiments/exp_20260606T011615775405Z/pause"
+        )
+        assert result == {"status": "paused"}

--- a/server/tests/unit/test_oracle.py
+++ b/server/tests/unit/test_oracle.py
@@ -18,12 +18,20 @@ from src.services.oracle import (  # noqa: E402
     DataQueryInput,
     OracleBacktestInput,
     SieveScoreInput,
+)
+from src.services.oracle import (
     backtest as svc_backtest,
+)
+from src.services.oracle import (
     data_query as svc_data_query,
+)
+from src.services.oracle import (
     sieve_score as svc_sieve_score,
 )
+from src.services.oracle import (
+    validate_experiment as svc_validate_experiment,
+)
 from src.shared.errors import SdkError  # noqa: E402
-
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -164,3 +172,54 @@ class TestBacktest:
         assert result["success"] is True
         assert result["metrics"]["sharpe_ratio"] == pytest.approx(1.5)
         assert result["trade_count"] == 12
+
+
+# ---------------------------------------------------------------------------
+# validate_experiment — must return the server's {valid, total_runs, ...}
+# shape directly, NOT route through the SDK's ExperimentStatus model
+# (mangroveai <= 1.5.0 mistypes this endpoint and crashes on a 200).
+# ---------------------------------------------------------------------------
+
+class TestValidateExperiment:
+    def test_returns_raw_validation_result_via_transport(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        client = MagicMock()
+        # Real server shape (verified live against Oracle v0.15.3):
+        client.oracle._core.request.return_value.json.return_value = {
+            "valid": True,
+            "total_runs": 12,
+            "errors": [],
+            "warnings": [],
+        }
+        monkeypatch.setattr("src.services.oracle.mangrove_ai_client", lambda: client)
+
+        result = svc_validate_experiment("exp_20260606T011615775405Z")
+
+        # The service must NOT call the mistyped SDK method...
+        client.oracle.validate_experiment.assert_not_called()
+        # ...and must POST straight to the validate endpoint via the transport.
+        client.oracle._core.request.assert_called_once_with(
+            "POST", "/oracle/experiments/exp_20260606T011615775405Z/validate"
+        )
+        assert result == {
+            "valid": True,
+            "total_runs": 12,
+            "errors": [],
+            "warnings": [],
+        }
+
+    def test_surfaces_invalid_config(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        client = MagicMock()
+        client.oracle._core.request.return_value.json.return_value = {
+            "valid": False,
+            "total_runs": 0,
+            "errors": ["No entry filter signals selected"],
+            "warnings": [],
+        }
+        monkeypatch.setattr("src.services.oracle.mangrove_ai_client", lambda: client)
+
+        result = svc_validate_experiment("exp_x")
+
+        assert result["valid"] is False
+        assert "No entry filter signals selected" in result["errors"]

--- a/tutorials/trading-app/09-oracle-strategies.md
+++ b/tutorials/trading-app/09-oracle-strategies.md
@@ -137,12 +137,21 @@ the model is overconfident. Always backtest before promoting to paper.
 
 ## Going further
 
-- The API reference for `client.oracle.*` lives in the
-  [mangrove-ai SDK docs](https://docs.mangrovedeveloper.ai/sdks/mangroveai).
-- For batch / async / bulk backtest variants (long-running, many-
-  strategy work), see the `backtest_async` / `backtest_bulk` SDK
-  methods — not yet exposed through the agent's MCP surface, but
-  reachable via `client.oracle.backtest_async(...)` if you script
+- **Search a whole parameter space, not one strategy at a time.** The
+  agent exposes the full managed sweep lifecycle as MCP tools
+  (`oracle_create_experiment` → `oracle_validate_experiment` →
+  `oracle_launch_experiment` → `oracle_get_experiment` →
+  `oracle_list_results`). Just ask: *"sweep the MACD windows on BTC 1h
+  and rank them."* The guided flow is the **`/sweep`** skill; the cheap
+  pre-screen is the **`/sieve`** skill.
+- The async / bulk single-strategy backtest variants are also on the
+  agent's MCP surface now (`oracle_backtest_async`, `oracle_backtest_poll`,
+  `oracle_backtest_bulk`) in addition to `client.oracle.*` if you script
   against the SDK directly.
+- The API reference for `client.oracle.*` lives in the
+  [mangrove-ai SDK docs](https://docs.mangrovedeveloper.ai/sdks/mangroveai),
+  and the worked SDK walkthroughs are the KB guides
+  [SIEVE end-to-end](https://docs.mangrovedeveloper.ai/guides/sieve-end-to-end-workflow)
+  and [Experiments](https://docs.mangrovedeveloper.ai/api-reference/experiments).
 - The full corpus schema (98 fields on the `results` table) is
   documented at `MangroveOracle/infra/terraform/schemas/results.json`.


### PR DESCRIPTION
## Why

Sweep experiments + SIEVE are built, deployed, and billable, and the agent already registers the MCP tools — but Sage had no runtime knowledge of *when or how* to use them, no guided skills, and no getting-started guide. This PR makes the agent actually able to drive the SIEVE → sweep → backtest path, and fixes a real defect that blocked it.

## What

**Skills (the core deliverable):**
- **`/sieve`** — guided cheap pre-filter: assemble ≤99 candidates, score in one call, drop `p_no_trades > 0.5`, rank by `P(winning)`, hand off to `/backtest` or `/sweep`. Never promotes on a SIEVE score alone.
- **`/sweep`** — guided managed experiment lifecycle: catalog → config → `create → validate → launch → poll → ranked results` → confirm winner with `/backtest`. **Config shape and caps were corrected to match the live server, not the stale SDK quickstart.**

**Wire it into the bot's behavior (`trading-bot-workflow.md`):**
- `sieve_score` + `oracle_get_experiment` added to the eager-load core set (`sieve_score` was missing entirely).
- New **Stage 0** demo beat for SIEVE/sweep (front-and-center).
- New **Stage 2.5 — Scale the search (SIEVE + sweep)** between Author and Backtest.
- Core loop now names the search step.

**Getting-started guide** (`docs/getting-started.md`) — plain-language, no-wallet, zero-to-ranked-strategy walkthrough centered on the cheap-first path, with a "what to say to the bot" cheat sheet.

**Bug fix found during live verification** — `validate_experiment` crashed against prod: the server returns `{valid, total_runs, errors, warnings}`, but `mangroveai <= 1.5.0` types the endpoint as `ExperimentStatus` (`experiment_id`+`status`) and raises a pydantic error on an otherwise-successful 200. The agent now reads the validate result via the transport directly. **+2 unit tests.** (Upstream SDK contract fix should be tracked separately.)

**Tutorial ch09 refresh** — it predated PR #82 and claimed experiments/bulk were "not yet exposed through the agent's MCP surface." They are now.

## Live verification (agent service → SDK → MangroveAI proxy → prod Oracle, real key)

- `sieve_score` — real probabilities + provenance (`oracle:v0.15.3 ai:v3.10.14`), e.g. BTC 1h MACD candidates: `p_trades≈0.92`, `P(winning)≈0.006`.
- `oracle_list_datasets` → 2246 datasets, 208 BTC/1h.
- `create → validate → launch → get_experiment` all succeed; a 1-run sweep reached `completed`.
- **Confirmed the real config contract** (now baked into `/sweep`): `datasets` are objects not filenames; every signal needs `signal_type`; entry requires ≥1 filter (`min_filters ≥ 1`).
- **Confirmed caps**: per-sweep size → 403 at validate; concurrent (plan allows 1) → 429 at launch.
- `validate_experiment` returns `{valid: true, total_runs: 1, ...}` after the fix.

### Known issue (server-side, NOT this PR)
`oracle_list_results` currently 400s on a **corpus Parquet schema bug** — `beats_all` is `INT32` where BQ expects `BOOL`, in an unrelated experiment's file written 2026-06-04. The tool + skill are correct; the corpus has a bad file. Needs a MangroveOracle/BQ fix — flagging, not fixing here.

## Tests
- `pytest tests/ --ignore=tests/e2e` → **357 passed**.
- `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)