### PR TITLE
fix(startup): don't let an unreachable x402 facilitator block cold start (#106)

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -511,6 +511,27 @@ The prompt during setup did not capture your key. Fix it manually:
 4. Save the file.
 5. Rerun: `./scripts/setup.sh --yes --no-mcp --no-verify`
 
+### "Health did not respond within 30s"
+
+The setup/verify scripts wait up to 30s for the agent to answer on
+`http://localhost:9080/health`. This message means the uvicorn process
+never bound the port — so the cause is in the **daemon log**, not the
+script output. Read it first:
+
+```bash
+tail -50 agent-data/bare.log
+```
+
+Look for a Python traceback (most common: port already in use, a missing
+dependency, or a bad value in `local-config.json`). Fix what the
+traceback names, then rerun `./scripts/setup.sh`.
+
+> The agent does **not** depend on reaching the external x402 payment
+> facilitator to start. If your network blocks it you'll see a harmless
+> `x402.hello_mangrove.facilitator_unavailable` warning in `bare.log`
+> (the paid demo tool is disabled), but `/health` and all free + API-key
+> features still come up. That warning is not a startup failure.
+
 ### Port 9080 is already in use
 
 Another program on your machine is already using the port the agent needs. These commands find it and stop it:

--- a/server/src/mcp/tools.py
+++ b/server/src/mcp/tools.py
@@ -21,6 +21,9 @@ from mcp.server.fastmcp import FastMCP
 from src.mcp.registry import ToolEntry, ToolParam, clear_tools, register_tool
 from src.shared.auth.middleware import has_valid_api_key
 from src.shared.errors import AgentError
+from src.shared.logging import get_logger
+
+_log = get_logger(__name__)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -3131,6 +3134,32 @@ def _register_oracle(server: FastMCP) -> None:
 # ---------------------------------------------------------------------------
 
 
+# Bound on the one-time x402 facilitator handshake performed while registering
+# the hello_mangrove demo tool. The facilitator is an EXTERNAL service; this cap
+# guarantees a slow/unreachable one can't stall startup past the ~30s window the
+# setup/verify scripts wait on /health. See issue #106.
+_X402_STARTUP_INIT_TIMEOUT_S = 6.0
+
+
+def _run_bounded(fn, timeout_s: float) -> Any:
+    """Run ``fn()`` but give up after ``timeout_s`` seconds.
+
+    Used so a slow/unreachable external dependency can't stall import-time
+    startup. On timeout the worker thread is abandoned (it finishes or errors
+    harmlessly on its own); we never block the port bind waiting on it.
+    """
+    import concurrent.futures
+
+    executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    future = executor.submit(fn)
+    try:
+        return future.result(timeout=timeout_s)
+    finally:
+        # Don't wait on the worker — if it's still blocked on the network we
+        # must let registration (and the port bind) proceed regardless.
+        executor.shutdown(wait=False)
+
+
 def _register_hello_mangrove(server: FastMCP) -> None:
     """Register hello_mangrove via the x402 library's MCP payment wrapper.
 
@@ -3138,6 +3167,17 @@ def _register_hello_mangrove(server: FastMCP) -> None:
     and settles via the shared x402ResourceServer, and attaches the settlement
     receipt to the result's ``_meta``. Clients using ``x402.mcp.x402MCPClient``
     auto-handle the empty-payment -> sign -> retry round-trip.
+
+    Building the payment wrapper requires a one-time handshake with the EXTERNAL
+    x402 facilitator (``initialize()`` fetches ``/supported`` over the network).
+    That handshake must NEVER gate app startup: the free + auth tiers (health,
+    discovery, wallets, strategies, backtests, KB) have to come up even when the
+    facilitator is unreachable, slow, or firewalled. Previously this ran eagerly
+    and un-guarded at import time, so an unreachable facilitator crashed/stalled
+    ``create_app()`` before uvicorn bound its port and ``/health`` never answered
+    (issue #106). We bound the attempt and degrade gracefully: if the facilitator
+    can't be reached the tool is still registered, but returns a clear error
+    instead of taking the whole agent down with it.
     """
     from x402 import ResourceConfig
     from x402.mcp import create_payment_wrapper
