### PR TITLE
fix(oracle): confirm sweep launch via poll on gateway 504 (MangroveOracle#296)

### DIFF
--- a/server/src/api/routes/oracle.py
+++ b/server/src/api/routes/oracle.py
@@ -280,10 +280,13 @@ async def post_validate_experiment(experiment_id: str) -> dict[str, Any]:
     "/experiments/{experiment_id}/launch",
     summary="Fan out a validated experiment into child backtests",
     description=(
-        "Up to 99 child backtests per launch. Returns immediately with "
-        "``status: 'launched'`` — the fan-out is asynchronous. Poll "
-        "``GET /experiments/{id}`` for completion progress or "
-        "``GET /results?experiment_id={id}`` for materializing results."
+        "Up to 99 child backtests per launch. The fan-out is asynchronous — "
+        "poll ``GET /experiments/{id}`` for completion progress or "
+        "``GET /results?experiment_id={id}`` for materializing results. "
+        "Launch is non-idempotent and may take several seconds; this endpoint "
+        "confirms the launch took effect (polling on an upstream gateway "
+        "timeout) before returning, so a success response means the sweep is "
+        "running — do not re-launch."
     ),
 )
 async def post_launch_experiment(experiment_id: str) -> dict[str, Any]:

--- a/server/src/mcp/tools.py
+++ b/server/src/mcp/tools.py
@@ -2882,10 +2882,12 @@ def _register_oracle(server: FastMCP) -> None:
     async def oracle_launch_experiment(experiment_id: str, api_key: str = "") -> str:
         """Fan out a validated experiment into child backtests.
 
-        Up to 99 children per launch. Returns immediately with
-        ``status: 'launched'`` — the fan-out is asynchronous. Poll
+        Up to 99 children per launch. The fan-out is asynchronous — poll
         ``oracle_get_experiment(id)`` for progress or
         ``oracle_list_results(experiment_id=id)`` for materializing rows.
+        Launch is non-idempotent; a success here means the sweep is running
+        (confirmed even if the upstream gateway timed out) — do NOT re-launch,
+        just poll.
 
         Bills: 1 unit per HTTP call (children not billed individually).
         """

--- a/server/src/services/oracle.py
+++ b/server/src/services/oracle.py
@@ -12,8 +12,10 @@ forward.
 """
 from __future__ import annotations
 
+import time
 from typing import Any
 
+from mangrove_ai.exceptions import APIError
 from mangrove_ai.models.oracle import (
     DataQueryRequest,
     OracleBacktestRequest,
@@ -299,14 +301,61 @@ def validate_experiment(experiment_id: str) -> dict[str, Any]:
 
 
 def launch_experiment(experiment_id: str) -> dict[str, Any]:
-    """Fan out a validated experiment into up to 99 child backtests."""
+    """Fan out a validated experiment into up to 99 child backtests.
+
+    Launch is asynchronous and non-idempotent. The call can return a gateway 504
+    even though the launch SUCCEEDED server-side (MangroveOracle#296); we do NOT
+    re-send it (a retry would hit the single-flight 409 / concurrent-cap 429). On
+    a gateway 5xx we confirm by polling ``get_experiment`` until the experiment
+    leaves ``validated``/``draft``. Returns the launch status body; callers keep
+    polling ``get_experiment`` for completion.
+    """
     client = mangrove_ai_client()
-    result = client.oracle.launch_experiment(experiment_id)
+    try:
+        body = client.oracle.launch_experiment(experiment_id).model_dump()
+    except APIError as exc:
+        if getattr(exc, "status_code", None) not in (502, 503, 504):
+            raise
+        _log.warning(
+            "oracle.launch_experiment gateway_timeout — confirming via poll",
+            extra={"experiment_id": experiment_id, "status_code": exc.status_code},
+        )
+        body = _confirm_launch(client, experiment_id)
     _log.info(
         "oracle.launch_experiment",
-        extra={"experiment_id": experiment_id, "status": result.status},
+        extra={"experiment_id": experiment_id, "status": body.get("status")},
     )
-    return result.model_dump()
+    return body
+
+
+def _confirm_launch(
+    client: Any,
+    experiment_id: str,
+    *,
+    poll_interval: float = 3.0,
+    timeout: float = 120.0,
+) -> dict[str, Any]:
+    """Confirm a launch that returned a gateway 5xx actually took effect.
+
+    Polls ``get_experiment`` until the experiment leaves ``validated``/``draft``
+    (proof the launch ran), returning a normalized status body. Raises
+    ``TimeoutError`` if the status never advances within ``timeout``.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        exp = client.oracle.get_experiment(experiment_id)
+        if exp.get("status") not in ("validated", "draft", None):
+            return {
+                "experiment_id": experiment_id,
+                "status": exp.get("status"),
+                "total_runs": exp.get("total_runs"),
+                "confirmed_via": "poll",
+            }
+        time.sleep(poll_interval)
+    raise TimeoutError(
+        f"Experiment {experiment_id} did not leave 'validated' within {timeout:.0f}s "
+        f"after launch"
+    )
 
 
 def pause_experiment(experiment_id: str) -> dict[str, Any]:

--- a/server/tests/unit/test_oracle.py
+++ b/server/tests/unit/test_oracle.py
@@ -252,3 +252,55 @@ class TestPauseExperiment:
             "POST", "/oracle/experiments/exp_20260606T011615775405Z/pause"
         )
         assert result == {"status": "paused"}
