### PR TITLE
chore(deps): bump mangroveai floor 1.6.0 → 1.7.2

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -34,7 +34,12 @@ PyJWT>=2.9.0
 # ([{col,dir}] not [str]) — the agent's oracle_data_query MCP tool parses
 # the typed DataQueryResponse, so it crashed on <1.5.2 against the live
 # (v0.15.7) Oracle. Also corrected SimulateRunResponse to the real shape.
-mangroveai>=1.6.0,<2.0.0
+# Floor raised to 1.7.2: completes the Oracle data-query DSL realignment
+# (DataQueryRequest now sends page_token + a typed filter op + numeric
+# bounds matching the server) and adds launch_experiment_and_wait() and the
+# signals category filter. The agent already resolves to 1.7.x at install
+# time, so this only raises the floor to match what it actually runs against.
+mangroveai>=1.7.2,<2.0.0
 # mangrovemarkets 1.0.0 moved EVM wallet keypair generation client-side.
 # The agent's wallet_manager.create_wallet() is unaffected — the SDK
 # call signature is unchanged, only the implementation shifted from


### PR DESCRIPTION
Raises the SDK floor `1.6.0 → 1.7.2` in `server/requirements.txt`.

1.7.2 completes the Oracle data-query DSL realignment (`DataQueryRequest` now sends `page_token` + a typed filter op + numeric bounds matching the server) and adds `launch_experiment_and_wait()` and the signals category filter.

The agent already resolves to 1.7.x at install time (the prior `>=1.6.0` was only a *minimum*, and pip installs the latest `<2.0.0` = 1.7.2), so this is a **floor-raise to match what it already runs against — no runtime behavior change.** CI `lint-and-test` covers it.

Context: this is the lightweight half of an investigation into the agent's Oracle launch handling. The heavier "use the SDK's `launch_experiment_and_wait`" swap was **declined** — the agent's `launch_experiment` intentionally returns immediately on the happy path (with an explicit "no poll on success" test), so adopting the always-poll SDK method would change behavior + return shape rather than being a clean dedup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)