### PR TITLE
feat(hooks): document guardrails + name the hook file on every block

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -1,4 +1,4 @@
-# app-in-a-box — Claude Code guardrail hooks
+# mangrove-agent — Claude Code guardrail hooks
 
 These hooks are **harness-enforced guardrails**: Claude Code runs them automatically (wired in [`.claude/settings.json`](../settings.json)) and the agent cannot disable them mid-session. They exist so the agent can't — by accident or by a prompt-injection — commit to `main`, leak wallet secrets into the transcript, or fire a doomed/unfunded swap.
 

--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -1,4 +1,4 @@
-# mangrove-agent — Claude Code guardrail hooks
+# app-in-a-box — Claude Code guardrail hooks
 
 These hooks are **harness-enforced guardrails**: Claude Code runs them automatically (wired in [`.claude/settings.json`](../settings.json)) and the agent cannot disable them mid-session. They exist so the agent can't — by accident or by a prompt-injection — commit to `main`, leak wallet secrets into the transcript, or fire a doomed/unfunded swap.
 
@@ -8,14 +8,16 @@ These hooks are **harness-enforced guardrails**: Claude Code runs them automatic
 
 | Hook | Event(s) | Fires on | Action |
 |---|---|---|---|
-| [`block-main-commits.sh`](block-main-commits.sh) | `PreToolUse` (Bash) | A `git commit`/`merge`/`rebase`/`reset --hard`/`reset HEAD~` while on `main`/`master`, or a `git push` (incl. `--force`) to `origin/main`/`master`. Detects the target via `git -C <path>` (worktree-safe). | **exit 2** (blocks) with a feature-branch fix. No-op outside a git repo or on non-Bash tools. |
-| [`block-wallet-secrets.sh`](block-wallet-secrets.sh) | `UserPromptSubmit` (`--mode user`) + `PostToolUse` (`--mode tool`) | A private-key shape (`0x`+64 hex) or a 12/24-word BIP-39 mnemonic. **user mode:** any match. **tool mode:** only when the key-shaped value sits in a key-named field (`private_key`, `seed_phrase`, …) — so tx hashes don't false-trip. | **exit 2** (blocks) and points to the out-of-band `stash-secret.sh` → vault-token import flow. Keeps key material out of the transcript + API context. |
-| [`preflight-swap.sh`](preflight-swap.sh) | `PreToolUse` (`mcp__mangrove-agent__execute_swap`) | The swap's wallet holds **0** of the input token on the target chain. | **exit 2** (blocks) with chain/funding guidance. Passes through if balance is non-zero or can't be cleanly read (the SDK then surfaces its own error). |
-| [`_hooklib.sh`](_hooklib.sh) | — (sourced) | n/a | Shared `block_footer` helper — appends the absolute hook path + don't-bypass notice to every block message. |
+| [`block-main-commits.sh`](block-main-commits.sh) | `PreToolUse` (Bash) | A `git commit`/`merge`/`rebase`/`reset --hard`/`reset HEAD~` while on `main`/`master`, or a `git push` (incl. `--force`) to `origin/main`/`master`. Detects the target via `git -C <path>` (worktree-safe). | **Blocker — exit 2** with a feature-branch fix. No-op outside a git repo or on non-Bash tools. |
+| [`block-wallet-secrets.sh`](block-wallet-secrets.sh) | `UserPromptSubmit` (`--mode user`) + `PostToolUse` (`--mode tool`) | A private-key shape (`0x`+64 hex) or a 12/24-word BIP-39 mnemonic. **user mode:** any match. **tool mode:** only when the key-shaped value sits in a key-named field (`private_key`, `seed_phrase`, …) — so tx hashes don't false-trip. | **Blocker — exit 2** and points to the out-of-band `stash-secret.sh` → vault-token import flow. Keeps key material out of the transcript + API context. |
+| [`preflight-swap.sh`](preflight-swap.sh) | `PreToolUse` (`mcp__mangrove-agent__execute_swap`) | The swap's wallet holds **0** of the input token on the target chain. | **Blocker — exit 2** with chain/funding guidance. Passes through if balance is non-zero or can't be cleanly read (the SDK then surfaces its own error). |
+| [`_hooklib.sh`](_hooklib.sh) | — (sourced) | n/a | Shared `block_footer` helper — appends the absolute hook path + don't-bypass notice to every block message. Not a hook itself; never registered in settings. |
+
+All three live hooks are **blockers** (they `exit 2` to stop the action). There are no reminder-only hooks registered in this repo's `settings.json`; if one is ever added (a hook that only prints to stdout and `exit 0`s), document it here as a **reminder** and do **not** give it a `block_footer`.
 
 ## Related: the code-level signing guard (not a hook)
 