@@ -3147,32 +3187,64 @@ def _register_hello_mangrove(server: FastMCP) -> None:
     from src.shared.x402.config import get_network, get_pay_to
     from src.shared.x402.server import _ensure_initialized
 
-    resource_server = _ensure_initialized()
-    accepts = resource_server.build_payment_requirements(
-        ResourceConfig(
-            scheme="exact",
-            network=get_network(),
-            pay_to=get_pay_to(),
-            price="$0.05",
+    def _build_payment_wrapper():
+        resource_server = _ensure_initialized()  # external facilitator /supported fetch
+        accepts = resource_server.build_payment_requirements(
+            ResourceConfig(
+                scheme="exact",
+                network=get_network(),
+                pay_to=get_pay_to(),
+                price="$0.05",
+            )
         )
-    )
+        return create_payment_wrapper(
+            resource_server,
+            accepts=accepts,
+            resource=X402ResourceInfo(
+                url="mcp://hello_mangrove",
+                description="hello_mangrove message — $0.05 USDC donation",
+            ),
+        )
 
-    wrapper = create_payment_wrapper(
-        resource_server,
-        accepts=accepts,
-        resource=X402ResourceInfo(
-            url="mcp://hello_mangrove",
-            description="hello_mangrove message — $0.05 USDC donation",
-        ),
-    )
+    wrapper = None
+    try:
+        wrapper = _run_bounded(_build_payment_wrapper, _X402_STARTUP_INIT_TIMEOUT_S)
+    except Exception as exc:  # facilitator unreachable / slow / errored
+        _log.warning(
+            "x402.hello_mangrove.facilitator_unavailable",
+            error_type=type(exc).__name__,  # e.g. TimeoutError, ConnectError
+            error=str(exc),
+            facilitator_timeout_s=_X402_STARTUP_INIT_TIMEOUT_S,
+            detail="x402 payment demo disabled this run; free + auth tiers unaffected",
+        )
 
-    @server.tool(
-        name="hello_mangrove",
-        description="x402 demo: $0.05 USDC on Base. Smoke test for the payment path.",
-    )
-    @wrapper
-    async def hello_mangrove() -> str:
-        return json.dumps(_impl())
+    if wrapper is not None:
+        @server.tool(
+            name="hello_mangrove",
+            description="x402 demo: $0.05 USDC on Base. Smoke test for the payment path.",
+        )
+        @wrapper
+        async def hello_mangrove() -> str:
+            return json.dumps(_impl())
+    else:
+        # Degraded registration: keep the tool in the catalog so discovery is
+        # stable, but make the call return an actionable error rather than
+        # silently giving away the paid resource or 500-ing.
+        @server.tool(
+            name="hello_mangrove",
+            description="x402 demo (payment facilitator was unreachable at startup).",
+        )
+        async def hello_mangrove() -> str:
+            return json.dumps({
+                "error": True,
+                "code": "X402_FACILITATOR_UNAVAILABLE",
+                "message": (
+                    "The x402 payment facilitator was unreachable when the agent "
+                    "started, so the paid demo is disabled in this environment. "
+                    "Restart the agent once outbound access to the facilitator is "
+                    "available. The agent's free and API-key tiers are unaffected."
+                ),
+            })
 
     register_tool(ToolEntry(
         name="hello_mangrove",

--- a/server/tests/test_x402_startup_resilience.py
+++ b/server/tests/test_x402_startup_resilience.py
@@ -1,0 +1,68 @@
+"""Regression tests for cold-start resilience to an unreachable x402 facilitator.
+
+Bug (issue #106): registering the ``hello_mangrove`` MCP demo tool eagerly
+initialized the EXTERNAL x402 facilitator (a blocking ``/supported`` fetch) at
+import time, inside ``create_app()``. If the facilitator was unreachable, slow,
+or firewalled, that call crashed or stalled app import *before uvicorn bound its
+port*, so ``/health`` never came up and the setup/verify scripts failed with
+"/health did not respond within 30s".
+
+The free + auth tiers must come up regardless of payment-facilitator reach. These
+tests force the facilitator init to fail and assert the app still starts, ``/health``
+answers, and the demo tool is still catalogued (degraded), never taking the agent
+down with it.
+"""
+import os
+
+os.environ.setdefault("ENVIRONMENT", "test")
+
+import concurrent.futures
+
+import pytest
+from fastapi.testclient import TestClient
+
+import src.shared.x402.server as x402_server
+from src.app import create_app
+from src.mcp.tools import _run_bounded
+
+
+def _boom():
+    """Stand in for an unreachable facilitator handshake."""
+    raise ConnectionError("simulated: x402 facilitator unreachable")
+
+
+def test_unreachable_facilitator_does_not_block_startup(monkeypatch):
+    """create_app() must succeed and /health must answer even if the x402
+    facilitator handshake fails — the core of issue #106."""
+    monkeypatch.setattr(x402_server, "_ensure_initialized", _boom)
+
+    app = create_app()  # before the fix this raised during MCP tool registration
+    with TestClient(app) as client:
+        resp = client.get("/health")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "healthy"
+
+
+def test_hello_mangrove_still_catalogued_when_facilitator_down(monkeypatch):
+    """The demo tool stays in the discovery catalog (degraded), so discovery is
+    stable rather than the tool silently vanishing or 500-ing startup."""
+    monkeypatch.setattr(x402_server, "_ensure_initialized", _boom)
+
+    app = create_app()
+    with TestClient(app) as client:
+        tools = client.get("/api/v1/agent/tools").json()["tools"]
+        names = {t["name"] for t in tools}
+        assert "hello_mangrove" in names
+
+
+def test_run_bounded_returns_value_quickly():
+    assert _run_bounded(lambda: 21 + 21, 5.0) == 42
+
+
+def test_run_bounded_gives_up_on_a_hanging_call():
+    """A call that outlasts the bound raises TimeoutError instead of blocking
+    forever — this is what keeps a hanging facilitator from stalling startup."""
+    import time
+
+    with pytest.raises(concurrent.futures.TimeoutError):
+        _run_bounded(lambda: time.sleep(10), 0.2)

--- a/tutorials/trading-app/03-setup.md
+++ b/tutorials/trading-app/03-setup.md
@@ -91,10 +91,20 @@ If everything went well, the last thing you see is:
 misfired. Edit `server/src/config/local-config.json` and paste your
 key into the `MANGROVE_API_KEY` field.
 
-**"/health did not respond"** — the server started but failed to
-come up. Check `agent-data/bare.log` for a traceback. Common causes:
-port conflict (something else on 9080), missing Python dependency,
-or a syntax error in the config file.
+**"/health did not respond"** (or `Health did not respond within 30s`)
+— the uvicorn process failed to bind its port, so nothing is serving
+`/health`. **First step: read the daemon log** —
+`tail -50 agent-data/bare.log` — the real cause (a traceback or a
+warning) is there, not in the script output. Common causes: port
+conflict (something else on 9080), a missing Python dependency, or a
+bad value in `local-config.json`.
+
+> Note: the agent no longer needs to reach the external x402 payment
+> facilitator just to start. If outbound access to it is blocked, you'll
+> see a one-line `x402.hello_mangrove.facilitator_unavailable` **warning**
+> in `bare.log` and the paid demo tool is disabled — but `/health` and
+> every free + API-key feature still come up normally. That warning is
+> informational, not the cause of a failed start.
 
 **Port 9080 is already taken** — if some other dev tool is using 9080
 too, bind somewhere else:


### PR DESCRIPTION
## Cold start no longer hangs/crashes when the x402 facilitator is unreachable

**Fixes #106.** On a cold start the agent made a **blocking call to the external x402 payment facilitator at app *import* time** (inside `create_app()`), before uvicorn bound its port. If that host was unreachable/slow/firewalled, app import **crashed or stalled**, the port never bound, and `/health` never answered — so `./scripts/setup.sh` / `./scripts/verify_quickstart.sh --bare` failed with **"Health did not respond within 30s."** The free + auth tiers (health, discovery, wallets, strategies, backtests, KB — the whole agent except one demo tool) have no business depending on a payment-network handshake just to start.

This PR bounds that handshake and makes it non-fatal: the agent always starts; only the optional `hello_mangrove` x402 *demo* degrades when the facilitator is unreachable. **No DB migration; no config schema change.**

## Root cause

`server/src/app.py:144` runs `app = create_app()` at import → `create_mcp_server()` → `register()` → `_register_hello_mangrove()`, which **eagerly** called `_ensure_initialized()` → `x402ResourceServer.initialize()` → `HTTPFacilitatorClient.get_supported()` — a blocking `GET {facilitator}/supported`. `FacilitatorConfig.timeout` defaults to **30s**, so:

- **unreachable (RST):** the exception propagated out of import → uvicorn failed to load `src.app:app` → worker exited → port never bound.
- **blackholed (dropped):** the call hung up to ~30s before failing — the tester's *"hung indefinitely … eventually timing out."*

The setup/verify scripts then printed `Health did not respond within 30s`. The real cause only ever landed in `agent-data/bare.log`, which onboarding never told you to read (the reporter's DOCS gap).

## Change

- **`server/src/mcp/tools.py`** — `_register_hello_mangrove()` now builds the x402 payment wrapper through `_run_bounded(...)` (a 6s cap, well under the 30s health window). On failure it logs `x402.hello_mangrove.facilitator_unavailable` and registers the demo tool in a **degraded** form that returns a clear `X402_FACILITATOR_UNAVAILABLE` error — instead of letting the exception abort `create_app()`. When the facilitator **is** reachable, behavior is byte-for-byte unchanged.
- **`server/tests/test_x402_startup_resilience.py`** — regression tests: app starts + `/health` 200 + `hello_mangrove` catalogued when the facilitator handshake fails; `_run_bounded` returns fast / times out a hanging call.
- **`SETUP.md`, `tutorials/trading-app/03-setup.md`** — troubleshooting for `Health did not respond within 30s`: read `agent-data/bare.log` first, and a note that the facilitator-unreachable warning is harmless. (The public `MangroveKnowledgeBase` quickstart was reviewed — it's a thin pointer that already references `bare.log` and is not wrong, so no separate docs PR.)

## Verification (real bare-metal runs, not just unit tests)

Stood up the server exactly as `setup.sh` does (`uvicorn src.app:app --host 0.0.0.0 --port 9080`) from this branch's worktree, against three facilitator conditions:

| Facilitator condition | Before this PR | After this PR |
|---|---|---|
| **Unreachable** (`http://127.0.0.1:1`, RST) | import crash → process **DEAD** → `/health` timeout | binds, **`/health` 200 in 3s** |
| **Hanging** (TCP accepts, never replies) | hangs ~30s → timeout | binds, **`/health` 200 in 8s** (6s bound + startup) |
| **Real** (`https://x402.org/facilitator`) | works | works — **no degradation**, `/health` 200 in 4s |

**The exact reporter command, with the facilitator unreachable:**

```
$ ./scripts/verify_quickstart.sh --bare
==> 4. waiting for /health (up to 30s)
  ✓ /health returned 200 after 1s
==> 5. GET /api/v1/agent/status
  ✓ agent version 0.1.0
==> 6. GET /api/v1/agent/tools with API key
  ✓ tool catalog returned 95 tools
✓ quickstart verified in 0s          # exit 0  (was: "Health did not respond within 30s")
```

**x402 demo still works online (no payment-path regression):**

```
$ curl -s -o /dev/null -w '%{http_code}\n' -H 'X-API-Key: dev-key-1' http://localhost:9080/api/x402/hello-mangrove
200
$ curl -s -o /dev/null -w '%{http_code}\n' http://localhost:9080/api/x402/hello-mangrove
402     # facilitator-backed payment-required path intact
```

**Degraded-mode startup log (unreachable facilitator) — a warning, not a crash:**

```
[warning] x402.hello_mangrove.facilitator_unavailable  error_type=ConnectError
          detail='x402 payment demo disabled this run; free + auth tiers unaffected'
INFO:     Uvicorn running on http://0.0.0.0:9080
INFO:     GET /health HTTP/1.1 200 OK
```

**Tests** (run with `ENVIRONMENT=test`, `PYTHONPATH=server`):

```
server/tests/test_x402_startup_resilience.py ....                         [4 passed]
test_x402 / test_mcp / test_mcp_auth / test_hello_mangrove / test_health /
  integration/test_mcp_tools ....................                         [20 passed]
ruff check server/src/mcp/tools.py server/tests/...  -> All checks passed!
```

## Claude session (resume this exact investigation)

```
Session: 58290ada-6183-46e1-a4b4-ae8019ce525a
Resume:  claude --resume 58290ada-6183-46e1-a4b4-ae8019ce525a
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
