### PR TITLE
fix(install): use a >=3.10 interpreter for the venv, not bare python3 (#100)

### DIFF
--- a/scripts/run-bare.sh
+++ b/scripts/run-bare.sh
@@ -34,19 +34,32 @@ ok()   { printf "${GREEN}  ✓${CLR} %s\n" "$1"; }
 fail() { printf "${RED}  ✗${CLR} %s\n" "$1" >&2; exit 1; }
 info() { printf "${DIM}    %s${CLR}\n" "$1"; }
 
-# -- 1. python3 version -----------------------------------------------------
+# pick_python [MIN_MINOR]  — echo the first interpreter that is >= 3.MIN_MINOR
+# (default 10). On stock macOS, bare `python3` can still be the system 3.9 even
+# after Homebrew installs python@3.12 — Homebrew lands it as `python3.12`, not
+# as `python3` on PATH — so prefer versioned names before falling back. (#100)
+pick_python() {
+  local min_minor="${1:-10}" cmd
+  for cmd in python3.13 python3.12 python3.11 python3.10 python3 python; do
+    if command -v "$cmd" >/dev/null 2>&1 \
+       && "$cmd" -c "import sys; sys.exit(0 if sys.version_info >= (3, $min_minor) else 1)" 2>/dev/null; then
+      printf '%s\n' "$cmd"
+      return 0
+    fi
+  done
+  return 1
+}
 
-step "1. python3 ≥ 3.11"
-if ! command -v python3 >/dev/null 2>&1; then
-  fail "python3 not on PATH. Install Python 3.11+: https://www.python.org/downloads/"
-fi
-PY_VER="$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')"
-PY_MAJOR="$(python3 -c 'import sys; print(sys.version_info.major)')"
-PY_MINOR="$(python3 -c 'import sys; print(sys.version_info.minor)')"
-if [ "$PY_MAJOR" -lt 3 ] || { [ "$PY_MAJOR" -eq 3 ] && [ "$PY_MINOR" -lt 11 ]; }; then
-  fail "python3 $PY_VER found; need ≥ 3.11. Install a newer Python."
-fi
-ok "python3 $PY_VER"
+# -- 1. python version ------------------------------------------------------
+
+step "1. python ≥ 3.11"
+# Select a >=3.11 interpreter by name (python3.12, …), not bare `python3`:
+# on stock macOS the latter is still the system 3.9 even after python@3.12
+# is installed. This same PY is reused for the venv below so it inherits the
+# right interpreter. (#100)
+PY="$(pick_python 11)" || fail "Python ≥ 3.11 not found. On macOS: 'brew install python@3.12' (Homebrew installs it as python3.12, not python3). Otherwise: https://www.python.org/downloads/"
+PY_VER="$("$PY" -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')"
+ok "python $PY_VER ($PY)"
 
 # -- 2. config file present + has real API key -----------------------------
 
@@ -78,8 +91,8 @@ ok "agent-data/ ready"
 
 step "4. $VENV_DIR"
 if [ ! -d "$VENV_DIR" ]; then
-  python3 -m venv "$VENV_DIR"
-  info "created $VENV_DIR"
+  "$PY" -m venv "$VENV_DIR"
+  info "created $VENV_DIR ($PY -> $("$PY" --version 2>&1))"
 fi
 # shellcheck disable=SC1091
 source "$VENV_DIR/bin/activate"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -56,6 +56,23 @@ ok()   { printf "${GREEN}  ✓${CLR} %s\n" "$1"; }
 fail() { printf "${RED}  ✗${CLR} %s\n" "$1" >&2; exit 1; }
 info() { printf "${DIM}    %s${CLR}\n" "$1"; }
 
+# pick_python [MIN_MINOR]  — echo the first interpreter that is >= 3.MIN_MINOR
+# (default 10; x402 requires >= 3.10). On stock macOS, bare `python3` can still
+# be the system 3.9 even after Homebrew installs python@3.12 — Homebrew lands it
+# as `python3.12`, not as `python3` on PATH — so prefer versioned names before
+# falling back to python3/python. (#100)
+pick_python() {
+  local min_minor="${1:-10}" cmd
+  for cmd in python3.13 python3.12 python3.11 python3.10 python3 python; do
+    if command -v "$cmd" >/dev/null 2>&1 \
+       && "$cmd" -c "import sys; sys.exit(0 if sys.version_info >= (3, $min_minor) else 1)" 2>/dev/null; then
+      printf '%s\n' "$cmd"
+      return 0
+    fi
+  done
+  return 1
+}
+
 usage() {
   cat <<EOF
 Usage: $0 [options]
@@ -197,8 +214,9 @@ if [ "$MODE" = "docker" ]; then
 else
   step "3. venv + pip install"
   if [ ! -d .venv ]; then
-    python3 -m venv .venv
-    info "created .venv"
+    PY="$(pick_python)" || fail "Python >= 3.10 is required (x402 needs it) but none was found. Install it (e.g. 'brew install python@3.12') and re-run."
+    "$PY" -m venv .venv
+    info "created .venv ($PY -> $("$PY" --version 2>&1))"
   fi
   # shellcheck disable=SC1091
   source .venv/bin/activate


### PR DESCRIPTION
Fixes #100.

## Problem
On stock macOS, `install-mac.sh` installs `python@3.12`, but Homebrew lands it as `python3.12` — **not** as `python3` on PATH. So bare `python3` stays the system 3.9.6, and:
- `setup.sh` / `run-bare.sh` create the venv with bare `python3` → venv inherits 3.9.6 → `pip install` fails (`x402>=2.2.0` needs Python >=3.10).
- `run-bare.sh` also aborts even earlier: its section-1 check gates bare `python3` against >=3.11, which 3.9.6 fails, so it never reaches venv creation.

## Fix
Add a `pick_python [MIN_MINOR]` selector (in both scripts) that prefers **versioned** interpreters (`python3.13 → python3.12 → … → python3 → python`) and returns the first one meeting the floor:
- `setup.sh` venv creation → floor **3.10** (the x402 requirement)
- `run-bare.sh` section-1 check **and** venv creation → floor **3.11** (its stated minimum), reusing the same `$PY` so the venv inherits it.

Clear error if nothing qualifies, pointing at `brew install python@3.12`.

## Verification
- Simulated the exact #100 condition: a fake `python3` reporting **3.9.6** on PATH alongside a real `python3.12` → `pick_python 11` selects **python3.12**, not the system 3.9.
- `default(>=3.10) → python3.12`, `>=3.11 → python3.12`, `>=3.99 → none (correct)`.
- `bash -n` clean on both scripts; no orphaned variable refs.
- ⚠️ Full macOS end-to-end was not runnable in the dev (Linux) environment — a maintainer confirming on a stock Mac would be the final check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)