### PR TITLE
fix(hooks): resolve block_footer path at source time (robust to cd)

### DIFF
--- a/.claude/hooks/_hooklib.sh
+++ b/.claude/hooks/_hooklib.sh
@@ -11,11 +11,20 @@
 # the agent must not disable/delete the hook to route around it — only the human
 # edits or removes it. Keep this dependency co-located in .claude/hooks/.
 
+# Capture the hooks dir at SOURCE time (top of the hook, before it may `cd`
+# elsewhere). The hook and this lib are co-located, so this dir + the hook's
+# basename is its true path regardless of the cwd when block_footer runs.
+_HOOKLIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+
 # block_footer <hook-path>  — emit the standard "which guardrail + don't-bypass"
 # footer to stderr (the channel Claude Code surfaces back to the agent/user).
 block_footer() {
     local src="${1:-${BASH_SOURCE[0]}}" abs
-    abs="$(cd "$(dirname "$src")" 2>/dev/null && pwd)/$(basename "$src")"
+    if [ -n "${_HOOKLIB_DIR:-}" ]; then
+        abs="$_HOOKLIB_DIR/$(basename "$src")"
+    else
+        abs="$(cd "$(dirname "$src")" 2>/dev/null && pwd)/$(basename "$src")"
+    fi
     cat >&2 <<EOF
 
 ──────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
block-main-commits-style hooks `cd` to another directory before they block (e.g. to inspect a different repo), which corrupts `block_footer`'s cwd-relative path resolve — the printed Guardrail path no longer points at the real hook file.

This captures the hooks dir at **source time** (`_HOOKLIB_DIR`, set when the hook sources `_hooklib.sh` at its top, before any `cd`) and prefers it when composing the absolute hook path, falling back to the old cwd-relative resolve only if that's unset.

Mirrors the fix already merged in mangrove-one/mangrove-workspace #54. Only `.claude/hooks/_hooklib.sh` changes; the helper is now byte-identical across the repos that carry it.

Verified: `bash -n` clean, and sourcing from a different cwd then calling `block_footer` prints the correct hooks-dir path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)