-Beyond these Claude-side hooks, there is a **hard signing guard in the agent itself**: [`server/src/services/wallet_manager.py::_validate_sign_target`](../../server/src/services/wallet_manager.py). Invariant: the agent signs **only** a 1inch `AggregationRouter` call or the ERC-20 `approve()` whose spender is a 1inch router — any other transaction shape (arbitrary EOA transfers, non-1inch contracts) is **refused at sign time**, on every chain. `preflight-swap.sh` is the Claude-side companion: it gates *when* a swap is attempted (balance present); `_validate_sign_target` restricts *what* may ever be signed.
+Beyond these Claude-side hooks, there is a **hard signing guard in the agent itself**: [`server/src/services/wallet_manager.py`](../../server/src/services/wallet_manager.py) (`_validate_sign_target`). Invariant: the agent signs **only** a 1inch `AggregationRouter` call or the ERC-20 `approve()` whose spender is a 1inch router — any other transaction shape (arbitrary EOA transfers, non-1inch contracts) is **refused at sign time**, on every chain. `preflight-swap.sh` is the Claude-side companion: it gates *when* a swap is attempted (balance present); the signing guard restricts *what* may ever be signed.
 
 ## Adjusting a hook
 

--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -1,0 +1,22 @@
+# mangrove-agent — Claude Code guardrail hooks
+
+These hooks are **harness-enforced guardrails**: Claude Code runs them automatically (wired in [`.claude/settings.json`](../settings.json)) and the agent cannot disable them mid-session. They exist so the agent can't — by accident or by a prompt-injection — commit to `main`, leak wallet secrets into the transcript, or fire a doomed/unfunded swap.
+
+**Standing rule:** when a hook blocks, its message now names the **exact hook file (absolute path)** and states that the block is intentional. **Only a human edits or removes a hook** — the agent must never modify/disable/delete one to route around a block. If a rule is wrong, change the file in a reviewed commit.
+
+## The hooks
+
+| Hook | Event(s) | Fires on | Action |
+|---|---|---|---|
+| [`block-main-commits.sh`](block-main-commits.sh) | `PreToolUse` (Bash) | A `git commit`/`merge`/`rebase`/`reset --hard`/`reset HEAD~` while on `main`/`master`, or a `git push` (incl. `--force`) to `origin/main`/`master`. Detects the target via `git -C <path>` (worktree-safe). | **exit 2** (blocks) with a feature-branch fix. No-op outside a git repo or on non-Bash tools. |
+| [`block-wallet-secrets.sh`](block-wallet-secrets.sh) | `UserPromptSubmit` (`--mode user`) + `PostToolUse` (`--mode tool`) | A private-key shape (`0x`+64 hex) or a 12/24-word BIP-39 mnemonic. **user mode:** any match. **tool mode:** only when the key-shaped value sits in a key-named field (`private_key`, `seed_phrase`, …) — so tx hashes don't false-trip. | **exit 2** (blocks) and points to the out-of-band `stash-secret.sh` → vault-token import flow. Keeps key material out of the transcript + API context. |
+| [`preflight-swap.sh`](preflight-swap.sh) | `PreToolUse` (`mcp__mangrove-agent__execute_swap`) | The swap's wallet holds **0** of the input token on the target chain. | **exit 2** (blocks) with chain/funding guidance. Passes through if balance is non-zero or can't be cleanly read (the SDK then surfaces its own error). |
+| [`_hooklib.sh`](_hooklib.sh) | — (sourced) | n/a | Shared `block_footer` helper — appends the absolute hook path + don't-bypass notice to every block message. |
+
+## Related: the code-level signing guard (not a hook)
+
+Beyond these Claude-side hooks, there is a **hard signing guard in the agent itself**: [`server/src/services/wallet_manager.py::_validate_sign_target`](../../server/src/services/wallet_manager.py). Invariant: the agent signs **only** a 1inch `AggregationRouter` call or the ERC-20 `approve()` whose spender is a 1inch router — any other transaction shape (arbitrary EOA transfers, non-1inch contracts) is **refused at sign time**, on every chain. `preflight-swap.sh` is the Claude-side companion: it gates *when* a swap is attempted (balance present); `_validate_sign_target` restricts *what* may ever be signed.
+
+## Adjusting a hook
+
+Edit the file and commit (changes are visible in review). To disable one, remove its entry from [`.claude/settings.json`](../settings.json) and/or delete the script — **a human action, in a reviewed PR**. The agent will not do this for you.

--- a/.claude/hooks/_hooklib.sh
+++ b/.claude/hooks/_hooklib.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# _hooklib.sh — shared helpers for this repo's .claude/hooks/*.sh guardrails.
+#
+# Source it near the top of a hook:
+#     source "$(dirname "${BASH_SOURCE[0]}")/_hooklib.sh"
+# then, right before `exit 2` on a block, append the standard footer:
+#     block_footer "${BASH_SOURCE[0]}"; exit 2
+#
+# The footer names the EXACT hook file (absolute path) so the user always knows
+# which guardrail fired and where it lives, and states the standing rule that
+# the agent must not disable/delete the hook to route around it — only the human
+# edits or removes it. Keep this dependency co-located in .claude/hooks/.
+
+# block_footer <hook-path>  — emit the standard "which guardrail + don't-bypass"
+# footer to stderr (the channel Claude Code surfaces back to the agent/user).
+block_footer() {
+    local src="${1:-${BASH_SOURCE[0]}}" abs
+    abs="$(cd "$(dirname "$src")" 2>/dev/null && pwd)/$(basename "$src")"
+    cat >&2 <<EOF
+
+──────────────────────────────────────────────────────────────────────────
+Guardrail: ${abs}
+This block is intentional. Do NOT modify, disable, or delete this hook to get
+around it. If the rule itself is wrong, the human edits/removes that file —
+the agent must not. (See .claude/hooks/README.md for what each hook guards.)
+──────────────────────────────────────────────────────────────────────────
+EOF
+}

