### PR TITLE
fix(skills): de-conflate sieve & sweep + sweep-config HTML builder

### DIFF
--- a/.claude/skills/sieve/SKILL.md
+++ b/.claude/skills/sieve/SKILL.md
@@ -7,10 +7,12 @@ description: >-
   my candidates", "rank these MACD variations". Also the natural next
   step after /create-strategy or /custom-signal produces a candidate
   set. Scores up to 99 candidates in ONE millisecond-cheap call through
-  the Mangrove SIEVE classifier, drops the dead-on-arrival ones, and
-  ranks the survivors by P(winning) before any expensive backtest.
-  Wraps `sieve_score` + `oracle_list_signals`, hands off to /backtest
-  (one winner) or /sweep (managed many).
+  the Mangrove SIEVE classifier, drops the dead-on-arrival ones (binary
+  head), and ranks the survivors by P(winning) (4-class head) — a cheap
+  SCREEN, never a verdict. Wraps `sieve_score` + `oracle_list_signals`,
+  hands the shortlist to /backtest (one winner) or /backtest/bulk
+  (several). This screens a FIXED candidate list; for a parameter-space
+  SEARCH that generates its own candidates, use /sweep instead.
 ---
 
 # SIEVE Skill
@@ -25,16 +27,27 @@ to find the 1 good one is wasteful.
 classifier trained on 1.24M historical Mangrove sweep runs. It scores a
 candidate in milliseconds and returns two things:
 
