### PR TITLE
feat(mcp): expose 5 DeFiLlama Pro tools to the agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,8 @@ Wallet setup and live trading are in Chapters 06 and 07 of the tutorial. The sum
 | Execution | `list_positions`, `get_position`, `list_trade_history` |
 | Logs | `list_evaluations`, `list_trades`, `list_all_trades` |
 | Knowledge Base | `kb_search`, `list_docs`, `get_doc` |
-| DeFi | `get_protocol_tvl` |
+| DeFi | `get_protocol_tvl`, `get_chain_tvl`, `get_stablecoin_metrics` |
+| DeFi Pro (Pro/Startup/Enterprise) | `get_token_unlocks`, `get_perp_funding`, `get_treasuries`, `get_etf_flows`, `get_lending_borrow_rates` |
 | Oracle research | `sieve_score`, `oracle_create_experiment`, `oracle_validate_experiment`, `oracle_launch_experiment`, `oracle_pause_experiment`, `oracle_get_experiment`, `oracle_list_experiments`, `oracle_data_query`, `oracle_backtest`, `oracle_backtest_async`, `oracle_backtest_poll`, `oracle_backtest_bulk`, `oracle_list_results`, `oracle_list_datasets`, `oracle_list_signals`, `oracle_list_templates` |
 
 Every tool has a mirrored REST endpoint at `/api/v1/agent/*`. Both call the same service layer — pick whichever fits your caller.

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Wallet setup and live trading are in Chapters 06 and 07 of the tutorial. The sum
 | Logs | `list_evaluations`, `list_trades`, `list_all_trades` |
 | Knowledge Base | `kb_search`, `list_docs`, `get_doc` |
 | DeFi | `get_protocol_tvl`, `get_chain_tvl`, `get_stablecoin_metrics` |
-| DeFi Pro (Pro/Startup/Enterprise) | `get_token_unlocks`, `get_perp_funding`, `get_treasuries`, `get_etf_flows`, `get_lending_borrow_rates` |
+| DeFi Pro (Pro/Startup/Enterprise) | `get_token_unlocks`, `get_perp_funding`, `get_treasuries`, `get_etf_flows`, `get_lending_borrow_rates` — starter: [docs/defi-pro.md](docs/defi-pro.md) |
 | Oracle research | `sieve_score`, `oracle_create_experiment`, `oracle_validate_experiment`, `oracle_launch_experiment`, `oracle_pause_experiment`, `oracle_get_experiment`, `oracle_list_experiments`, `oracle_data_query`, `oracle_backtest`, `oracle_backtest_async`, `oracle_backtest_poll`, `oracle_backtest_bulk`, `oracle_list_results`, `oracle_list_datasets`, `oracle_list_signals`, `oracle_list_templates` |
 
 Every tool has a mirrored REST endpoint at `/api/v1/agent/*`. Both call the same service layer — pick whichever fits your caller.

--- a/docs/defi-pro.md
+++ b/docs/defi-pro.md
@@ -1,0 +1,66 @@
+# DeFi Pro tools — starter
+
+Five DeFiLlama **Pro** analytics tools are exposed over MCP. They surface the
+paid DeFiLlama API tier through MangroveAI, so the same access rules apply.
+
+| Tool | Returns |
+|---|---|
+| `get_token_unlocks` | token unlock schedules + supply metrics (supply-shock signal) |
+| `get_perp_funding` | aggregated perpetual funding rates across venues |
+| `get_treasuries` | protocol treasury holdings (crowd-positioning signal) |
+| `get_etf_flows` | ETF net flows |
+| `get_lending_borrow_rates` | lending / borrow rates across markets |
+
+The free DeFi tools (`get_protocol_tvl`, `get_chain_tvl`, `get_stablecoin_metrics`)
+work on any plan and need no special entitlement.
+
+## Access rules
+
+- **Plan**: the five Pro tools require a **Pro, Startup, or Enterprise** plan.
+  On an unentitled plan the tool returns an error carrying
+  `code: TIER_UPGRADE_REQUIRED` (HTTP 403 upstream) — upgrade to use them.
+- **x402**: an x402-paid call pays per request and is not subscription-checked.
+- **Monthly cap**: 1,000 Pro calls per account per month. Past the cap the tool
+  returns `error: quota_exceeded` (HTTP 429 upstream). The cap is uniform across
+  paid tiers and protects the shared DeFiLlama budget.
+
+## 1. Configure the MCP server (Claude Code)
+
+Copy the drop-in config and add your MangroveAI key:
+
+```bash
+cp .mcp.json.example .mcp.json
+# edit .mcp.json: set MANGROVE_API_KEY to a key on a Pro/Startup/Enterprise plan
+```
+
+Restart Claude Code so it picks up the MCP server, then verify the tools are
+registered:
+
+```bash
+./scripts/verify_quickstart.sh --bare   # tool catalog should include the DeFi Pro tools
+```
+
+## 2. Call a Pro tool
+
+Ask the agent (it routes to the MCP tool):
+
+> "What token unlocks are coming up? Use get_token_unlocks."
+
+Or invoke the tool directly from any MCP client. Each tool takes a single
+optional `api_key` argument (falls back to the server-configured key) and
+returns the JSON envelope:
+
+```json
+{ "success": true, "count": 338, "data": [ { "name": "Chainlink", "circSupply": 748009578.99, "events": [ ... ] }, ... ] }
+```
+
+On an unentitled plan you get `{"error": "...", "code": "TIER_UPGRADE_REQUIRED"}`;
+past the monthly cap, `{"error": "quota_exceeded", "resource_type": "defillama_pro_calls"}`.
+
+## Programmatic use (SDK)
+
+For scripts/services, the MangroveAI SDK is the quickest path —
+`pip install mangroveai`, then see `examples/defi_pro.py` in the SDK repo for one
+runnable call per Pro method with 403/429 handling. The SDK methods are
+`client.defi.get_token_unlocks()` / `get_perp_funding()` / `get_treasuries()` /
+`get_etf_flows()` / `get_lending_borrow_rates()`.