+
+
+class TestLaunchExperimentPollOn504:
+    """WS4 (MangroveOracle#296): launch is non-idempotent; a gateway 504 may have
+    succeeded server-side, so the service confirms via polling instead of failing
+    or re-launching."""
+
+    def test_happy_path_returns_status_without_polling(self, monkeypatch):
+        from src.services.oracle import launch_experiment
+
+        client = MagicMock()
+        result = MagicMock()
+        result.model_dump.return_value = {"status": "preparing", "experiment_id": "e1", "total_runs": 72}
+        client.oracle.launch_experiment.return_value = result
+        monkeypatch.setattr("src.services.oracle.mangrove_ai_client", lambda: client)
+
+        body = launch_experiment("e1")
+        assert body["status"] == "preparing"
+        client.oracle.get_experiment.assert_not_called()  # no poll on success
+
+    def test_gateway_504_confirms_via_poll(self, monkeypatch):
+        from mangrove_ai.exceptions import APIError
+
+        from src.services.oracle import launch_experiment
+
+        client = MagicMock()
+        client.oracle.launch_experiment.side_effect = APIError(504, "timeout", "gw", "GATEWAY_TIMEOUT")
+        # first poll still validated, then advanced to preparing
+        client.oracle.get_experiment.side_effect = [
+            {"status": "validated"},
+            {"status": "preparing", "total_runs": 72},
+        ]
+        monkeypatch.setattr("src.services.oracle.mangrove_ai_client", lambda: client)
+        monkeypatch.setattr("src.services.oracle.time.sleep", lambda *_: None)
+
+        body = launch_experiment("e1")
+        assert body["status"] == "preparing"
+        assert body["confirmed_via"] == "poll"
+        assert client.oracle.launch_experiment.call_count == 1  # never re-launched
+
+    def test_non_gateway_error_reraises(self, monkeypatch):
+        from mangrove_ai.exceptions import APIError
+
+        from src.services.oracle import launch_experiment
+
+        client = MagicMock()
+        client.oracle.launch_experiment.side_effect = APIError(400, "bad", "nope", "BAD")
+        monkeypatch.setattr("src.services.oracle.mangrove_ai_client", lambda: client)
+
+        with pytest.raises(APIError):
+            launch_experiment("e1")
+        client.oracle.get_experiment.assert_not_called()


### PR DESCRIPTION
WS4 of the MangroveOracle #296 remediation — make the agent's sweep-launch path resilient to the 504-but-succeeded behavior.

## Problem
Oracle's launch is non-idempotent and can return a gateway 504 even though it **succeeded** server-side. The agent passed that 504 straight to its callers, and its route + MCP-tool docstrings claimed launch "returns immediately with `status: 'launched'`".

## Fix
`oracle_service.launch_experiment` now catches a gateway **5xx (502/503/504)** and confirms the launch took effect by polling `get_experiment` until the experiment leaves `validated`/`draft` (returning a normalized body with `confirmed_via: "poll"`), instead of re-sending the non-idempotent POST. Non-gateway errors still surface. Route description + MCP-tool docstring updated to document the poll-after-launch contract ("a success means the sweep is running — do not re-launch").

This is correct regardless of SDK version (works with both the old retry-on-504 SDK and the new idempotent-only one in MangroveAI-SDK #28).

## Tests / verification
`tests/unit/test_oracle.py` +3: happy path returns status without polling; gateway 504 confirms via poll and **launches exactly once**; non-gateway error re-raises. **11 oracle unit tests green** (venv install of server reqs), ruff clean.

Part of #296 (with MangroveOracle #302, MangroveAI gateway-deadline #675, MangroveAI-SDK #28). KB docs follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)