### PR TITLE
fix(wallet): generate keys locally in-process + add LOCAL_AGENT_URL

### DIFF
--- a/.claude/rules/wallet-presentation.md
+++ b/.claude/rules/wallet-presentation.md
@@ -2,6 +2,20 @@
 
 Rules for `create_wallet`, `import_wallet`, `get_balances`, and any future wallet tooling.
 
+## Core invariant -- keys are generated, stored, and signed with LOCALLY
+
+Wallet **key generation, storage, and signing all happen on this machine, in
+the agent process** -- the private key never crosses the network:
+
+- `create_wallet` mints the keypair **in-process via `eth_account`** (see
+  `wallet_manager.create_wallet`). It does NOT call a remote server to generate
+  keys. (`sign()` likewise decrypts + signs locally.)
+- **`LOCAL_AGENT_URL`** (default `http://localhost:9080`) is this agent's own
+  surface -- wallet/secret ops (the SecretVault + `reveal`/`stash`/`confirm`
+  scripts) live here. It is distinct from **`MANGROVEMARKETS_BASE_URL`**, the
+  *remote, keyless* MangroveMarkets server used only for DEX quotes / routing /
+  balances / broadcast. The markets server never receives a private key.
+
 ## Core invariant -- agent NEVER sees plaintext keys
 
 After phase-2 security rework, wallet secrets flow out-of-band:

--- a/scripts/confirm-backup.sh
+++ b/scripts/confirm-backup.sh
@@ -16,7 +16,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$REPO_ROOT"
 
-BASE_URL="${BASE_URL:-http://localhost:9080}"
+LOCAL_AGENT_URL="${LOCAL_AGENT_URL:-http://localhost:9080}"
 CONFIG_FILE="server/src/config/local-config.json"
 
 GREEN="\033[32m"; RED="\033[31m"; YELLOW="\033[33m"; DIM="\033[2m"; CLR="\033[0m"
@@ -41,16 +41,16 @@ if [ -z "$API_KEY" ]; then
   fail "No API key in $CONFIG_FILE."
 fi
 
-if ! curl -fsS -m 5 "$BASE_URL/health" >/dev/null 2>&1; then
-  fail "$BASE_URL/health not responding. Is the agent running?"
+if ! curl -fsS -m 5 "$LOCAL_AGENT_URL/health" >/dev/null 2>&1; then
+  fail "$LOCAL_AGENT_URL/health not responding. Is the agent running?"
 fi
 
 # Export so the heredoc (with quoted 'PY' tag to disable shell
 # interpolation) can read via os.environ.
-export API_KEY BASE_URL ADDRESS
+export API_KEY LOCAL_AGENT_URL ADDRESS
 RESPONSE="$(python3 - <<'PY'
 import json, urllib.request, os, sys