--- a/server/src/mcp/tools.py
+++ b/server/src/mcp/tools.py
@@ -1559,7 +1559,13 @@ def _register_on_chain(server: FastMCP) -> None:
 
 
 def _register_defi(server: FastMCP) -> None:
-    """Macro DeFi metrics (TVL, stablecoin supply)."""
+    """Macro DeFi metrics (TVL, stablecoin supply) + DeFiLlama Pro signals.
+
+    The Pro tools (token unlocks, perp funding, treasuries, ETF flows, lending
+    rates) require the caller's plan to include DeFi Pro (Pro / Startup /
+    Enterprise). On an unentitled plan the underlying call returns 403 and the
+    tool surfaces a structured error advising an upgrade.
+    """
     from src.shared.clients.mangrove import mangrove_ai_client
 
     @server.tool()
@@ -1615,6 +1621,93 @@ def _register_defi(server: FastMCP) -> None:
     register_tool(ToolEntry(
         name="get_stablecoin_metrics",
         description="Stablecoin supply + flow metrics (macro liquidity proxy).",
+        access="auth",
+        parameters=[_APIKEY],
+    ))
+
+    # --- DeFiLlama Pro (require a Pro / Startup / Enterprise plan) -----------
+
+    @server.tool()
+    async def get_token_unlocks(api_key: str = "") -> str:
+        """Token unlock schedules + supply metrics (supply-shock signal). Pro plan."""
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            return json.dumps(_dump(mangrove_ai_client().defi.get_token_unlocks()))
+        except Exception as e:  # noqa: BLE001
+            return _err("DEFI_TOKEN_UNLOCKS_FAILED", str(e))
+
+    register_tool(ToolEntry(
+        name="get_token_unlocks",
+        description="Token unlock schedules + supply metrics across tokens (tradeable supply-shock signal). Requires a Pro/Startup/Enterprise plan.",
+        access="auth",
+        parameters=[_APIKEY],
+    ))
+
+    @server.tool()
+    async def get_perp_funding(api_key: str = "") -> str:
+        """Aggregated DeFi perpetual funding rates across venues. Pro plan."""
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            return json.dumps(_dump(mangrove_ai_client().defi.get_perp_funding()))
+        except Exception as e:  # noqa: BLE001
+            return _err("DEFI_PERP_FUNDING_FAILED", str(e))
+
+    register_tool(ToolEntry(
+        name="get_perp_funding",
+        description="Aggregated DeFi perpetual funding rates across venues. Requires a Pro/Startup/Enterprise plan.",
+        access="auth",
+        parameters=[_APIKEY],
+    ))
+
+    @server.tool()
+    async def get_treasuries(api_key: str = "") -> str:
+        """Protocol treasury holdings (crowd-positioning signal). Pro plan."""
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            return json.dumps(_dump(mangrove_ai_client().defi.get_treasuries()))
+        except Exception as e:  # noqa: BLE001
+            return _err("DEFI_TREASURIES_FAILED", str(e))
+
+    register_tool(ToolEntry(
+        name="get_treasuries",
+        description="Protocol treasury holdings (crowd-positioning signal). Requires a Pro/Startup/Enterprise plan.",
+        access="auth",
+        parameters=[_APIKEY],
+    ))
+
+    @server.tool()
+    async def get_etf_flows(api_key: str = "") -> str:
+        """Crypto ETF net flows (institutional flow signal). Pro plan."""
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            return json.dumps(_dump(mangrove_ai_client().defi.get_etf_flows()))
+        except Exception as e:  # noqa: BLE001
+            return _err("DEFI_ETF_FLOWS_FAILED", str(e))
+
+    register_tool(ToolEntry(
+        name="get_etf_flows",
+        description="Crypto ETF net flows (institutional flow signal; daily BTC ETF flows correlate with spot). Requires a Pro/Startup/Enterprise plan.",
+        access="auth",
+        parameters=[_APIKEY],
+    ))
+
+    @server.tool()
+    async def get_lending_borrow_rates(api_key: str = "") -> str:
+        """Lending-pool borrow rates (rate-spread features). Pro plan."""
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            return json.dumps(_dump(mangrove_ai_client().defi.get_lending_borrow_rates()))
+        except Exception as e:  # noqa: BLE001
+            return _err("DEFI_LENDING_RATES_FAILED", str(e))
+
+    register_tool(ToolEntry(
+        name="get_lending_borrow_rates",
+        description="DeFi lending-pool borrow rates (rate-spread features). Requires a Pro/Startup/Enterprise plan.",
         access="auth",
         parameters=[_APIKEY],
     ))

