### PR TITLE
chore: bump mangroveai pin to >=1.5.2 (Oracle data_query fix)

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -28,7 +28,13 @@ PyJWT>=2.9.0
 # optional on ExperimentStatus). The agent's oracle service reads those
 # two endpoints via the transport directly as a version-independent
 # safeguard, so it works on >=1.5.1 without depending on the typed model.
-mangroveai>=1.5.1,<2.0.0
+# Floor raised to 1.5.2: fixed the Oracle data_query response model
+# (DataQueryResponse.table now optional + total_bytes_billed/
+# cost_estimate_usd/next_page_token added) and DataQueryRequest.order_by
+# ([{col,dir}] not [str]) — the agent's oracle_data_query MCP tool parses
+# the typed DataQueryResponse, so it crashed on <1.5.2 against the live
+# (v0.15.7) Oracle. Also corrected SimulateRunResponse to the real shape.
+mangroveai>=1.5.2,<2.0.0
 # mangrovemarkets 1.0.0 moved EVM wallet keypair generation client-side.
 # The agent's wallet_manager.create_wallet() is unaffected — the SDK
 # call signature is unchanged, only the implementation shifted from


### PR DESCRIPTION
## What

Bumps the `mangroveai` floor from `>=1.5.1` to `>=1.5.2` so the agent's `oracle_data_query` MCP tool works against the live Oracle.

## Why

`oracle_data_query` (server/src/services/oracle.py) parses the typed `DataQueryResponse` via `model_dump()`. Before 1.5.2 that model required a `table` field and typed `order_by` as `[str]`, neither of which matched the real Oracle response — so the tool crashed against the deployed Oracle (now v0.15.7). SDK v1.5.2 makes `table` optional, adds the real server fields (`total_bytes_billed`, `cost_estimate_usd`, `next_page_token`), and corrects `order_by` to `[{col,dir}]`.

This is the downstream of MangroveAI-SDK#20 (v1.5.2) and MangroveOracle#262 (v0.15.7).

## Verification (released 1.5.2 vs live Oracle v0.15.7)

```
results data_query (select+filter+order_by desc, limit 3) -> 200  model_dump() OK  table=results
ohlcv   data_query (timestamp,close,volume, limit 2)       -> 200  model_dump() OK  table=ohlcv
```

Both paths — the one that crashed pre-1.5.2 (`results`/`table`) and the WS1 tenancy fix (`ohlcv`, was 400 on `org_id`) — parse cleanly through the exact agent service return shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)