### PR TITLE
docs: add Discord community link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@
     <a href="https://github.com/MangroveTechnologies/mangrove-agent/blob/main/LICENSE">
       <img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License">
     </a>
+    <a href="https://discord.gg/xUcn4R6zJR">
+      <img src="https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white" alt="Discord">
+    </a>
   </p>
 </div>
 


### PR DESCRIPTION
Adds a link to the Mangrove Technologies Discord (https://discord.gg/xUcn4R6zJR) to the README so visitors can find the community.

- Static shields.io Discord badge (no live-count dependency, never breaks).
- Permanent, non-expiring invite (verified: `expires_at: null`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)