--- a/server/tests/integration/test_mcp_tools.py
+++ b/server/tests/integration/test_mcp_tools.py
@@ -62,6 +62,10 @@ CORE_TOOLS = {
     "list_evaluations", "list_trades", "list_all_trades",
     # kb
     "kb_search",
+    # defi (DeFiLlama; the Pro tools require a Pro/Startup/Enterprise plan)
+    "get_protocol_tvl", "get_chain_tvl", "get_stablecoin_metrics",
+    "get_token_unlocks", "get_perp_funding", "get_treasuries",
+    "get_etf_flows", "get_lending_borrow_rates",
     # x402 demo
     "hello_mangrove",
 }


### PR DESCRIPTION
## Phase 4 of the DeFiLlama Pro program (agent layer)

Exposes the MangroveAI DeFi Pro endpoints as MCP tools so agents can call them. Completes the vertical: Roots provider (#59) -> MangroveAI tier-gated API (#696) -> SDK methods (#30) -> **agent MCP tools (this PR)**.

### Tools added (in `_register_defi`)
| Tool | SDK method | MangroveAI endpoint |
|---|---|---|
| `get_token_unlocks` | `defi.get_token_unlocks()` | `GET /defi/token-unlocks` |
| `get_perp_funding` | `defi.get_perp_funding()` | `GET /defi/perp-funding` |
| `get_treasuries` | `defi.get_treasuries()` | `GET /defi/treasuries` |
| `get_etf_flows` | `defi.get_etf_flows()` | `GET /defi/etf-flows` |
| `get_lending_borrow_rates` | `defi.get_lending_borrow_rates()` | `GET /defi/lending-rates` |

Each mirrors the existing `_register_defi` pattern (api_key auth via `_require`/`_auth_error`, `_dump`/`_err` envelope) and notes **"Requires a Pro/Startup/Enterprise plan."** in its description.

### Tier gating
The gate is enforced **server-side by MangroveAI** (`@require_feature('defi_pro')`): free/beginner/intermediate get a 403 + upgrade message; pro/startup/enterprise/custom pass. **x402 payers bypass the subscription check** (they pay per-call in the 402 mechanism). The agent does not re-implement gating -- it surfaces whatever MangroveAI returns.

### Tests / docs
- Added all 8 DeFi tools (3 existing + 5 new) to `CORE_TOOLS` so `test_all_expected_tools_registered` asserts they register.
- README DeFi table updated with a dedicated **DeFi Pro (Pro/Startup/Enterprise)** row.

### Local verification
- `pytest tests/` -> **385 passed, 2 skipped** (venv with `requirements.txt`)
- `tests/integration/test_mcp_tools.py` -> **6 passed** (registration of all 5 new tools asserted)
- `ruff check` -> clean

### Dependency note
Agent SDK pin stays `mangroveai>=1.6.0,<2.0.0`. The new SDK methods arrive via the `<2.0.0` ceiling once **SDK v1.7.3 is published**. Live agent->SDK->MangroveAI calls are gated on that publish + the MangroveAI Phase 2 prod deploy (both pending, user-timed). Registration/wiring is verified now; the live call is provable post-promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)