-- **binary** — `{p_no_trades, p_trades}`. The go/no-go gate: if SIEVE
-  thinks the strategy will never fire on real data, you skip the
-  backtest entirely.
+- **binary (2-class)** — `{p_no_trades, p_trades}`. The go/no-go gate: if
+  SIEVE thinks the strategy will never fire on real data, you skip the
+  backtest entirely. (This is the same head the `/sweep` engine uses as
+  its inline pre-filter — but that's a *different* mechanism; see below.)
 - **four_class** — `{losing, no_trades, wash, winning}`. A softmax over
-  outcomes. Rank survivors by `P(winning)` and only spend backtest
-  compute on the top slice.
+  outcomes. Rank survivors by `P(winning)` to order the shortlist.
 
-A 99-candidate search compresses to ~5 backtests. Same signal quality at
-~10% of the cost. **SIEVE is a fast filter, not a backtest** — it never
-replaces the real thing (see Prohibited).
+Use **both** heads: binary to drop the dead, 4-class to rank what's left.
+
+**SIEVE is a SCREEN, not a verdict.** Both heads are cheap *predictions*
+over an aggregate of millions of runs — they tell you what's worth paying
+to backtest, never whether a strategy is actually good. Only a real
+backtest decides. A 99-candidate screen compresses to ~5 backtests: same
+signal quality at ~10% of the cost (see Prohibited).
+
+**Two different SIEVE uses — don't confuse them:**
+- **This skill** = offline screen of a fixed shortlist via the
+  `sieve_score` endpoint (≤99 per call), then hand survivors to a backtest.
+- **`/sweep`'s pre-filter** = the binary head running *inside* the engine
+  during a parameter search, skipping dead configs as they're generated.
+  That's part of `/sweep`, not this skill — and it never uses the 4-class head.
 
 ## Trigger
 
@@ -52,8 +65,9 @@ Activate when the user:
 Do NOT activate for:
 
 - A single known strategy the user wants to evaluate → `/backtest`
-- A managed, ranked sweep over a parameter grid with persisted results
-  → `/sweep` (SIEVE feeds it; this skill is the cheap pre-screen)
+- A parameter-space SEARCH where the engine generates and backtests its
+  own candidates → `/sweep` (a separate workflow — this skill does NOT
+  feed it; `/sweep` has its own built-in binary pre-filter)
 - Authoring new strategies from scratch → `/create-strategy`
 
 ## Phase A — Assemble candidates (≤ 99)
@@ -81,10 +95,11 @@ Where the candidates come from:
 
 - **From `/create-strategy` or `/custom-signal`** — the candidate set is
   already built; carry it straight in.
-- **From a parameter sweep the user describes** — generate the
-  variations yourself. "Sweep entry-window 8→20, exit-window 20→40"
-  means build the cross-product of those param values into N candidate
-  objects.
+- **From a set of variations the user wants screened** — generate the
+  variations yourself into N candidate objects (≤99) and score them.
+  (If the user instead wants a *managed* parameter search — the engine
+  generating + backtesting + ranking candidates with persisted results —
+  that's `/sweep`, not this. Screening a list ≠ searching a space.)
 
 **Get the signal names + param specs right.** Call `oracle_list_signals`
 once and use it to validate every `name`, `signal_type` (`TRIGGER` /
@@ -132,14 +147,20 @@ to delete the strategy. Say so rather than reporting "everything died."
 
 ## Phase D — Handoff
 
-The shortlist is now ready for real evaluation. Route it:
+The shortlist is now ready for real evaluation — a **backtest**, which is
+the actual verdict SIEVE only screened for. Route it:
 
 - **One clear winner, or the user wants a careful single verdict** →
   `/backtest` on that candidate (register it first with
   `create_strategy_manual` if it isn't a strategy yet).
-- **Several survivors worth comparing head-to-head with ranked,
-  persisted results** → `/sweep` — feed the shortlist as the experiment's
-  signal mix.
+- **Several survivors to backtest together** → `/backtest/bulk`
+  (`oracle_backtest_bulk`) — one call backtests the shortlist with shared
+  OHLCV fetches and returns all results.
+
+Do NOT route the shortlist into `/sweep`. A sweep is a parameter-space
+search that generates its own candidates; it does not consume a
+pre-screened list. (If the user wants to *search* rather than *screen a
+list*, that was a `/sweep` job from the start.)
 
 Always carry the provenance forward: log `model_version` +
 `code_version` next to the shortlist, so when SIEVE is retrained you can
@@ -159,6 +180,9 @@ tell which snapshot produced the ranking.
   It's a filter signal, full stop.
 - **Never** delete a whole batch because `p_no_trades ≈ 1.0` — that's a
   "widen the params and re-score" signal, not a dead end.
+- **Never** feed a SIEVE shortlist into `/sweep` — a sweep generates its
+  own candidates from a parameter space; this skill screens a fixed list
+  and hands it to `/backtest` / `/backtest/bulk`.
 
 ## Summary — Decision Tree
 
@@ -178,7 +202,8 @@ User has many candidates / wants to try many variations
 │     → rank survivors by P(winning), keep top 5–10 / top ~10%
 │     → p_no_trades ≈ 1.0 everywhere → widen params, re-score
 │
-└─ Phase D: handoff (NEVER promote from here)
+└─ Phase D: handoff (NEVER promote from here; a backtest is the verdict)
       → one winner / careful verdict → /backtest
-      → several to compare, ranked + persisted → /sweep
+      → several survivors to backtest together → /backtest/bulk
+      → (NOT /sweep — that searches a space, it doesn't take a screened list)
 ```

--- a/.claude/skills/sweep/SKILL.md
+++ b/.claude/skills/sweep/SKILL.md
@@ -4,12 +4,14 @@ description: >-
   Use when the user wants to search a parameter SPACE at scale rather
   than test one config — "sweep the RSI window from 7 to 21", "try every
   MACD variation on BTC 1h and rank them", "what's the best config for
-  X", "run an experiment". Drives the managed Oracle experiment
-  lifecycle (create → validate → launch → poll → results), fanning a
-  strategy template out into up to 99 ranked backtests in one
-  experiment. Pair it with /sieve to prune the grid cheaply first. Wraps
-  `oracle_list_datasets` + `oracle_list_signals` + `oracle_create_experiment`
-  + `oracle_validate_experiment` + `oracle_launch_experiment` +
+  X", "run an experiment", "hyperparameter search". Drives the managed
+  Oracle experiment lifecycle (create → validate → launch → poll →
+  results): you give it a strategy template + a parameter space, and the
+  ENGINE generates and backtests the candidates (grid or random/
+  Monte-Carlo), ranking the results. A binary SIEVE pre-filter skips
+  dead configs during the sweep. Wraps `oracle_list_datasets` +
+  `oracle_list_signals` + `oracle_create_experiment` +
+  `oracle_validate_experiment` + `oracle_launch_experiment` +
   `oracle_get_experiment` + `oracle_list_results`; hands the winner to
   /backtest for a confirming verdict before paper/live.
 ---
@@ -18,11 +20,17 @@ description: >-
 
 This skill exists because **finding a good strategy is a search problem,
 not a single guess.** `/backtest` answers "is THIS config good?" A sweep
-answers "of these 99 configs, which is best?" — it takes a strategy
-template plus a parameter grid (or random search) over signal params,
-fans it out into up to 99 individual backtests against one or more
-datasets, and ranks the results. You author once and let the engine do
-the search.
+answers "across this whole parameter space, which config is best?" — you
+give it a strategy template plus a parameter space, and the **engine
+generates its own candidates** (grid enumeration or random/Monte-Carlo
+sampling), backtests each against one or more datasets, and ranks the
+results. You author the search space once and let the engine explore it.
+
+**A sweep is NOT "screen a list then run the survivors."** It generates
+the candidates itself from the parameter space — you never hand it a
+pre-made list of strategies. (That different workflow — score a fixed
+shortlist with SIEVE, then backtest the keepers — is `/sieve` →
+`/backtest`/`/backtest/bulk`. See "How this differs from /sieve" below.)
 
 The lifecycle is intentionally explicit — **validate before launch,
 separate from create** — so you (and Oracle) can confirm the config and
@@ -35,10 +43,6 @@ create ──▶ [update]* ──▶ validate ──▶ launch ──▶ (runnin
                                                       └─▶ delete (cancels children)
 ```
 
-**Always prune with `/sieve` first** when the grid is large: SIEVE
-scores 99 candidates in one cheap call, so you spend sweep compute only
-on the configs it doesn't already predict will die.
-
 ## Trigger
 
 Activate when the user:
@@ -47,15 +51,49 @@ Activate when the user:
   "try entry-window 8 to 20 and exit-window 20 to 40")
 - Wants the best of many variations, ranked ("try every MACD config on
   BTC 1h and tell me the best", "compare these across timeframes")
-- Has a shortlist from `/sieve` worth a managed, persisted, ranked run
-- Says "run an experiment" / "do a sweep" / "hyperparameter search"
+- Says "run an experiment" / "do a sweep" / "hyperparameter search" /
+  "Monte-Carlo search over the params"
 
 Do NOT activate for:
 
 - A single known config the user wants evaluated → `/backtest`
-- Cheaply scoring/screening candidates without persisting → `/sieve`
-  (use it first, then come here with the survivors)
+- Screening/ranking a FIXED set of candidate strategies they already
+  have, without a parameter search → `/sieve` (then `/backtest` /
+  `/backtest/bulk`). That is a separate workflow, not a pre-step to this one.
 - Authoring a single strategy from a loose goal → `/create-strategy`
+
+## How this differs from /sieve (read this — they are NOT a pipeline)
+
+These get conflated; they are different tools:
+
+- **`/sweep` (this skill)** = parameter-space SEARCH. The engine generates
+  candidates by sampling the space and backtests them. Its built-in SIEVE
+  hook is the **binary** pre-filter (below) that runs *inside* the sweep.
+- **`/sieve`** = cheap screening of a **fixed shortlist** you already have
+  (≤99 per call), via the standalone `sieve_score` endpoint. It hands
+  survivors to `/backtest` / `/backtest/bulk` — **not** to a sweep.
+
+You do not "prune a grid with /sieve and then sweep the survivors." A
+sweep makes its own candidates. The only place SIEVE touches a sweep is
+the in-sweep binary pre-filter.
+
+## SIEVE binary pre-filter (default ON for every sweep)
+
+The Oracle engine can run each generated candidate through the **binary**
+SIEVE head *before* backtesting it, and skip the ones it predicts will
+never fire a trade — saving compute on dead-on-arrival configs. Set it in
+the config and **default it on at threshold 0.8**:
+
+```json
+"pre_filter": {"enabled": true, "confidence_threshold": 0.8}
+```
+
+Meaning: skip a candidate if `P(no_trades) > 0.8`. This is the **2-class
+(binary) head only** — a will-it-trade gate. The **4-class head
+(losing/no_trades/wash/winning) is NOT used in sweeps** — it is a
+post-hoc/replay classifier (it labels already-completed runs). Never
+describe the sweep as "ranking candidates by P(winning) before running"
+— it does not.
 
 ## Phase A — Orient with the catalog
 
@@ -63,22 +101,42 @@ Three free (non-billable) metadata calls. Always start here — building a
 config from memory produces names the validator rejects.
 
 1. `oracle_list_datasets` — the curated OHLCV snapshots the engine runs
-   against. Each carries `asset`, `timeframe`, `file`, `rows`,
-   `start_date`, `end_date`. **You reference datasets by their `file`
-   value** in the config. Pick the dataset(s) matching the user's asset +
-   timeframe; show the date range so they know what window they're
-   sweeping.
+   against. Each carries `asset`, `timeframe`, `file`, `hash`, `rows`,
+   `start_date`, `end_date`. **You reference a dataset by passing its
+   whole object** (see Phase B rule 1), not by filename. Pick the
+   dataset(s) matching the user's asset + timeframe; sort by `end_date`
+   and show the date range so they know the window they're sweeping.
 2. `oracle_list_signals` — the 223 signals with typed param specs.
    Each: `name`, `type` (`TRIGGER` / `FILTER`), `params` (tunable spec +
-   ranges), `requires`, `category`. This is the source of truth for valid
-   signal names and which params are sweepable.
+   ranges), `requires`, `category` (`momentum` / `trend` / `volume` /
+   `volatility` / `patterns`). The source of truth for valid signal names
+   and which params are sweepable. **Select signals by category** when the
+   user names a style ("momentum sweep" → triggers/filters in `momentum`).
 3. `oracle_list_templates` (optional) — predefined strategy templates you
    can seed the experiment from instead of building entry/exit by hand.
 
 ## Phase B — Build the experiment config
 
-Build the config dict in the real Oracle `ExperimentConfig` shape (this
-is the executable SDK shape, not the older curl-doc shape):
+Two ways to build it:
+
+**(i) Author it directly** — translate the user's intent ("sweep MACD
+fast 8→16, slow 20→30 on BTC 1h") into the `ExperimentConfig` yourself,
+citing the dataset + signals from Phase A. Do NOT ask the user to
+hand-write JSON.
+
+**(ii) Configure via the HTML builder** (`sweep-config.html`, shipped
+with this skill) — for when the user wants to drive the setup visually:
+1. Fetch `oracle_list_signals` + `oracle_list_datasets`, and embed them
+   into the page's `CATALOG` block (the HTML makes **no** API calls — it
+   only builds JSON, so the catalog must be injected).
+2. Hand the user the file; they pick dataset, signals (filterable by
+   category), param ranges, grid/random + size, and **Download
+   config.json**.
+3. **You** read the downloaded `config.json`, then run validate →
+   **confirm `total_runs` + cost with the user** → launch. Never
+   auto-launch from a saved config without that confirmation.
+
+The real Oracle `ExperimentConfig` shape (executable SDK shape):
 
 ```json
 {
@@ -90,10 +148,13 @@ is the executable SDK shape, not the older curl-doc shape):
   "entry_signals": {
     "triggers": [
       {"name": "macd_bullish_cross", "signal_type": "TRIGGER",
-       "params": {"window_fast": 12, "window_slow": 26}}
+       "params": {"window_sign": 9},
+       "params_sweep": {"window_fast": {"values": [8, 12, 16]},
+                        "window_slow": {"values": [21, 26, 30]}}}
     ],
     "filters": [
-      {"name": "is_above_sma", "signal_type": "FILTER", "params": {"window": 50}}
+      {"name": "is_above_sma", "signal_type": "FILTER",
+       "params_sweep": {"window": {"values": [50, 100]}}}
     ],
     "min_filters": 1,
     "max_filters": 1
@@ -101,20 +162,21 @@ is the executable SDK shape, not the older curl-doc shape):
   "exit_signals": {
     "triggers": [
       {"name": "macd_bearish_cross", "signal_type": "TRIGGER",
-       "params": {"window_fast": 12, "window_slow": 26}}
+       "params": {"window_fast": 12, "window_slow": 26, "window_sign": 9}}
     ],
     "filters": []
   },
-  "execution_config": {"base": {}, "sweep_axes": []}
+  "grid_signals": {"n_param_combos": 24},
+  "execution_config": {"base": {}, "sweep_axes": []},
+  "pre_filter": {"enabled": true, "confidence_threshold": 0.8}
 }
 ```
 
-> **These four details are server-enforced — verified live against Oracle
-> v0.15.3. Get them wrong and `create`/`validate` reject the config:**
+> **Server-enforced — verified live. Get these wrong and `create`/`validate` reject:**
 >
 > 1. **`datasets` holds the whole dataset OBJECTS** returned by
->    `oracle_list_datasets` (the dicts with `asset`/`timeframe`/`file`/
->    `hash`/…), NOT bare filename strings. (A bare string → HTTP 422.)
+>    `oracle_list_datasets` (dicts with `asset`/`timeframe`/`file`/`hash`/…),
+>    NOT bare filename strings. (A bare string → HTTP 422.)
 > 2. **Every signal needs `signal_type`** (`"TRIGGER"` or `"FILTER"`) —
 >    the value of the catalog's `type` field. Omitting it → HTTP 422.
 > 3. **`entry_signals` requires at least one filter** and `min_filters ≥ 1`.
@@ -125,29 +187,28 @@ is the executable SDK shape, not the older curl-doc shape):
 
 Config rules of thumb:
 
-- **`search_mode`** — `"grid"` enumerates every parameter combination
-  (deterministic, exhaustive). `"random"` samples N combos (set
-  `n_random`) — use it when the full grid would exceed 99.
+- **The parameter space lives in `params_sweep`** on each signal — a dict
+  of `{param: {"values": [...]}}` or `{param: {"min": .., "max": .., "step": ..}}`.
+  Fixed params go in `params`. This is what the engine searches.
+- **`search_mode`** — `"grid"` enumerates parameter combinations;
+  `"random"` samples (Monte-Carlo). Use `"random"` when the space is huge
+  and you want a representative sample rather than exhaustive coverage.
+- **Sweep SIZE (how many backtests run) is controlled by you:**
+  - **grid:** `grid_signals.n_param_combos` caps the combos drawn from the
+    space (it does NOT run the full cross-product by default). Set it to
+    the number of runs you want (e.g. 24, 100, 500).
+  - **random:** `n_random` = number of samples.
+  - Pick the size deliberately and tell the user — this is what they're
+    paying compute for.
 - **`kind`** — `"single"` (one asset) is the default. `"pair"` is
-  continuous two-asset rotation (needs `pairs` + `rotation_params`,
-  random mode only) — only reach for it if the user explicitly wants
-  pair rotation.
-- **Keep the grid ≤ 99.** The engine refuses grids larger than 99
-  strategies. If the user's ranges blow past that, either narrow the
-  ranges, switch to `"random"` with `n_random ≤ 99`, or **pre-prune with
-  `/sieve`** and seed the sweep from the survivors.
-- **SIEVE pre-filter.** If supported by the config (`pre_filter` block),
-  enabling it lets the engine skip runs it predicts will produce no
-  trades — a free compute saving. Default it on for large grids.
+  continuous two-asset rotation (needs `pairs` + `rotation_params`, random
+  mode only) — only for explicit pair-rotation requests.
+- **`pre_filter`** — default `{enabled: true, confidence_threshold: 0.8}`
+  (binary SIEVE gate; see above). Skips configs predicted not to trade.
 - **`execution_config`** — `{"base": {}, "sweep_axes": []}` uses canonical
-  trading defaults. Only populate `base` (from `oracle_list_signals`'
-  sibling exec-config defaults) if the user wants specific risk settings,
-  and only add `sweep_axes` if they want to sweep an execution parameter
-  too.
-
-Do NOT ask the user to hand-write this. Translate their intent ("sweep
-MACD fast 8→16, slow 20→30 on BTC 1h") into the config yourself, citing
-the dataset + signals you pulled in Phase A.
+  trading defaults. Only populate `base` (from the exec-config defaults) if
+  the user wants specific risk settings; add `sweep_axes` only to sweep an
+  execution parameter too.
 
 ## Phase C — create → validate → launch
 
@@ -157,52 +218,53 @@ the dataset + signals you pulled in Phase A.
    It returns `{"valid": bool, "total_runs": int, "errors": [...],
    "warnings": [...]}`. Check `valid` and report `total_runs` to the user
    before paying to launch. If `valid` is `false`, the `errors` list says
-   why (bad signal name, params out of range, no entry filter, grid >
-   cap); fix the config with `oracle_update_experiment(experiment_id,
-   config)` (**only `draft` experiments are mutable**) and re-validate.
-   Surface the error verbatim — don't paper over it.
-   - *(Note: `oracle_validate_experiment` returns this validation result,
-     not a `status` field — the agent reads it straight from the server.)*
-3. `oracle_launch_experiment(experiment_id)` — fans the validated grid
+   why (bad signal name, params out of range, no entry filter, sweep
+   exceeds the tier's per-sweep cap); fix with
+   `oracle_update_experiment(experiment_id, config)` (**drafts only**) and
+   re-validate. Surface errors verbatim.
+   - *(`oracle_validate_experiment` returns the validation result, not a
+     `status` field — read it straight from the server.)*
+3. `oracle_launch_experiment(experiment_id)` — fans the validated search
    out asynchronously; returns `{"status": "preparing", "experiment_id":
    ..., "total_runs": ...}`.
 
-**Two different caps — know which surfaces where (verified live):**
+**Two tier caps — know which surfaces where (verified live). Note: there
+is NO fixed 99 limit on a sweep — that 99 is SIEVE's per-call cap, not the
+sweep's. Sweep size is bounded by your TIER:**
 
-- **Per-sweep size** (max backtests in one grid) — tier-dependent;
-  rejected at **validate** (HTTP 403 / `valid: false`). Shrink the grid,
-  switch to `random`, or pre-prune with `/sieve`.
-- **Concurrent sweeps in flight** — **plan-dependent, often just 1** on
-  the free tier; rejected at **launch** (HTTP 429, *"Concurrent sweep
-  limit reached: you have N sweep(s) already in flight; your plan allows
-  up to M"*). You can only run one sweep at a time — wait for the current
-  one to finish (poll Phase D), then launch the next. Relay the message
-  plainly and offer to wait or upgrade.
+- **Per-sweep size** = `max_backtests_per_sweep` for the caller's tier
+  (e.g. Pro 5,000 / Startup 20,000 / Enterprise 100,000). Enforced at
+  **validate** → HTTP 403 / `valid: false` if `total_runs` exceeds it.
+  Fix by shrinking `n_param_combos`/`n_random`, or the user upgrades tier.
+- **Concurrent sweeps in flight** = `concurrent_sweep_cap` (often 1 on
+  lower tiers). Enforced at **launch** → HTTP 429 (*"Concurrent sweep
+  limit reached…"*). Wait for the running one to finish (poll Phase D),
+  then launch. Relay the message plainly; offer to wait or upgrade.
 
-**Cost note:** `create` + `launch` each count as a billable Oracle
-experiment call (1 unit; the fan-out children are NOT billed
-individually). Tell the user before launching.
+**Cost note:** `create` + `launch` each count as one billable Oracle
+experiment call; the fan-out children are NOT billed individually. Tell
+the user before launching.
 
 ## Phase D — Poll
 
-The fan-out runs in the background. Track it without hammering the API:
+The fan-out runs in the background (cloud — these run as Cloud Run Jobs on
+the prod Oracle, not locally). Track it without hammering the API:
 
 - `oracle_get_experiment(experiment_id)` → `status` + `completed_runs`
-  (live progress against total).
+  (live progress against `total_runs`).
 - `oracle_list_results(experiment_id=...)` → results as they materialize,
   paginated.
 
 **Poll with patience, not a tight loop.** `oracle_list_results` is
-billable per call — prefer a larger page every several seconds over
-rapid small polls. Tell the user it's a background job and roughly how
-many runs to expect.
+billable per call — prefer a larger page every several seconds over rapid
+small polls. Tell the user it's a background job and roughly how many runs
+to expect.
 
 **If `oracle_list_results` returns a BigQuery / Parquet schema error**
 (e.g. *"column 'X' has type INT32 which does not match … BOOL"*), that is
-a **server-side corpus issue, not your config** — `get_experiment` still
+a **server-side corpus issue, not the config** — `get_experiment` still
 shows progress. Surface it as an Oracle-side problem, note the experiment
-ran, and don't blame the user's sweep. (Graceful downgrade, per
-`trading-bot-workflow.md`.)
+ran, and don't blame the user's sweep.
 
 ## Phase E — Rank + verdict + handoff
 
@@ -211,37 +273,38 @@ ran, and don't blame the user's sweep. (Graceful downgrade, per
 2. **Verdict against the same thresholds `/backtest` uses** (the 6 in
    `server/src/services/data/threshold_spec.json`: sortino ≥ 1.5,
    sharpe ≥ 1.2, calmar ≥ 1.0, irr_annualized ≥ 0.15, max_drawdown ≤ 0.7,
-   win_rate ≥ 0.25). A sweep result with `total_trades < 10` is
-   `INSUFFICIENT_TRADES`, not a winner — same rule as `/backtest`.
-3. **Benchmark-relative line.** Each result row carries
-   `benchmark_asset_return` / `benchmark_btc_return`. Report whether the
-   top strategy beat buy-and-hold, not just its absolute return.
-4. **Present the leaderboard** — top 5 by sortino, with the threshold
-   pass/fail and benchmark deltas — so the user can see the search, not
-   just the winner.
+   win_rate ≥ 0.25). A result with `total_trades < 10` is
+   `INSUFFICIENT_TRADES`, not a winner.
+3. **Benchmark-relative line.** Each row carries `benchmark_asset_return` /
+   `benchmark_btc_return`. Report whether the top strategy beat
+   buy-and-hold, not just absolute return.
+4. **Present the leaderboard** — top 5 by sortino, with threshold pass/fail
+   and benchmark deltas — so the user sees the search, not just the winner.
 5. **Confirm the winner before promotion.** Sweep runs are fast/coarse;
    register the winning config (`create_strategy_manual`) and hand to
    `/backtest` for a full single-strategy verdict on a properly sized
-   window. Only after that PASS does it go to paper (and live is further
-   gated on allocation + backup — see `trading-bot-workflow.md`).
+   window. Only after that PASS does it go to paper (live further gated on
+   allocation + backup — see `trading-bot-workflow.md`).
 
 ## Lifecycle housekeeping
 
 - `oracle_pause_experiment(id)` stops a running fan-out without losing
   completed results; relaunch to resume.
-- `oracle_delete_experiment(id)` removes it and cancels in-flight
-  children. Offer cleanup once the user has their winner.
+- `oracle_delete_experiment(id)` removes it and cancels in-flight children.
+  Offer cleanup once the user has their winner.
 
 ## Prohibited
 
-- **Never** call `launch` without a successful `validate` — the engine
-  rejects it, and you'd waste the round-trip.
-- **Never** try to mutate a non-draft experiment — `update` only works on
-  `draft`. Create a new one instead.
-- **Never** build a grid > 99 and hope — narrow it, switch to random, or
-  pre-prune with `/sieve`.
-- **Never** promote a sweep winner straight to paper/live on the sweep
-  metrics alone — confirm with a full `/backtest` first.
+- **Never** call `launch` without a successful `validate`.
+- **Never** mutate a non-draft experiment — `update` only works on `draft`.
+- **Never** claim a fixed "99" sweep limit — that's SIEVE's per-call cap.
+  Sweep size is the tier's `max_backtests_per_sweep`; control it with
+  `n_param_combos` / `n_random`.
+- **Never** describe a sweep as "screen with /sieve then run the survivors"
+  or "rank candidates by P(winning) before running" — the engine generates
+  its own candidates; the only in-sweep SIEVE is the binary pre-filter.
+- **Never** promote a sweep winner straight to paper/live on sweep metrics
+  alone — confirm with a full `/backtest` first.
 - **Never** tight-poll `oracle_list_results` — it's billable per call.
 - **Never** invent a metric or a run count; report what
   `oracle_validate_experiment` / `oracle_list_results` returned.
@@ -252,18 +315,19 @@ ran, and don't blame the user's sweep. (Graceful downgrade, per
 User wants to search a parameter space / rank many configs
 │
 ├─ Phase A: catalog — oracle_list_datasets + oracle_list_signals (+templates)
-│     → pick dataset(s) by file; confirm valid signal names + params
+│     → pick dataset object(s) by asset/timeframe; valid signal names by category
 │
-├─ Phase B: build the ExperimentConfig from the user's intent
-│     → grid vs random; keep ≤99; enable SIEVE pre-filter on big grids
-│     → pre-prune with /sieve if the grid would exceed 99
+├─ Phase B: build the ExperimentConfig (author directly OR via sweep-config.html)
+│     → params_sweep = the search space; grid (n_param_combos) vs random (n_random)
+│     → pre_filter {enabled:true, confidence_threshold:0.8} (binary SIEVE gate)
+│     → size it deliberately; tier cap (max_backtests_per_sweep), not 99
 │
 ├─ Phase C: oracle_create_experiment → oracle_validate_experiment → oracle_launch_experiment
-│     → READ validate response (total_runs / errors / tier caps)
-│     → fix-and-revalidate on error (drafts only); surface caps plainly
+│     → READ validate (total_runs / errors / tier cap 403); confirm cost before launch
+│     → concurrent cap → 429 at launch: wait, then launch
 │
 ├─ Phase D: poll oracle_get_experiment + oracle_list_results
-│     → background job; large pages, not tight loops (results reads bill)
+│     → background cloud job; large pages, not tight loops (results reads bill)
 │
 └─ Phase E: rank by sortino → verdict vs threshold_spec → benchmark line
       → present top-5 leaderboard

--- a/.claude/skills/sweep/sweep-config.html
+++ b/.claude/skills/sweep/sweep-config.html
@@ -1,0 +1,366 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Mangrove Sweep Config Builder</title>
+<!--
+  Lightweight, self-contained sweep-experiment config builder for the Mangrove Oracle engine.
+  It makes NO API calls (avoids CORS + keeps your API key out of the browser): it only BUILDS
+  the ExperimentConfig JSON. Flow:
+    1. The agent fetches /api/v1/oracle/signals + /datasets and fills the CATALOG block below
+       (or you load a catalog.json the agent saved next to this file).
+    2. You pick a dataset, signals (filter by category), and a parameter space.
+    3. Download config.json (or copy it).
+    4. Hand it back to the agent: it validates -> reports total_runs + cost -> confirms -> launches.
+  Field shapes mirror MangroveOracle src/models/experiment.py (ExperimentConfig).
+-->
+<style>
+  :root{
+    --bg:#f5f8f9; --panel:#fff; --line:#e2e8ec; --line2:#eef2f5; --ink:#16242e;
+    --muted:#647480; --brand:#2f93b3; --brand-deep:#1f6f88; --brand-soft:#e9f4f8;
+    --good:#1f9d57; --warn:#d9831a; --bad:#e0431a;
+  }
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--ink);
+    font-family:ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;font-size:14px;line-height:1.5}
+  header{background:var(--brand-deep);color:#fff;padding:14px 20px}
+  header h1{margin:0;font-size:17px;font-weight:650}
+  header p{margin:3px 0 0;font-size:12.5px;opacity:.85}
+  .wrap{max-width:980px;margin:18px auto;padding:0 16px;display:flex;flex-direction:column;gap:14px}
+  .panel{background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:15px 17px}
+  .panel h2{margin:0 0 10px;font-size:14px;font-weight:650;color:var(--brand-deep)}
+  label{display:block;font-size:12px;color:var(--muted);margin:8px 0 3px}
+  input[type=text],input[type=number],select,textarea{
+    width:100%;padding:7px 9px;border:1px solid var(--line);border-radius:7px;background:#fff;font:inherit;color:var(--ink)}
+  input:focus,select:focus,textarea:focus{outline:2px solid var(--brand)}
+  .row{display:flex;gap:10px;flex-wrap:wrap}
+  .row>div{flex:1;min-width:140px}
+  .pill{display:inline-block;padding:1px 8px;border-radius:20px;font-size:11px;background:var(--brand-soft);color:var(--brand-deep);margin-left:6px}
+  .sig{border:1px solid var(--line2);border-radius:9px;padding:10px 12px;margin:8px 0;background:#fbfdfe}
+  .sig .hd{display:flex;align-items:center;gap:8px;justify-content:space-between}
+  .sig .nm{font-weight:600}
+  .param{display:grid;grid-template-columns:150px 110px 1fr;gap:8px;align-items:center;margin-top:6px}
+  .param .pn{font-size:12.5px;color:var(--ink)}
+  button{font:inherit;border:0;border-radius:8px;padding:8px 13px;cursor:pointer;background:var(--brand);color:#fff;font-weight:600}
+  button.ghost{background:#fff;color:var(--brand-deep);border:1px solid var(--line)}
+  button.sm{padding:4px 9px;font-size:12px}
+  .muted{color:var(--muted);font-size:12px}
+  .est{font-size:13px;background:var(--brand-soft);border:1px solid var(--line);border-radius:8px;padding:9px 12px}
+  .est b{color:var(--brand-deep)}
+  .warnbox{background:#fff7ea;border:1px solid #f3d9a8;color:#7a4d05;border-radius:8px;padding:8px 11px;font-size:12.5px}
+  pre{background:#0f1c24;color:#cfe6ef;padding:12px;border-radius:9px;overflow:auto;font-size:12px;max-height:340px}
+  .cat-tabs{display:flex;gap:6px;flex-wrap:wrap;margin-bottom:6px}
+  .cat-tabs button{background:#fff;color:var(--muted);border:1px solid var(--line);font-weight:500}
+  .cat-tabs button.on{background:var(--brand);color:#fff;border-color:var(--brand)}
+  .grid2{display:grid;grid-template-columns:1fr 1fr;gap:10px}
+  .checkrow{display:flex;align-items:center;gap:8px;margin-top:6px}
+  .checkrow input{width:auto}
+</style>
+</head>
+<body>
+<header>
+  <h1>Mangrove Sweep Config Builder</h1>
+  <p>Builds an Oracle <code>ExperimentConfig</code> JSON. No API calls — download it and hand it back to the agent to validate &amp; launch.</p>
+</header>
+
+<div class="wrap">
+
+  <div class="panel" id="catalogPanel">
+    <h2>Catalog</h2>
+    <p class="muted" id="catStatus">Waiting for catalog. The agent embeds it in this file, or load a <code>catalog.json</code> the agent saved.</p>
+    <input type="file" id="catFile" accept="application/json" />
+  </div>
+
+  <div class="panel">
+    <h2>Experiment</h2>
+    <div class="row">
+      <div><label>Name</label><input type="text" id="name" placeholder="BTC 1h MACD momentum sweep" /></div>
+    </div>
+    <label>Description</label><input type="text" id="description" placeholder="Grid over MACD windows; one entry trigger, one exit trigger." />
+    <div class="row">
+      <div>
+        <label>Search mode</label>
+        <select id="search_mode">
+          <option value="grid">grid (enumerate combinations, capped)</option>
+          <option value="random">random (Monte-Carlo sample)</option>
+        </select>
+      </div>
+      <div id="sizeGrid">
+        <label>Grid: max param combos (<code>n_param_combos</code>)</label>
+        <input type="number" id="n_param_combos" value="24" min="1" />
+      </div>
+      <div id="sizeRandom" style="display:none">
+        <label>Random: samples (<code>n_random</code>)</label>
+        <input type="number" id="n_random" value="50" min="1" />
+      </div>
+    </div>
+  </div>
+
+  <div class="panel">
+    <h2>Dataset</h2>
+    <div class="row">
+      <div><label>Asset</label><select id="dsAsset"></select></div>
+      <div><label>Timeframe</label><select id="dsTf"></select></div>
+      <div style="flex:2"><label>Dataset (most recent first)</label><select id="dsPick"></select></div>
+    </div>
+    <p class="muted" id="dsInfo"></p>
+  </div>
+
+  <div class="panel">
+    <h2>Signals <span class="muted">— filter by category, add to a bucket</span></h2>
+    <div class="cat-tabs" id="catTabs"></div>
+    <div class="row">
+      <div><label>Signal</label><select id="sigPick"></select></div>
+      <div style="max-width:170px"><label>Add to</label>
+        <select id="sigBucket">
+          <option value="entry_triggers">Entry trigger</option>
+          <option value="entry_filters">Entry filter</option>
+          <option value="exit_triggers">Exit trigger</option>
+          <option value="exit_filters">Exit filter</option>
+        </select>
+      </div>
+      <div style="max-width:120px;display:flex;align-items:flex-end"><button class="sm" id="addSig">+ Add</button></div>
+    </div>
+    <div class="grid2" style="margin-top:10px">
+      <div><div class="muted">Entry triggers</div><div id="b_entry_triggers"></div></div>
+      <div><div class="muted">Entry filters (≥1 required)</div><div id="b_entry_filters"></div></div>
+      <div><div class="muted">Exit triggers</div><div id="b_exit_triggers"></div></div>
+      <div><div class="muted">Exit filters</div><div id="b_exit_filters"></div></div>
+    </div>
+  </div>
+
+  <div class="panel">
+    <h2>SIEVE pre-filter <span class="pill">binary head</span></h2>
+    <div class="checkrow">
+      <input type="checkbox" id="pf_enabled" checked />
+      <label style="margin:0">Skip configs predicted not to trade (recommended)</label>
+    </div>
+    <div class="row" style="margin-top:6px">
+      <div style="max-width:240px"><label>Skip if P(no_trades) &gt; threshold</label>
+        <input type="number" id="pf_threshold" value="0.8" min="0" max="1" step="0.05" /></div>
+    </div>
+    <p class="muted">Binary go/no-go gate only. The 4-class head is post-hoc and not used in sweeps.</p>
+  </div>
+
+  <div class="panel">
+    <h2>Review &amp; export</h2>
+    <div class="est" id="estimate">—</div>
+    <div id="warnings"></div>
+    <div style="margin:10px 0;display:flex;gap:10px;flex-wrap:wrap">
+      <button id="dlBtn">Download config.json</button>
+      <button class="ghost" id="copyBtn">Copy JSON</button>
+    </div>
+    <pre id="out">{}</pre>
+  </div>
+
+</div>
+
+<script>
+/* ===== CATALOG: the agent fills this. Shape:
+   { signals:[{name,type,params:{p:{type,min,max,default,optional}},category,requires}],
+     datasets:[{asset,timeframe,file,hash,rows,start_date,end_date}],
+     execDefaults:{...} }
+   Leave empty to load via the file picker (catalog.json). ===== */
+let CATALOG = { signals: [], datasets: [], execDefaults: {} };
+
+const $ = id => document.getElementById(id);
+const CATS = ["momentum","trend","volume","volatility","patterns"];
+let activeCat = "all";
+const buckets = { entry_triggers:[], entry_filters:[], exit_triggers:[], exit_filters:[] };
+
+function bootstrap(){
+  const ok = (CATALOG.signals||[]).length && (CATALOG.datasets||[]).length;
+  $("catStatus").innerHTML = ok
+    ? `Loaded <b>${CATALOG.signals.length}</b> signals, <b>${CATALOG.datasets.length}</b> datasets.`
+    : "No catalog yet — embed it in this file or load catalog.json below.";
+  if(!ok) return;
+  buildCatTabs(); buildDatasetPickers(); buildSignalPicker(); render();
+}
+
+/* ---- dataset pickers ---- */
+function buildDatasetPickers(){
+  const assets = [...new Set(CATALOG.datasets.map(d=>d.asset))].sort();
+  $("dsAsset").innerHTML = assets.map(a=>`<option>${a}</option>`).join("");
+  refreshTf();
+  $("dsAsset").onchange = refreshTf;
+  $("dsTf").onchange = refreshDsPick;
+  $("dsPick").onchange = ()=>{ showDsInfo(); render(); };
+}
+function refreshTf(){
+  const a=$("dsAsset").value;
+  const tfs=[...new Set(CATALOG.datasets.filter(d=>d.asset===a).map(d=>d.timeframe))].sort();
+  $("dsTf").innerHTML=tfs.map(t=>`<option>${t}</option>`).join(""); refreshDsPick();
+}
+function refreshDsPick(){
+  const a=$("dsAsset").value,t=$("dsTf").value;
+  const ds=CATALOG.datasets.filter(d=>d.asset===a&&d.timeframe===t)
+    .sort((x,y)=>(y.end_date||"").localeCompare(x.end_date||""));
+  $("dsPick").innerHTML=ds.map((d,i)=>`<option value="${d.file}">${d.start_date} → ${d.end_date} (${d.file})</option>`).join("");
+  showDsInfo(); render();
+}
+function currentDataset(){
+  const f=$("dsPick").value; return CATALOG.datasets.find(d=>d.file===f)||null;
+}
+function showDsInfo(){ const d=currentDataset(); $("dsInfo").textContent = d?`Window: ${d.start_date} → ${d.end_date}`:""; }
+
+/* ---- signal catalog ---- */
+function buildCatTabs(){
+  const tabs=["all",...CATS];
+  $("catTabs").innerHTML=tabs.map(c=>`<button data-c="${c}" class="${c===activeCat?'on':''}">${c}</button>`).join("");
+  $("catTabs").querySelectorAll("button").forEach(b=>b.onclick=()=>{activeCat=b.dataset.c;buildCatTabs();buildSignalPicker();});
+}
+function buildSignalPicker(){
+  const sigs=CATALOG.signals.filter(s=>activeCat==="all"||s.category===activeCat)
+    .sort((a,b)=>a.name.localeCompare(b.name));
+  $("sigPick").innerHTML=sigs.map(s=>`<option value="${s.name}">${s.name} — ${s.type} · ${s.category||"?"}</option>`).join("");
+}
+$("addSig").onclick=()=>{
+  const name=$("sigPick").value, bucket=$("sigBucket").value;
+  const meta=CATALOG.signals.find(s=>s.name===name); if(!meta) return;
+  const isFilter=bucket.endsWith("filters");
+  const entry={ name, signal_type: isFilter?"FILTER":"TRIGGER", timeframe:"1h",
+    params:{}, params_sweep:{}, _spec:meta.params||{}, _modes:{} };
+  for(const [p,spec] of Object.entries(meta.params||{})){
+    entry._modes[p]="fixed";
+    entry.params[p]= spec.default!=null?spec.default:(spec.min!=null?spec.min:0);
+  }
+  buckets[bucket].push(entry); renderBuckets(); render();
+};
+
+function renderBuckets(){
+  for(const b of Object.keys(buckets)){
+    const host=$("b_"+b);
+    host.innerHTML = buckets[b].length? "" : `<span class="muted">none</span>`;
+    buckets[b].forEach((e,idx)=>host.appendChild(sigCard(b,e,idx)));
+  }
+}
+function sigCard(bucket,e,idx){
+  const wrap=document.createElement("div"); wrap.className="sig";
+  const hd=document.createElement("div"); hd.className="hd";
+  hd.innerHTML=`<span class="nm">${e.name} <span class="pill">${e.signal_type}</span></span>`;
+  const rm=document.createElement("button"); rm.className="ghost sm"; rm.textContent="remove";
+  rm.onclick=()=>{buckets[bucket].splice(idx,1);renderBuckets();render();};
+  hd.appendChild(rm); wrap.appendChild(hd);
+  for(const [p,spec] of Object.entries(e._spec)){
+    const row=document.createElement("div"); row.className="param";
+    const lo=spec.min!=null?` [${spec.min}–${spec.max}]`:"";
+    row.innerHTML=`<span class="pn">${p}<span class="muted">${lo}</span></span>`;
+    const mode=document.createElement("select");
+    mode.innerHTML=`<option value="fixed">fixed</option><option value="values">sweep: values</option><option value="range">sweep: min/max/step</option>`;
+    mode.value=e._modes[p]||"fixed";
+    const val=document.createElement("div");
+    const draw=()=>{
+      e._modes[p]=mode.value;
+      if(mode.value==="fixed"){
+        val.innerHTML=`<input type="number" value="${e.params[p]??0}">`;
+        val.querySelector("input").oninput=ev=>{e.params[p]=num(ev.target.value);render();};
+      }else if(mode.value==="values"){
+        const cur=(e.params_sweep[p]&&e.params_sweep[p].values||[]).join(",");
+        val.innerHTML=`<input type="text" placeholder="e.g. 8,12,16" value="${cur}">`;
+        val.querySelector("input").oninput=ev=>{e.params_sweep[p]={values:parseList(ev.target.value)};render();};
+      }else{
+        const s=e.params_sweep[p]||{};
+        val.innerHTML=`<div class="row" style="gap:6px">
+          <input type="number" placeholder="min" value="${s.min??''}" data-k="min" style="min-width:60px">
+          <input type="number" placeholder="max" value="${s.max??''}" data-k="max" style="min-width:60px">
+          <input type="number" placeholder="step" value="${s.step??''}" data-k="step" style="min-width:60px"></div>`;
+        val.querySelectorAll("input").forEach(inp=>inp.oninput=()=>{
+          const o={}; val.querySelectorAll("input").forEach(x=>{if(x.value!=="")o[x.dataset.k]=num(x.value);});
+          e.params_sweep[p]=o; render();
+        });
+      }
+    };
+    mode.onchange=()=>{ if(mode.value!=="fixed"){delete e.params[p];} else {delete e.params_sweep[p];e.params[p]=0;} draw(); render(); };
+    draw();
+    row.appendChild(mode); row.appendChild(val); wrap.appendChild(row);
+  }
+  return wrap;
+}
+
+/* ---- helpers ---- */
+const num=v=>{const n=Number(v);return Number.isInteger(n)?n:(isNaN(n)?0:n);};
+const parseList=s=>s.split(",").map(x=>x.trim()).filter(Boolean).map(num);
+function rangeCount(o){ if(o.min==null||o.max==null||!o.step) return o.min!=null?1:0; return Math.floor((o.max-o.min)/o.step+1e-9)+1; }
+function spaceSize(){
+  let prod=1, swept=0;
+  for(const b of Object.values(buckets)) for(const e of b)
+    for(const [p,mode] of Object.entries(e._modes||{})){
+      if(mode==="values"){const v=(e.params_sweep[p]||{}).values||[]; if(v.length){prod*=v.length;swept++;}}
+      else if(mode==="range"){const c=rangeCount(e.params_sweep[p]||{}); if(c>1){prod*=c;swept++;}}
+    }
+  return swept?prod:1;
+}
+
+/* ---- mode toggle ---- */
+$("search_mode").onchange=()=>{
+  const g=$("search_mode").value==="grid";
+  $("sizeGrid").style.display=g?"":"none"; $("sizeRandom").style.display=g?"none":""; render();
+};
+["name","description","n_param_combos","n_random","pf_enabled","pf_threshold","dsPick"].forEach(id=>{
+  const el=$(id); if(el) el.addEventListener("input",render);
+});
+
+/* ---- build config + estimate ---- */
+function buildConfig(){
+  const ds=currentDataset();
+  const mode=$("search_mode").value;
+  const mapBucket=arr=>arr.map(e=>{
+    const o={name:e.name,signal_type:e.signal_type,timeframe:e.timeframe};
+    if(Object.keys(e.params).length) o.params={...e.params};
+    if(Object.keys(e.params_sweep).length) o.params_sweep={...e.params_sweep};
+    return o;
+  });
+  const cfg={
+    name:$("name").value||"untitled sweep",
+    description:$("description").value||"",
+    search_mode:mode,
+    kind:"single",
+    datasets: ds?[ds]:[],
+    entry_signals:{ triggers:mapBucket(buckets.entry_triggers), filters:mapBucket(buckets.entry_filters), min_filters:1, max_filters:Math.max(1,buckets.entry_filters.length) },
+    exit_signals:{ triggers:mapBucket(buckets.exit_triggers), filters:mapBucket(buckets.exit_filters) },
+    execution_config:{ base:{}, sweep_axes:[] },
+    pre_filter:{ enabled:$("pf_enabled").checked, confidence_threshold:Number($("pf_threshold").value) }
+  };
+  if(mode==="grid") cfg.grid_signals={ n_param_combos:parseInt($("n_param_combos").value||"24",10) };
+  else cfg.n_random=parseInt($("n_random").value||"50",10);
+  return cfg;
+}
+function render(){
+  const cfg=buildConfig();
+  $("out").textContent=JSON.stringify(cfg,null,2);
+  // estimate
+  const full=spaceSize();
+  const mode=cfg.search_mode;
+  let runs;
+  if(mode==="grid"){ const cap=cfg.grid_signals.n_param_combos; runs=Math.min(full,cap);
+    $("estimate").innerHTML=`Parameter space ≈ <b>${full}</b> combos · grid cap <b>${cap}</b> → will run <b>${runs}</b> backtests. <span class="muted">(grid samples up to the cap; raise n_param_combos for more.)</span>`;
+  } else { runs=cfg.n_random;
+    $("estimate").innerHTML=`Random/Monte-Carlo: <b>${runs}</b> samples from a space of ≈ <b>${full}</b> combos.`;
+  }
+  // warnings
+  const w=[];
+  if(!cfg.datasets.length) w.push("Pick a dataset.");
+  if(!cfg.entry_signals.triggers.length) w.push("Add at least one entry trigger.");
+  if(!cfg.entry_signals.filters.length) w.push("Entry requires ≥1 filter (engine rejects otherwise).");
+  w.push("Sweep size is bounded by your tier's max_backtests_per_sweep at validate — there is no fixed 99 limit.");
+  $("warnings").innerHTML = w.map((m,i)=>`<div class="${i<w.length-1?'warnbox':'muted'}" style="margin-top:6px">${m}</div>`).join("");
+}
+
+/* ---- export ---- */
+$("dlBtn").onclick=()=>{
+  const blob=new Blob([JSON.stringify(buildConfig(),null,2)],{type:"application/json"});
+  const a=document.createElement("a"); a.href=URL.createObjectURL(blob); a.download="config.json"; a.click();
+};
+$("copyBtn").onclick=()=>navigator.clipboard.writeText(JSON.stringify(buildConfig(),null,2));
+
+/* ---- catalog.json loader (file://-safe) ---- */
+$("catFile").onchange=ev=>{
+  const f=ev.target.files[0]; if(!f) return;
+  const r=new FileReader(); r.onload=()=>{ try{ CATALOG=JSON.parse(r.result); bootstrap(); }catch(e){ alert("Bad catalog.json: "+e); } }; r.readAsText(f);
+};
+
+bootstrap();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
Fixes the SIEVE/sweep conflation in the agent skills and ships a lightweight sweep-config HTML builder.

**Root cause (verified in Oracle engine code):**
- The `99` cap is **SIEVE-only** (`src/api/routes/sieve.py MAX_ITEMS_PER_REQUEST = 99`). Sweeps have no 99 limit.
- Sweep size is the tier's `max_backtests_per_sweep` (Pro 5,000), enforced at `validate` (403).
- SIEVE-in-sweep = the **binary** `P(no_trades)` pre-filter only; the **4-class** head is post-hoc/replay.
- A sweep **generates its own candidates** from a parameter space — you don't 'prune a grid with /sieve and sweep the survivors.'

## Changes
- **`sweep/SKILL.md`** — rewritten: 99-myth removed → tier cap; binary `pre_filter` default ON @0.8; 4-class flagged post-hoc; sweep-size controls (`n_param_combos`/`n_random`); new 'configure via HTML' path (agent embeds catalog, validates, **confirms before launch**).
- **`sieve/SKILL.md`** — screens a *fixed shortlist* → `/backtest`/`/backtest/bulk` (not `/sweep`); both heads labeled 'screen, not a verdict'.
- **`sweep-config.html`** (new) — single self-contained file, signals filterable by category, `pre_filter` pre-checked @0.8, outputs `config.json`; makes no API calls (CORS-safe). JS syntax-checked.

## Verification
Live prod sweep with the corrected config (binary pre-filter @0.8) — numbers in the PR thread.
Paired docs fix: MangroveKnowledgeBase PR (linked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)