--- a/.claude/hooks/block-main-commits.sh
+++ b/.claude/hooks/block-main-commits.sh
@@ -31,6 +31,10 @@
 
 set -uo pipefail
 
+# Shared footer: names this hook's absolute path + the don't-bypass rule.
+# Degrades to a no-op if the lib is somehow absent (never breaks the guard).
+source "$(dirname "${BASH_SOURCE[0]}")/_hooklib.sh" 2>/dev/null || block_footer() { :; }
+
 INPUT="$(cat)"
 
 # Extract tool_name + the command payload. The PreToolUse JSON shape is
@@ -117,6 +121,7 @@ Fix:
 If you intended to rebase, merge, or reset main to track origin, do it
 from a throwaway branch or via the GitHub UI so the history is reviewed.
 EOF
+                block_footer "${BASH_SOURCE[0]}"
                 exit 2
                 ;;
         esac
@@ -144,6 +149,7 @@ branch and open a PR:
   git push -u origin feature/<short-description>
   gh pr create
 EOF
+        block_footer "${BASH_SOURCE[0]}"
         exit 2
         ;;
 esac

--- a/.claude/hooks/block-wallet-secrets.sh
+++ b/.claude/hooks/block-wallet-secrets.sh
@@ -31,6 +31,9 @@
 
 set -uo pipefail
 
+# Shared footer: names this hook's absolute path + the don't-bypass rule.
+source "$(dirname "${BASH_SOURCE[0]}")/_hooklib.sh" 2>/dev/null || block_footer() { :; }
+
 MODE=""
 for arg in "$@"; do
     case "$arg" in
@@ -119,4 +122,5 @@ the plaintext should go through the SecretVault + reveal-secret.sh CLI.
 If this was a false positive (not a real key/mnemonic), rephrase to
 avoid the 0x + 64-hex or 12/24-lowercase-word structure.
 EOF
+block_footer "${BASH_SOURCE[0]}"
 exit 2

--- a/.claude/hooks/preflight-swap.sh
+++ b/.claude/hooks/preflight-swap.sh
@@ -17,6 +17,9 @@
 
 set -uo pipefail
 
+# Shared footer: names this hook's absolute path + the don't-bypass rule.
+source "$(dirname "${BASH_SOURCE[0]}")/_hooklib.sh" 2>/dev/null || block_footer() { :; }
+
 INPUT="$(cat)"
 
 # Fast path: only fire on the execute_swap MCP tool. All other tools pass through.
@@ -148,6 +151,7 @@ If you expected this wallet to be funded:
 
 Re-run execute_swap once the deposit is confirmed on the target chain.
 EOF
+    block_footer "${BASH_SOURCE[0]}"
     exit 2
 fi
 


### PR DESCRIPTION
Reference implementation for the portfolio-wide hook-visibility work (template to fan out to the other repos).

## What
- **`.claude/hooks/README.md`** — catalogs the three guardrails (`block-main-commits`, `block-wallet-secrets`, `preflight-swap`): event, what trips each, and action — plus the **code-level 1inch signing guard** (`server/src/services/wallet_manager.py::_validate_sign_target`), and the standing rule that **only a human disables/removes a hook**.
- **`_hooklib.sh`** — shared `block_footer()` that appends the firing hook's **absolute path** + a *"this block is intentional, don't bypass it"* notice to every block message. (The hooks already self-named with a *relative* path; this makes it unambiguous and adds the don't-bypass rule consistently.)
- Wired `block_footer` into all three hooks' block paths. **Detection logic untouched**; degrades to a no-op if the lib is somehow absent (never weakens a guard).

## Why
You flagged: (a) the agent hooks weren't **documented for review**, and (b) on a block the user should be told **which hook / where it lives**. This addresses both, and encodes the never-bypass / human-only-removes rule in the message itself.

## Verified
`bash -n` on all four scripts; `block-main-commits` and `block-wallet-secrets` still **exit 2** and now print:
```
Guardrail: /…/.claude/hooks/<hook>.sh
This block is intentional. Do NOT modify, disable, or delete this hook to get around it…
```

## Next (separate PRs, this is the template)
Replicate to `fourth-turning-partners`, `app-in-a-box`, `mangrove-platform-backend`, and the portfolio-root `~/mangrove/.claude/hooks/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)