### PR TITLE
fix(dex): convert human swap amounts to base units before quoting (get_swap_quote INSUFFICIENT_LIQUIDITY)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -201,6 +201,13 @@ Get all token balances for a wallet on an EVM chain.
 
 Get the best swap quote across all venues or from a specific venue.
 
+> **Units note.** This is the **raw backend tool**, whose `amount` is in the
+> token's **smallest units** (wei / base units), as shown below. The agent's
+> own `get_swap_quote` tool and `POST /api/v1/agent/dex/quote` route instead
+> take `amount` in **human units** (e.g. `0.001` = 0.001 ETH) and convert to
+> base units for you — passing a human float (e.g. `0.001`) straight to the
+> raw tool reads as sub-wei dust and returns `INSUFFICIENT_LIQUIDITY`.
+
 **Parameters:**
 
 | Param | Type | Required | Description |

--- a/server/src/api/routes/dex.py
+++ b/server/src/api/routes/dex.py
@@ -17,6 +17,7 @@ from fastapi import APIRouter, Depends
 from pydantic import BaseModel, Field
 
 from src.models.domain import OrderIntent
+from src.services import dex_service
 from src.services.order_executor import execute_one
 from src.shared.auth.dependency import require_api_key
 from src.shared.clients.mangrove import mangrove_markets_client
@@ -50,24 +51,31 @@ async def dex_pairs(venue_id: str) -> list[Any]:
 class QuoteRequest(BaseModel):
     input_token: str
     output_token: str
-    amount: float
+    amount: float = Field(
+        ...,
+        gt=0,
+        description=(
+            "Amount of input_token to swap, in HUMAN units (e.g. 0.001 = "
+            "0.001 ETH, 25 = 25 USDC). Converted to the token's smallest "
+            "units (base units / wei) before the upstream call."
+        ),
+    )
     chain_id: int
     venue_id: str | None = None
 
 
 @router.post("/quote", summary="Get a swap quote")
 async def dex_quote(req: QuoteRequest) -> dict:
-    try:
-        quote = mangrove_markets_client().dex.get_quote(
-            input_token=req.input_token,
-            output_token=req.output_token,
-            amount=req.amount,
-            chain_id=req.chain_id,
-            venue_id=req.venue_id,
-        )
-    except Exception as e:  # noqa: BLE001
-        raise SdkError(f"dex.get_quote failed: {e}") from e
-    return quote.model_dump() if hasattr(quote, "model_dump") else quote
+    # dex_service converts the human amount to the token's base units (what
+    # the backend/1inch expects) and converts the returned amounts back to
+    # human units. AgentError subclasses propagate to the central handler.
+    return dex_service.get_quote(
+        input_token=req.input_token,
+        output_token=req.output_token,
+        amount=req.amount,
+        chain_id=req.chain_id,
+        venue_id=req.venue_id,
+    )
 
 
 class SwapRequest(BaseModel):

--- a/server/src/mcp/tools.py
+++ b/server/src/mcp/tools.py
@@ -462,26 +462,28 @@ def _register_dex(server: FastMCP) -> None:
     ) -> str:
         """Get a DEX swap quote.
 
-        Mirrors `mangrovemarkets.dex.get_quote(input_token, output_token,
-        amount, venue_id, chain_id, mode)`. `mode` is an optional
-        routing hint recognized by some venues (e.g. 1inch supports
-        modes that bias for gas-cost vs price-improvement).
+        `amount` is the quantity of `input_token` in HUMAN units (e.g.
+        0.001 = 0.001 ETH, 25 = 25 USDC) — NOT base units. The agent
+        converts it to the token's smallest units (base units / wei)
+        before calling the backend, and converts the returned
+        input_amount/output_amount back to human units (raw values kept
+        as input_amount_base_units / output_amount_base_units). `mode` is
+        an optional routing hint recognized by some venues (e.g. 1inch
+        supports modes that bias for gas-cost vs price-improvement).
         """
         if not _require(api_key):
             return _auth_error()
         try:
-            from src.shared.clients.mangrove import mangrove_markets_client
-            kwargs: dict[str, Any] = {
-                "input_token": input_token,
-                "output_token": output_token,
-                "amount": amount,
-                "chain_id": chain_id,
-                "venue_id": venue_id,
-            }
-            if mode is not None:
-                kwargs["mode"] = mode
-            q = mangrove_markets_client().dex.get_quote(**kwargs)
-            return json.dumps(_dump(q))
+            from src.services import dex_service
+            q = dex_service.get_quote(
+                input_token=input_token,
+                output_token=output_token,
+                amount=amount,
+                chain_id=chain_id,
+                venue_id=venue_id,
+                mode=mode,
+            )
+            return json.dumps(q)
         except AgentError as e:
             return _handle_agent_error(e)
 
@@ -490,9 +492,9 @@ def _register_dex(server: FastMCP) -> None:
         description="Get a DEX swap quote. Optionally pin a venue + mode.",
         access="auth",
         parameters=[
-            ToolParam(name="input_token", type="string", required=True, description="Input token"),
-            ToolParam(name="output_token", type="string", required=True, description="Output token"),
-            ToolParam(name="amount", type="number", required=True, description="Input amount"),
+            ToolParam(name="input_token", type="string", required=True, description="Input token (contract address; native ETH = 0xEeee…EEeE)"),
+            ToolParam(name="output_token", type="string", required=True, description="Output token (contract address)"),
+            ToolParam(name="amount", type="number", required=True, description="Input amount in HUMAN units (e.g. 0.001 = 0.001 ETH, 25 = 25 USDC). Converted to base units internally."),
             ToolParam(name="chain_id", type="integer", required=True, description="EVM chain id"),
             ToolParam(name="venue_id", type="string", required=False, description="Optional specific venue"),
             ToolParam(name="mode", type="string", required=False, description="Optional routing hint (venue-specific)"),

--- a/server/src/services/dex_service.py
+++ b/server/src/services/dex_service.py
@@ -1,0 +1,190 @@
+"""dex_service — shared DEX quote logic for routes + MCP tools.
+
+Why this module exists
+----------------------
+The MangroveMarkets backend (and the 1inch aggregator it proxies) expect a
+swap ``amount`` in the input token's **smallest units** — base units / wei —
+and return ``input_amount`` / ``output_amount`` the same way. The
+``mangrovemarkets`` SDK documents this in every example::
+
+    amount=1_000_000   # == 1 USDC (6 decimals)
+    amount=100_000     # == 0.1 USDC
+    # quote.output_amount is wei
+
+The agent, by contrast, works in **human-readable** token quantities
+everywhere else: ``get_balances`` converts to human units, ``_paper_fill``
+multiplies ``intent.amount`` by a mark price, and ``wallet-presentation.md``
+states the convention outright ("Convert raw amounts to human-readable
+units"). The LLM driving the tools — and the tester who filed this bug —
+naturally pass ``0.001`` meaning *0.001 ETH*.
+
+Passing that human float straight through to ``dex.get_quote`` made the
+backend read ``0.001`` as 0.001 **base units** — sub-wei dust for an
+18-decimal token — so 1inch found no route and returned
+``INSUFFICIENT_LIQUIDITY`` for **every** pair/chain/amount (0.0001 .. 1.0 all
+collapse to dust in base units). That is the reported blocker.
+
+This module is the single boundary that converts human <-> base units, so
+the agent keeps its human-amount convention end-to-end while the backend
+always receives the base units it expects.
+"""
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any
+
+from src.shared.clients.mangrove import mangrove_markets_client
+from src.shared.errors import SdkError, ValidationError
+from src.shared.logging import get_logger
+
+_log = get_logger(__name__)
+
+# 1inch's native-asset sentinels (ETH on mainnet/Base, etc.) — never an
+# ERC-20 contract, always 18 decimals, so resolve offline.
+_NATIVE_SENTINELS = {
+    "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+    "0x0000000000000000000000000000000000000000",
+}
+_NATIVE_DECIMALS = 18
+
+
+def _is_address(token: str) -> bool:
+    return isinstance(token, str) and token.startswith("0x") and len(token) == 42
+
+
+def resolve_decimals(client: Any, chain_id: int, token: str) -> int:
+    """Return the ERC-20 decimals for ``token`` on ``chain_id``.
+
+    Resolution order:
+    1. Native-asset sentinel -> 18 (offline, no network call).
+    2. 0x address -> ``dex.token_info(...).decimals``.
+    3. Symbol -> first exact ``dex.token_search(...)`` match's decimals.
+
+    Raises ``SdkError`` if decimals cannot be determined. We refuse to
+    guess: a wrong decimals silently mis-scales the amount (e.g. treating
+    6-decimal USDC as 18 would request 10^12x too much), which is far worse
+    than a clear error.
+    """
+    t = (token or "").strip()
+    if not t:
+        raise ValidationError("token is required to resolve decimals.")
+    if t.lower() in _NATIVE_SENTINELS:
+        return _NATIVE_DECIMALS
+
+    if _is_address(t):
+        try:
+            info = client.dex.token_info(chain_id=chain_id, address=t)
+        except Exception as e:  # noqa: BLE001
+            raise SdkError(
+                f"Could not look up token decimals for {t} on chain {chain_id}: {e}",
+                suggestion=(
+                    "The amount must be converted to the token's smallest "
+                    "units, which needs its decimals. Verify the token "
+                    "address + chain_id are correct."
+                ),
+            ) from e
+        dec = getattr(info, "decimals", None)
+        if dec is None:
+            raise SdkError(f"token_info for {t} returned no decimals.")
+        return int(dec)
+
+    # Symbol path (e.g. "USDC"). Best-effort via token_search.
+    try:
+        matches = client.dex.token_search(chain_id=chain_id, query=t)
+    except Exception as e:  # noqa: BLE001
+        raise SdkError(
+            f"Could not resolve token symbol '{t}' on chain {chain_id}: {e}",
+            suggestion="Pass the token's contract address instead of its symbol.",
+        ) from e
+    for m in matches or []:
+        if str(getattr(m, "symbol", "")).upper() == t.upper():
+            return int(m.decimals)
+    if matches:
+        return int(matches[0].decimals)
+    raise SdkError(
+        f"Unknown token '{t}' on chain {chain_id}; cannot determine decimals.",
+        suggestion="Pass the token's contract address instead of its symbol.",
+    )
+
+
+def to_base_units(amount: float, decimals: int) -> int:
+    """Human token amount -> integer base units. Uses Decimal for exactness."""
+    if amount is None:
+        raise ValidationError("amount is required.")
+    if amount < 0:
+        raise ValidationError(f"amount must be non-negative, got {amount}.")
+    return int(Decimal(str(amount)) * (Decimal(10) ** decimals))
+
+
+def from_base_units(raw: float | int | str, decimals: int) -> float:
+    """Integer base units -> human token amount."""
+    return float(Decimal(str(raw)) / (Decimal(10) ** decimals))
+
+
+def get_quote(
+    input_token: str,
+    output_token: str,
+    amount: float,
+    chain_id: int,
+    venue_id: str | None = None,
+    mode: str | None = None,
+) -> dict:
+    """Get a DEX swap quote, in human token units in *and* out.
+
+    ``amount`` is a human-readable quantity of ``input_token`` (e.g. 0.001
+    ETH, 25 USDC). It is converted to the token's base units before the
+    backend call; the returned ``input_amount`` / ``output_amount`` are
+    converted back to human units. The raw base-unit values are preserved
+    as ``*_base_units`` for callers that need them.
+    """
+    client = mangrove_markets_client()
+
+    in_decimals = resolve_decimals(client, chain_id, input_token)
+    raw_amount = to_base_units(amount, in_decimals)
+    if raw_amount <= 0:
+        raise ValidationError(
+            f"amount {amount} is too small to quote: it rounds to 0 base "
+            f"units for a {in_decimals}-decimal token.",
+            suggestion="Increase the amount.",
+        )
+
+    kwargs: dict[str, Any] = {
+        "input_token": input_token,
+        "output_token": output_token,
+        "amount": raw_amount,
+        "chain_id": chain_id,
+        "venue_id": venue_id,
+    }
+    if mode is not None:
+        kwargs["mode"] = mode
+
+    try:
+        quote = client.dex.get_quote(**kwargs)
+    except Exception as e:  # noqa: BLE001
+        raise SdkError(f"dex.get_quote failed: {e}") from e
+
+    out_decimals = resolve_decimals(client, chain_id, output_token)
+
+    data = quote.model_dump() if hasattr(quote, "model_dump") else dict(quote)
+    raw_in = data.get("input_amount")
+    raw_out = data.get("output_amount")
+    if raw_in is not None:
+        data["input_amount_base_units"] = raw_in
+        data["input_amount"] = from_base_units(raw_in, in_decimals)
+    if raw_out is not None:
+        data["output_amount_base_units"] = raw_out
+        data["output_amount"] = from_base_units(raw_out, out_decimals)
+    data["input_token_decimals"] = in_decimals
+    data["output_token_decimals"] = out_decimals
+
+    _log.info(
+        "dex.quote",
+        input_token=input_token,
+        output_token=output_token,
+        amount=amount,
+        amount_base_units=raw_amount,
+        in_decimals=in_decimals,
+        out_decimals=out_decimals,
+        quote_id=data.get("quote_id"),
+    )
+    return data

--- a/server/src/services/dex_service.py
+++ b/server/src/services/dex_service.py
@@ -72,18 +72,40 @@ def resolve_decimals(client: Any, chain_id: int, token: str) -> int:
         return _NATIVE_DECIMALS
 
     if _is_address(t):
+        # We need ONLY decimals here. The SDK's strongly-typed TokenInfo can
+        # reject an otherwise-fine response over an unrelated field — e.g. the
+        # live markets server returns `tags` as {provider, value} objects while
+        # the SDK models `tags: list[str]` (root cause fixed upstream in the
+        # MangroveMarkets SDK). A swap must not fail because a metadata field's
+        # schema drifted, so if the typed lookup fails we fall back to the raw
+        # tool payload for the decimals field only.
+        dec: Any = None
         try:
             info = client.dex.token_info(chain_id=chain_id, address=t)
+            dec = getattr(info, "decimals", None)
         except Exception as e:  # noqa: BLE001
-            raise SdkError(
-                f"Could not look up token decimals for {t} on chain {chain_id}: {e}",
-                suggestion=(
-                    "The amount must be converted to the token's smallest "
-                    "units, which needs its decimals. Verify the token "
-                    "address + chain_id are correct."
-                ),
-            ) from e
-        dec = getattr(info, "decimals", None)
+            try:
+                raw = client.dex._call_tool(
+                    "oneinch_token_info", {"chain_id": chain_id, "address": t}
+                )
+                tok = raw.get("token", raw) if isinstance(raw, dict) else {}
+                dec = tok.get("decimals")
+            except Exception:  # noqa: BLE001
+                dec = None
+            if dec is None:
+                raise SdkError(
+                    f"Could not look up token decimals for {t} on chain {chain_id}: {e}",
+                    suggestion=(
+                        "The amount must be converted to the token's smallest "
+                        "units, which needs its decimals. Verify the token "
+                        "address + chain_id are correct."
+                    ),
+                ) from e
+            _log.warning(
+                "token_info model rejected the response for %s on chain %s "
+                "(%s); fell back to raw decimals=%s",
+                t, chain_id, e, dec,
+            )
         if dec is None:
             raise SdkError(f"token_info for {t} returned no decimals.")
         return int(dec)

--- a/server/tests/e2e/test_smoke.py
+++ b/server/tests/e2e/test_smoke.py
@@ -97,9 +97,24 @@ def _stub_sdk() -> MagicMock:
     sdk.dex.supported_pairs.return_value = [
         MagicMock(model_dump=MagicMock(return_value={"from_token": "USDC", "to_token": "ETH"})),
     ]
+    # Backend echoes/returns base units; dex_service converts to human.
     sdk.dex.get_quote.return_value = _resp({
-        "quote_id": "q-1", "input_amount": 1, "output_amount": 0.0004, "exchange_rate": 2500.0,
+        "quote_id": "q-1",
+        "input_amount": 100_000_000_000_000_000_000,  # 100 WETH in wei
+        "output_amount": 250_000_000,                 # 250 USDC base units
+        "exchange_rate": 2500.0,
     })
+
+    # dex_service resolves token decimals via token_info to convert the
+    # human amount -> base units; .decimals must be a real int.
+    def _token_info(chain_id, address):
+        dec = 6 if address.lower() == "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913" else 18
+        return MagicMock(decimals=dec, model_dump=MagicMock(return_value={
+            "address": address, "symbol": "TKN", "name": "TKN",
+            "decimals": dec, "chain_id": chain_id,
+        }))
+
+    sdk.dex.token_info.side_effect = _token_info
     sdk.dex.balances.return_value = _resp({"balances": []})
 
     for attr, payload in [
@@ -141,6 +156,7 @@ def client(tmp_path, monkeypatch):
         "src.api.routes.kb.mangrove_ai_client",
         "src.api.routes.wallet.mangrove_markets_client",
         "src.api.routes.dex.mangrove_markets_client",
+        "src.services.dex_service.mangrove_markets_client",
         "src.services.candidate_generator.mangrove_ai_client",
         "src.services.backtest_service.mangrove_ai_client",
         "src.services.strategy_service.mangrove_ai_client",
@@ -192,7 +208,9 @@ _SMOKE_ENDPOINTS = [
     ("GET", "/api/v1/agent/dex/venues", None, None, False),
     ("GET", "/api/v1/agent/dex/pairs", None, {"venue_id": "uniswap-v2"}, False),
     ("POST", "/api/v1/agent/dex/quote",
-     {"input_token": "USDC", "output_token": "ETH", "amount": 100.0, "chain_id": 8453}, None, False),
+     {"input_token": "0x4200000000000000000000000000000000000006",
+      "output_token": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+      "amount": 100.0, "chain_id": 8453}, None, False),
     # Strategies (auth-gated; autonomous + list + get via smoke)
     ("GET", "/api/v1/agent/strategies", None, None, False),
     # Logs (auth-gated; tolerates empty)

--- a/server/tests/integration/test_dex_routes.py
+++ b/server/tests/integration/test_dex_routes.py
@@ -71,12 +71,25 @@ def client(tmp_path, monkeypatch):
     tx_status.error_message = None
     sdk.dex.tx_status.return_value = tx_status
 
-    token_info = MagicMock()
-    token_info.model_dump.return_value = {
-        "address": "0x" + "a" * 40, "symbol": "USDC", "name": "USD Coin",
-        "decimals": 6, "chain_id": 8453,
+    # token_info is now consulted by dex_service.get_quote to convert the
+    # human amount -> base units, so return realistic per-address decimals.
+    _DECIMALS = {
+        ("0x" + "a" * 40): ("USDC", 6),
+        "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913": ("USDC", 6),   # USDC on Base
+        "0x4200000000000000000000000000000000000006": ("WETH", 18),  # WETH on Base
     }
-    sdk.dex.token_info.return_value = token_info
+
+    def _token_info(chain_id, address):
+        symbol, decimals = _DECIMALS.get(address.lower(), ("TKN", 18))
+        ti = MagicMock()
+        ti.decimals = decimals
+        ti.model_dump.return_value = {
+            "address": address, "symbol": symbol, "name": symbol,
+            "decimals": decimals, "chain_id": chain_id,
+        }
+        return ti
+
+    sdk.dex.token_info.side_effect = _token_info
 
     spot_price = MagicMock()
     spot_price.model_dump.return_value = {
@@ -92,6 +105,7 @@ def client(tmp_path, monkeypatch):
     sdk.dex.gas_price.return_value = gas_price
 
     monkeypatch.setattr("src.api.routes.dex.mangrove_markets_client", lambda: sdk)
+    monkeypatch.setattr("src.services.dex_service.mangrove_markets_client", lambda: sdk)
     monkeypatch.setattr("src.services.order_executor.mangrove_markets_client", lambda: sdk)
     monkeypatch.setattr(
         "src.services.order_executor.wallet_sign",
@@ -108,6 +122,7 @@ def client(tmp_path, monkeypatch):
     from src.app import create_app
     app = create_app()
     with TestClient(app) as c:
+        c.app_sdk = sdk  # expose the mock so tests can assert/reconfigure calls
         yield c
     ss.reset_scheduler_cache()
     db_mod.reset_connection()
@@ -131,16 +146,66 @@ def test_pairs(client):
     assert r.json()[0]["from_token"] == "USDC"
 
 
-def test_quote(client):
+_WETH_BASE = "0x4200000000000000000000000000000000000006"
+_USDC_BASE = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+
+
+def test_quote_converts_human_amount_to_base_units(client):
+    """Regression for the INSUFFICIENT_LIQUIDITY blocker.
+
+    A human amount (0.001 WETH) must reach the backend as base units
+    (0.001 * 1e18 = 1e15 wei). The pre-fix code forwarded 0.001 verbatim,
+    which the backend read as sub-wei dust and rejected with
+    INSUFFICIENT_LIQUIDITY for every pair/chain.
+    """
+    # Backend echoes/returns amounts in base units (wei).
+    quote = MagicMock()
+    quote.model_dump.return_value = {
+        "quote_id": "q-weth", "venue_id": "1inch",
+        "input_amount": 1_000_000_000_000_000,   # 0.001 WETH in wei
+        "output_amount": 2_500_000,               # 2.5 USDC in base units (6 dp)
+        "exchange_rate": 2500.0,
+    }
+    client.app_sdk.dex.get_quote.return_value = quote
+    client.app_sdk.dex.get_quote.side_effect = None
+
     r = client.post(
         "/api/v1/agent/dex/quote",
         headers=_auth(),
-        json={"input_token": "USDC", "output_token": "ETH", "amount": 100.0, "chain_id": 84532},
+        json={
+            "input_token": _WETH_BASE, "output_token": _USDC_BASE,
+            "amount": 0.001, "chain_id": 8453,
+        },
     )
-    assert r.status_code == 200
+    assert r.status_code == 200, r.text
+
+    # The SDK was called with the BASE-unit amount, not the human float.
+    _, kwargs = client.app_sdk.dex.get_quote.call_args
+    assert kwargs["amount"] == 1_000_000_000_000_000
+
     body = r.json()
-    assert body["quote_id"] == "q-1"
-    assert body["output_amount"] == 0.04
+    assert body["quote_id"] == "q-weth"
+    # Returned amounts are converted back to human units for display.
+    assert body["input_amount"] == 0.001
+    assert body["output_amount"] == 2.5
+    assert body["input_amount_base_units"] == 1_000_000_000_000_000
+    assert body["input_token_decimals"] == 18
+    assert body["output_token_decimals"] == 6
+
+
+def test_quote_rejects_dust_amount(client):
+    """An amount that rounds to 0 base units gets a clear client error,
+    not a confusing upstream INSUFFICIENT_LIQUIDITY."""
+    r = client.post(
+        "/api/v1/agent/dex/quote",
+        headers=_auth(),
+        json={
+            "input_token": _USDC_BASE, "output_token": _WETH_BASE,
+            "amount": 0.0000001, "chain_id": 8453,  # < 1e-6 USDC -> 0 base units
+        },
+    )
+    assert r.status_code == 400
+    assert r.json()["code"] == "VALIDATION_ERROR"
 
 
 def test_swap_requires_confirm(client):

--- a/server/tests/unit/test_dex_service.py
+++ b/server/tests/unit/test_dex_service.py
@@ -1,0 +1,113 @@
+"""Unit tests for dex_service — human <-> base-unit conversion.
+
+Covers the root cause of the INSUFFICIENT_LIQUIDITY blocker: the agent
+must convert a human swap amount (e.g. 0.001 ETH) to the input token's
+base units (wei) before the backend call, and convert returned amounts
+back to human units.
+"""
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock
+
+os.environ.setdefault("ENVIRONMENT", "test")
+
+import pytest  # noqa: E402
+
+from src.services import dex_service  # noqa: E402
+from src.shared.errors import SdkError, ValidationError  # noqa: E402
+
+_WETH = "0x4200000000000000000000000000000000000006"
+_USDC = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+_NATIVE_ETH = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"
+
+
+def _client_with_decimals(mapping):
+    """A mock SDK client whose token_info returns the mapped decimals."""
+    client = MagicMock()
+
+    def _token_info(chain_id, address):
+        ti = MagicMock()
+        ti.decimals = mapping[address.lower()]
+        return ti
+
+    client.dex.token_info.side_effect = _token_info
+    return client
+
+
+# -- pure conversion -------------------------------------------------------
+
+@pytest.mark.parametrize("amount,decimals,expected", [
+    (0.001, 18, 1_000_000_000_000_000),
+    (1.0, 18, 1_000_000_000_000_000_000),
+    (1.0, 6, 1_000_000),
+    (25, 6, 25_000_000),
+    (0.0001, 18, 100_000_000_000_000),
+])
+def test_to_base_units(amount, decimals, expected):
+    assert dex_service.to_base_units(amount, decimals) == expected
+
+
+def test_from_base_units_roundtrip():
+    assert dex_service.from_base_units(1_000_000_000_000_000, 18) == 0.001
+    assert dex_service.from_base_units(2_500_000, 6) == 2.5
+
+
+def test_to_base_units_rejects_negative():
+    with pytest.raises(ValidationError):
+        dex_service.to_base_units(-1.0, 18)
+
+
+# -- decimals resolution ---------------------------------------------------
+
+def test_resolve_decimals_native_sentinel_is_offline():
+    client = MagicMock()
+    assert dex_service.resolve_decimals(client, 8453, _NATIVE_ETH) == 18
+    client.dex.token_info.assert_not_called()  # no network call for native
+
+
+def test_resolve_decimals_address_uses_token_info():
+    client = _client_with_decimals({_USDC.lower(): 6})
+    assert dex_service.resolve_decimals(client, 8453, _USDC) == 6
+
+
+def test_resolve_decimals_raises_on_lookup_failure():
+    client = MagicMock()
+    client.dex.token_info.side_effect = RuntimeError("upstream 500")
+    with pytest.raises(SdkError):
+        dex_service.resolve_decimals(client, 8453, _USDC)
+
+
+# -- get_quote end-to-end (mocked client) ----------------------------------
+
+def test_get_quote_sends_base_units_and_returns_human(monkeypatch):
+    client = _client_with_decimals({_WETH.lower(): 18, _USDC.lower(): 6})
+    quote = MagicMock()
+    quote.model_dump.return_value = {
+        "quote_id": "q1",
+        "input_amount": 1_000_000_000_000_000,  # 0.001 WETH in wei
+        "output_amount": 2_500_000,             # 2.5 USDC base units
+    }
+    client.dex.get_quote.return_value = quote
+    monkeypatch.setattr(dex_service, "mangrove_markets_client", lambda: client)
+
+    out = dex_service.get_quote(
+        input_token=_WETH, output_token=_USDC, amount=0.001, chain_id=8453,
+    )
+
+    _, kwargs = client.dex.get_quote.call_args
+    assert kwargs["amount"] == 1_000_000_000_000_000  # base units, not 0.001
+    assert out["input_amount"] == 0.001
+    assert out["output_amount"] == 2.5
+    assert out["output_amount_base_units"] == 2_500_000
+
+
+def test_get_quote_rejects_dust(monkeypatch):
+    client = _client_with_decimals({_USDC.lower(): 6})
+    monkeypatch.setattr(dex_service, "mangrove_markets_client", lambda: client)
+    with pytest.raises(ValidationError):
+        # 1e-7 USDC * 1e6 -> 0 base units
+        dex_service.get_quote(
+            input_token=_USDC, output_token=_WETH, amount=0.0000001, chain_id=8453,
+        )
+    client.dex.get_quote.assert_not_called()

--- a/server/tests/unit/test_dex_service.py
+++ b/server/tests/unit/test_dex_service.py
@@ -74,8 +74,36 @@ def test_resolve_decimals_address_uses_token_info():
 def test_resolve_decimals_raises_on_lookup_failure():
     client = MagicMock()
     client.dex.token_info.side_effect = RuntimeError("upstream 500")
+    # The raw-payload fallback can't recover decimals from a bare mock
+    # (non-dict), so the lookup still surfaces a clear SdkError.
     with pytest.raises(SdkError):
         dex_service.resolve_decimals(client, 8453, _USDC)
+
+
+def test_resolve_decimals_falls_back_to_raw_when_model_rejects():
+    """If the SDK's typed TokenInfo rejects the response over an unrelated
+    field (e.g. live server returns `tags` as objects vs the SDK's
+    `list[str]`), decimals must still resolve from the raw tool payload —
+    a swap can't fail on a metadata schema mismatch.
+    """
+    client = MagicMock()
+    client.dex.token_info.side_effect = ValueError(
+        "8 validation errors for TokenInfo: tags.0 Input should be a valid string"
+    )
+    client.dex._call_tool.return_value = {
+        "token": {"address": _USDC, "symbol": "USDC", "decimals": 6,
+                  "tags": [{"provider": "1inch", "value": "bluechip"}]}
+    }
+    assert dex_service.resolve_decimals(client, 8453, _USDC) == 6
+    client.dex._call_tool.assert_called_once()
+
+
+def test_resolve_decimals_fallback_handles_unwrapped_payload():
+    """Fallback also reads decimals when the server doesn't wrap in `token`."""
+    client = MagicMock()
+    client.dex.token_info.side_effect = ValueError("validation error")
+    client.dex._call_tool.return_value = {"decimals": 18, "symbol": "WETH"}
+    assert dex_service.resolve_decimals(client, 8453, _WETH) == 18
 
 
 # -- get_quote end-to-end (mocked client) ----------------------------------


### PR DESCRIPTION
## Bottom line

`get_swap_quote` / `POST /api/v1/agent/dex/quote` returned `INSUFFICIENT_LIQUIDITY`
for **every** pair, chain, and amount (the tester's blocker, Discord `#testing-log`).
Root cause: the agent forwarded the caller's **human** `amount` (e.g. `0.001` = 0.001 ETH)
straight to the backend, which expects the input token's **base units (wei)** —
so `0.001` was read as sub-wei dust and 1inch found no route. This PR converts
human ↔ base units at the backend boundary.

Fixes #108.

## What & why

The backend `dex_get_quote` (and 1inch behind it) take `amount` in the input
token's smallest units. The agent works in **human** units everywhere else
(`get_balances`, paper fills, `wallet-presentation.md`). The base-units
conversion at the boundary was missing, so `0.001` ETH → `0.001` base units →
dust → `INSUFFICIENT_LIQUIDITY` for every amount on every chain.

## Change

- **New `server/src/services/dex_service.py`** — shared quote service:
  - resolves input/output token decimals (native sentinel offline; ERC-20 via `token_info`),
  - converts the human `amount` → base units before the backend call,
  - converts the returned `input_amount`/`output_amount` → human units (raw kept as `*_base_units`),
  - rejects a dust amount that rounds to 0 base units with a clear `VALIDATION_ERROR`.
- `routes/dex.py` + `mcp/tools.py::get_swap_quote` call the shared service.
- **Decimals lookup hardened**: the live server returns `tags` as `{provider,value}`
  objects while the SDK models `tags: list[str]`, so the typed `TokenInfo` parse
  failed and decimals couldn't be read. `resolve_decimals` now falls back to the
  raw tool payload's `decimals` field if the typed model rejects an unrelated
  field — a swap must not fail on metadata schema drift. Root cause is also fixed
  upstream in the SDK: MangroveTechnologies/MangroveMarkets#47.
- `docs/api-reference.md`: note distinguishing the raw backend tool (base units)
  from the agent wrapper (human units).

**Scope:** the reported blocker is the **quote** path — fixed and verified here.
`execute_swap` / cron share the same root cause via `order_executor` (tracked in
#122); that path moves real funds and needs live verification on a funded testnet
wallet, so it is a follow-up. Today the live swap path also dusts and fails
closed, so it is safe in the meantime.

## Verification — LIVE hosted backend (not a stub)

Rebased onto current `main`, ran the worktree server bare-metal and drove the
real `POST /api/v1/agent/dex/quote` route → real `mangrovemarkets` SDK → the
**hosted** MangroveMarkets backend (`https://mangrovemarkets-pcqgpciucq-uc.a.run.app`)
→ 1inch, using the agent's configured `MANGROVE_API_KEY`. USDC→WETH on Base (8453):

```
amount=1.0 (human)  -> HTTP 200
  quote_id:                 1inch-2a1a5267b5684917a7371b013e7ceb07
  input_amount: 1.0          input_amount_base_units: 1000000        (decimals 6)
  output_amount: 0.000641…   output_amount_base_units: 641299809117099 (decimals 18)

amount=25.5 (human) -> HTTP 200
  quote_id:                 1inch-407f85f39c0d46c78737edba5e8e588f
  input_amount: 25.5         input_amount_base_units: 25500000
  output_amount: 0.016353…
```

Pre-fix, the same human-amount call returned `[200] INSUFFICIENT_LIQUIDITY`
(matches the tester's screenshot). The base-units conversion is correct in both
directions against the real backend.

**Tests:** `415 passed, 2 skipped` (unit + integration + e2e); `ruff` clean.
New in `tests/unit/test_dex_service.py`: human→base-units conversion, dust
rejection, and decimals-fallback-on-model-rejection regressions.
