### PR TITLE
chore(deps): bump mangroveai floor to >=1.5.1

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -23,7 +23,12 @@ PyJWT>=2.9.0
 # is normal Python packaging (Pillow/PIL, beautifulsoup4/bs4, etc.).
 # An attempted PyPI rename to `mangrove-ai` was rejected by PyPI's
 # similarity check — that's why we kept the dist name as-is.
-mangroveai>=1.4.0,<2.0.0
+# Floor raised to 1.5.1: that release fixed the Oracle experiment
+# validate/pause response models (ExperimentValidation; experiment_id
+# optional on ExperimentStatus). The agent's oracle service reads those
+# two endpoints via the transport directly as a version-independent
+# safeguard, so it works on >=1.5.1 without depending on the typed model.
+mangroveai>=1.5.1,<2.0.0
 # mangrovemarkets 1.0.0 moved EVM wallet keypair generation client-side.
 # The agent's wallet_manager.create_wallet() is unaffected — the SDK
 # call signature is unchanged, only the implementation shifted from


### PR DESCRIPTION
## Why
`mangroveai` **v1.5.1** (just released) fixes the Oracle experiment validate/pause response models — `ExperimentValidation` + `experiment_id` optional on `ExperimentStatus` ([MangroveAI-SDK #19](https://github.com/MangroveTechnologies/MangroveAI-SDK/pull/19)). The agent already reads those two endpoints via the transport directly (the version-independent safeguard added in #90), so it works on ≥1.5.1 today; this raises the floor so a fresh `pip install` can't resolve the older, broken SDK.

## Verification
- Installed the real **mangroveai 1.5.1** wheel from PyPI.
- Full non-e2e suite: **358 passed**.

## Deferred follow-up
The transport-direct `validate_experiment`/`pause_experiment` reads can be simplified back to the typed `client.oracle.*` calls now that 1.5.1 ships correct models. Deferred because that swap warrants a live round-trip to re-verify, and the test key's **monthly sweep quota is currently spent** — will do it once quota resets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)