-url = os.environ["BASE_URL"] + "/api/v1/agent/wallet/" + os.environ["ADDRESS"] + "/confirm-backup"
+url = os.environ["LOCAL_AGENT_URL"] + "/api/v1/agent/wallet/" + os.environ["ADDRESS"] + "/confirm-backup"
 req = urllib.request.Request(
     url,
     data=b"{}",

--- a/scripts/reveal-secret.sh
+++ b/scripts/reveal-secret.sh
@@ -27,7 +27,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$REPO_ROOT"
 
-BASE_URL="${BASE_URL:-http://localhost:9080}"
+LOCAL_AGENT_URL="${LOCAL_AGENT_URL:-http://localhost:9080}"
 CONFIG_FILE="server/src/config/local-config.json"
 
 GREEN="\033[32m"; RED="\033[31m"; YELLOW="\033[33m"; DIM="\033[2m"; CLR="\033[0m"
@@ -75,14 +75,14 @@ if [ -z "$API_KEY" ]; then
   fail "No API key in $CONFIG_FILE (API_KEYS field)."
 fi
 
-if ! curl -fsS -m 5 "$BASE_URL/health" >/dev/null 2>&1; then
-  fail "$BASE_URL/health not responding. Is the agent running?"
+if ! curl -fsS -m 5 "$LOCAL_AGENT_URL/health" >/dev/null 2>&1; then
+  fail "$LOCAL_AGENT_URL/health not responding. Is the agent running?"
 fi
 
 if [ "$MODE" = "id" ]; then
-  URL="$BASE_URL/api/v1/agent/wallet/reveal-secret/$ARG"
+  URL="$LOCAL_AGENT_URL/api/v1/agent/wallet/reveal-secret/$ARG"
 else
-  URL="$BASE_URL/api/v1/agent/wallet/$ARG/reveal"
+  URL="$LOCAL_AGENT_URL/api/v1/agent/wallet/$ARG/reveal"
 fi
 
 # Export so the Python heredoc can read via os.environ.

--- a/scripts/stash-secret.sh
+++ b/scripts/stash-secret.sh
@@ -24,7 +24,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$REPO_ROOT"
 
-BASE_URL="${BASE_URL:-http://localhost:9080}"
+LOCAL_AGENT_URL="${LOCAL_AGENT_URL:-http://localhost:9080}"
 CONFIG_FILE="server/src/config/local-config.json"
 
 GREEN="\033[32m"; RED="\033[31m"; YELLOW="\033[33m"; DIM="\033[2m"; CLR="\033[0m"
@@ -49,8 +49,8 @@ if [ -z "$API_KEY" ]; then
   fail "No API key in $CONFIG_FILE (API_KEYS field)."
 fi
 
-if ! curl -fsS -m 5 "$BASE_URL/health" >/dev/null 2>&1; then
-  fail "$BASE_URL/health not responding. Is the agent running? (./setup.sh)"
+if ! curl -fsS -m 5 "$LOCAL_AGENT_URL/health" >/dev/null 2>&1; then
+  fail "$LOCAL_AGENT_URL/health not responding. Is the agent running? (./setup.sh)"
 fi
 
 # -- prompt for secret (hidden) ---------------------------------------------
@@ -78,12 +78,12 @@ step "Stashing in the agent's in-process vault"
 # contains characters that would break a shell-quoted curl data arg.
 # Export so the heredoc (run in a subshell via python3 - <<'PY') can
 # read via os.environ.
-export SECRET API_KEY BASE_URL
+export SECRET API_KEY LOCAL_AGENT_URL
 RESPONSE="$(python3 - <<'PY'
 import json, urllib.request, os, sys
 body = json.dumps({"secret": os.environ["SECRET"]}).encode()
 req = urllib.request.Request(
-    os.environ["BASE_URL"] + "/api/v1/agent/wallet/stash-secret",
+    os.environ["LOCAL_AGENT_URL"] + "/api/v1/agent/wallet/stash-secret",
     data=body,
     method="POST",
     headers={"Content-Type": "application/json", "X-API-Key": os.environ["API_KEY"]},

--- a/server/src/config.py
+++ b/server/src/config.py
@@ -48,6 +48,13 @@ class _Config:
         self._load_required_keys(required_keys, gcp_project_id)
         self._load_full_app_keys(full_app_keys, gcp_project_id)
 
+        # LOCAL_AGENT_URL — this agent's own local surface. Wallet/secret ops
+        # (key generation, the SecretVault, reveal/stash/confirm) live HERE, on
+        # the client machine, and must never be a remote host. Distinct from
+        # MANGROVEMARKETS_BASE_URL (the remote, keyless DEX-routing server).
+        # Defaulted (not required) so existing configs without the key still boot.
+        self.LOCAL_AGENT_URL = self._raw_config.get("LOCAL_AGENT_URL") or "http://localhost:9080"
+
     def _load_required_keys(self, required_keys: set, gcp_project_id: str) -> None:
         """Validate and set all required config keys. Exits on missing or null values."""
         for key in required_keys:

--- a/server/src/config/dev-config.json
+++ b/server/src/config/dev-config.json
@@ -3,6 +3,7 @@
   "API_KEYS": "secret:app-config-dev:api_keys",
   "MANGROVE_API_KEY": "secret:app-config-dev:mangrove_api_key",
   "MANGROVEMARKETS_BASE_URL": "http://localhost:9081",
+  "LOCAL_AGENT_URL": "http://localhost:9080",
   "DB_PATH": "./agent-data/agent.db",
   "MASTER_KEY_PATH": "./agent-data/master.key",
   "KEYRING_SERVICE_NAME": "mangrove-agent",

--- a/server/src/config/local-example-config.json
+++ b/server/src/config/local-example-config.json
@@ -3,6 +3,7 @@
   "API_KEYS": "dev-key-1",
   "MANGROVE_API_KEY": "REPLACE_WITH_YOUR_DEV_OR_PROD_KEY",
   "MANGROVEMARKETS_BASE_URL": "http://localhost:9081",
+  "LOCAL_AGENT_URL": "http://localhost:9080",
   "DB_PATH": "./agent-data/agent.db",
   "MASTER_KEY_PATH": "./agent-data/master.key",
   "KEYRING_SERVICE_NAME": "mangrove-agent",

--- a/server/src/config/prod-config.json
+++ b/server/src/config/prod-config.json
@@ -3,6 +3,7 @@
   "API_KEYS": "secret:app-config-prod:api_keys",
   "MANGROVE_API_KEY": "secret:app-config-prod:mangrove_api_key",
   "MANGROVEMARKETS_BASE_URL": "http://localhost:9081",
+  "LOCAL_AGENT_URL": "http://localhost:9080",
   "DB_PATH": "./agent-data/agent.db",
   "MASTER_KEY_PATH": "./agent-data/master.key",
   "KEYRING_SERVICE_NAME": "mangrove-agent",

--- a/server/src/config/test-config.json
+++ b/server/src/config/test-config.json
@@ -3,6 +3,7 @@
   "API_KEYS": "test-key-1,test-key-2",
   "MANGROVE_API_KEY": "test_key_not_used_in_unit_tests",
   "MANGROVEMARKETS_BASE_URL": "http://localhost:9081",
+  "LOCAL_AGENT_URL": "http://localhost:9080",
   "DB_PATH": ":memory:",
   "MASTER_KEY_PATH": "./agent-data-test/master.key",
   "KEYRING_SERVICE_NAME": "mangrove-agent-test",

--- a/server/src/services/wallet_manager.py
+++ b/server/src/services/wallet_manager.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 
 import uuid
 from datetime import datetime, timezone
-from typing import Any, Literal
+from typing import Literal
 
 from eth_account import Account
 from eth_account.datastructures import SignedTransaction
@@ -35,7 +35,6 @@ from eth_utils import to_checksum_address
 from pydantic import BaseModel
 
 from src.services.secret_vault import vault
-from src.shared.clients.mangrove import mangrove_markets_client
 from src.shared.crypto.fernet import decrypt, encrypt, get_master_key_source
 from src.shared.db.sqlite import get_connection
 from src.shared.errors import (
@@ -263,22 +262,6 @@ def _derive_address(secret: str) -> str:
     return Account.from_mnemonic(s).address
 
 
-def _extract_secret(create_result: Any) -> str:
-    """Pull whichever sensitive field the SDK populated.
-
-    SDK's WalletCreateResult can have any of: seed_phrase, private_key, secret.
-    We store whichever is present, in priority order (seed_phrase > private_key > secret).
-    """
-    for attr in ("seed_phrase", "private_key", "secret"):
-        val = getattr(create_result, attr, None)
-        if val:
-            return str(val)
-    raise SigningError(
-        "SDK wallet.create() returned no seed_phrase, private_key, or secret.",
-        suggestion="Check the mangrovemarkets SDK version and the target chain's supported wallet_creation mode.",
-    )
-
-
 def _safety_note(secret_type: SecretType, master_key_source: str) -> str:
     src_blurb = {
         "keyfile": "your local keyfile (./agent-data/master.key, chmod 600)",
@@ -341,12 +324,18 @@ def create_wallet(
             suggestion="Supported: evm (with a valid chain_id).",
         )
 
-    result = mangrove_markets_client().wallet.create(
-        chain=chain_normalized, network=network, chain_id=chain_id,
-    )
-    secret = _extract_secret(result)
-    address = str(result.address)
-    secret_type = _detect_secret_type(secret)
+    # Generate the keypair LOCALLY, in-process — the private key is never
+    # requested from or transmitted to any remote server. eth_account is the
+    # same library sign() uses. This is the custody invariant: wallet keys are
+    # born, stored, and signed with entirely on this machine; the MangroveMarkets
+    # server only ever sees keyless routing/quotes (see MANGROVEMARKETS_BASE_URL).
+    # EVM-only in v1 (guarded above); a fresh secp256k1 private key is chain-agnostic.
+    acct = Account.create()
+    secret = acct.key.hex()
+    if not secret.startswith("0x"):
+        secret = "0x" + secret
+    address = acct.address
+    secret_type: SecretType = "private_key"
 
     conn = get_connection()
     existing = conn.execute(

--- a/server/tests/e2e/test_smoke.py
+++ b/server/tests/e2e/test_smoke.py
@@ -141,7 +141,6 @@ def client(tmp_path, monkeypatch):
         "src.api.routes.kb.mangrove_ai_client",
         "src.api.routes.wallet.mangrove_markets_client",
         "src.api.routes.dex.mangrove_markets_client",
-        "src.services.wallet_manager.mangrove_markets_client",
         "src.services.candidate_generator.mangrove_ai_client",
         "src.services.backtest_service.mangrove_ai_client",
         "src.services.strategy_service.mangrove_ai_client",

--- a/server/tests/integration/test_wallet_routes.py
+++ b/server/tests/integration/test_wallet_routes.py
@@ -61,7 +61,9 @@ def client(tmp_path, monkeypatch):
         setattr(sdk.portfolio, attr, MagicMock(return_value=m))
     sdk.portfolio.history.return_value = [MagicMock(model_dump=MagicMock(return_value={"tx": "0xabc"}))]
 
-    monkeypatch.setattr("src.services.wallet_manager.mangrove_markets_client", lambda: sdk)
+    # create_wallet now generates the keypair locally (eth_account) — there is
+    # no markets-SDK call on the create path to patch. The route-level client
+    # below still backs the keyless read endpoints (balances/portfolio/history).
     monkeypatch.setattr("src.api.routes.wallet.mangrove_markets_client", lambda: sdk)
 
     from src.app import create_app
@@ -85,7 +87,8 @@ def test_create_wallet_happy_path(client):
     )
     assert r.status_code == 201
     body = r.json()
-    assert body["address"] == _TEST_ADDRESS
+    # Locally generated EVM address (no fixed SDK address to assert against).
+    assert body["address"].startswith("0x") and len(body["address"]) == 42
     assert body["chain"] == "evm"
     # Phase-2 contract: the plaintext key MUST NOT appear in the response.
     assert "seed_phrase" not in body
@@ -139,10 +142,11 @@ def test_reveal_secret_is_single_read(client):
     )
     sid = r.json()["vault_token"]
 
-    # First reveal: 200 + plaintext.
+    # First reveal: 200 + plaintext (a locally generated 0x + 64-hex key).
     r1 = client.get(f"/api/v1/agent/wallet/reveal-secret/{sid}", headers=_auth())
     assert r1.status_code == 200
-    assert r1.json()["secret"] == _TEST_PRIVKEY
+    secret = r1.json()["secret"]
+    assert secret.startswith("0x") and len(secret) == 66
 
     # Second reveal: rejected (vault consumed the entry).
     r2 = client.get(f"/api/v1/agent/wallet/reveal-secret/{sid}", headers=_auth())
@@ -151,19 +155,20 @@ def test_reveal_secret_is_single_read(client):
 
 
 def test_confirm_backup_flips_flag(client):
-    client.post(
+    created = client.post(
         "/api/v1/agent/wallet/create",
         headers=_auth(),
         json={"chain": "evm", "network": "testnet", "chain_id": 84532},
     )
+    addr = created.json()["address"]  # locally generated, capture it
     r = client.post(
-        f"/api/v1/agent/wallet/{_TEST_ADDRESS}/confirm-backup",
+        f"/api/v1/agent/wallet/{addr}/confirm-backup",
         headers=_auth(),
         json={},
     )
     assert r.status_code == 200
     body = r.json()
-    assert body["address"] == _TEST_ADDRESS
+    assert body["address"] == addr
     assert body["backup_confirmed_at"]
     assert "unlocked" in body["message"].lower() or "confirmed" in body["message"].lower()
 

--- a/server/tests/unit/test_wallet_manager.py
+++ b/server/tests/unit/test_wallet_manager.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import os
-from unittest.mock import MagicMock
 
 os.environ.setdefault("ENVIRONMENT", "test")
 
@@ -51,21 +50,18 @@ def stub_keyring(monkeypatch):
 
 @pytest.fixture
 def mock_sdk_create(monkeypatch):
-    """Stub mangrove_markets_client().wallet.create() to return a fixed EVM wallet."""
-    sdk_result = MagicMock()
-    sdk_result.address = _TEST_ADDRESS
-    sdk_result.private_key = _TEST_PRIVKEY
-    sdk_result.seed_phrase = None
-    sdk_result.secret = None
+    """Pin create_wallet's LOCAL key generation to a fixed EVM keypair.
 
-    sdk_client = MagicMock()
-    sdk_client.wallet.create.return_value = sdk_result
-
+    create_wallet now generates keys in-process via eth_account (no SDK / no
+    network), so we patch Account.create() to a deterministic key — tests that
+    reference _TEST_ADDRESS / _TEST_PRIVKEY downstream stay stable.
+    """
+    fixed = Account.from_key(_TEST_PRIVKEY)
     monkeypatch.setattr(
-        "src.services.wallet_manager.mangrove_markets_client",
-        lambda: sdk_client,
+        "src.services.wallet_manager.Account.create",
+        lambda *a, **k: fixed,
     )
-    return sdk_client
+    return fixed
 
 
 # -- crypto/fernet -----------------------------------------------------------
@@ -147,6 +143,25 @@ def test_create_wallet_evm_persists_encrypted(temp_db, stub_keyring, mock_sdk_cr
     assert row["encryption_method"] == "fernet-v1"
     # Fresh wallet: backup not confirmed yet.
     assert row["backup_confirmed_at"] is None
+
+
+def test_create_wallet_generates_locally_no_markets_client(temp_db, stub_keyring):
+    """create_wallet mints the keypair in-process via eth_account — no SDK, no
+    network. Runs WITHOUT mock_sdk_create so it exercises real local generation:
+    two calls yield distinct, valid keys, and wallet_manager no longer even
+    imports a markets client (the custody invariant)."""
+    import src.services.wallet_manager as wm
+    from src.services.wallet_manager import create_wallet
+
+    r1 = create_wallet(chain="evm", network="testnet", chain_id=84532)
+    r2 = create_wallet(chain="evm", network="testnet", chain_id=84532)
+
+    assert r1.address != r2.address  # real randomness, not a fixture
+    for r in (r1, r2):
+        assert r.address.startswith("0x") and len(r.address) == 42
+        assert r.vault_token
+    # No remote key-gen path exists in the wallet service at all.
+    assert not hasattr(wm, "mangrove_markets_client")
 
 
 def test_create_wallet_xrpl_raises(temp_db, stub_keyring, mock_sdk_create):


### PR DESCRIPTION
## Local wallet key generation + `LOCAL_AGENT_URL`

Closes the one custody gap we found: `wallet_manager.create_wallet()` called `mangrove_markets_client().wallet.create()`, so a **freshly created private key was generated at `MANGROVEMARKETS_BASE_URL` and returned over the network**. If that URL is remote, the key is born off-machine — contradicting "keys never leave your machine." (Storage and signing were already local; this was the only remote-custody touchpoint.)

### Changes
1. **Local key generation (the fix).** `create_wallet()` now mints the EVM keypair **in-process via `eth_account.Account.create()`** — the same library `sign()` already uses. No SDK call, no network. Removes the now-dead markets-client import + `_extract_secret` helper.
2. **`LOCAL_AGENT_URL`** (new config key, default `http://localhost:9080`) — makes the custody boundary explicit: this is the agent's *own* local surface for wallet/secret ops, distinct from **`MANGROVEMARKETS_BASE_URL`** (remote, **keyless** DEX routing/quotes only). Defaulted in `config.py` so existing configs without the key still boot; added to the template configs.
3. **Secret scripts** (`reveal`/`stash`/`confirm-secret.sh`) now read `LOCAL_AGENT_URL` (was an ad-hoc `BASE_URL`).
4. **Docs** (`wallet-presentation.md`) state the generate/store/sign-local invariant + the URL split.

`MANGROVEMARKETS_BASE_URL` is unchanged (stays at the run.app value) — with key-gen now local, that URL is keyless, so it's safe wherever it points. (Follow-ups: #119 friendly markets domain, #120 stand up the markets server.)

## Local E2E verification

Built the server bare-metal from this branch on `:9086`, with **`MANGROVEMARKETS_BASE_URL` pointed at an unreachable host (`http://localhost:9`)** — so a successful wallet creation proves key-gen is fully local:

```
Server: /health 200 on :9086  (came up fine despite markets URL unreachable — startup doesn't depend on it)

create_wallet (POST /api/v1/agent/wallet/create, testnet) with markets server UNREACHABLE:
  -> HTTP 201   address=0x3BA67f48DBa34C1732b22EbEBF21aeAff5065535  (valid EVM addr)
  -> vault_token present; secret_type=private_key; backup_required=true
  reveal-secret -> HTTP 200, secret is 0x + 64 hex
  RESULT: PASS — wallet created + key minted LOCALLY while the markets server was unreachable

Test suite (ENVIRONMENT=test pytest tests/):  400 passed, 2 skipped
  + new test: test_create_wallet_generates_locally_no_markets_client
    (two creates yield distinct valid keys; wallet_manager has no markets client at all)
ruff check server/src/ :  All checks passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
