### PR TITLE
fix(setup): honor BARE_PORT + refuse to start on an occupied port

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,10 @@ When it's finished:
 ./scripts/setup.sh --no-mcp                        # skip Claude Code registration
 ./scripts/setup.sh --no-verify                     # skip the post-start verify pass
 ./scripts/setup.sh --docker                        # use Docker instead of bare-metal
+BARE_PORT=9085 ./scripts/setup.sh                  # use a different port (9080 busy/squatted)
 ```
+
+`BARE_PORT` is honored end-to-end (server + health check + MCP registration + verify). If 9080 is occupied, `setup.sh` refuses to start and tells you to free it or set `BARE_PORT` — it will not silently bind-fail or report a false success.
 
 ---
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -534,7 +534,17 @@ traceback names, then rerun `./scripts/setup.sh`.
 
 ### Port 9080 is already in use
 
-Another program on your machine is already using the port the agent needs. These commands find it and stop it:
+`setup.sh` now **refuses to start** (instead of silently failing or reporting a false success) when 9080 is taken. You have two options.
+
+**Option 1 — use a different port** (easiest; e.g. if 9080 is squatted by VSCode/"Code Helper"):
+
+```bash
+BARE_PORT=9085 ./scripts/setup.sh
+```
+
+`BARE_PORT` is honored end-to-end — the server, the `/health` check, the MCP registration, and the verify pass all target it.
+
+**Option 2 — free up 9080** by stopping whatever holds it:
 
 **Mac** — finds whatever is using port 9080 and force-stops it:
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -11,8 +11,8 @@
 #   2. Ensure MANGROVE_API_KEY is set (prompt if missing, unless --yes)
 #   3. Ensure agent-data/ directory exists (keyfile + DB live there)
 #   4. Install deps into .venv (pip install)
-#   5. Start uvicorn in the background (via run-bare.sh under nohup,
-#      unless --foreground)
+#   5. Start uvicorn in the background (honors BARE_PORT; default 9080),
+#      unless --foreground
 #   6. Wait for /health
 #   7. Register the MCP server with Claude Code (unless --no-mcp)
 #   8. Run verify_quickstart.sh (unless --no-verify)
@@ -34,7 +34,11 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$REPO_ROOT"
 
-BASE_URL="${BASE_URL:-http://localhost:9080}"
+PORT="${BARE_PORT:-9080}"
+# Exported so the child scripts (setup-mcp.sh, verify_quickstart.sh) target the
+# SAME port. Honors BARE_PORT so a busy 9080 (e.g. squatted by VSCode/Code
+# Helper) can be sidestepped end-to-end with one env var.
+export BASE_URL="${BASE_URL:-http://localhost:$PORT}"
 CONFIG_FILE="server/src/config/local-config.json"
 EXAMPLE_CONFIG="server/src/config/local-example-config.json"
 PID_FILE="agent-data/bare.pid"
@@ -240,13 +244,20 @@ else
   if [ -f "$PID_FILE" ] && kill -0 "$(cat "$PID_FILE")" 2>/dev/null; then
     info "uvicorn already running (pid $(cat "$PID_FILE"))"
   else
+    # Refuse to start if $PORT is already occupied. Otherwise uvicorn fails to
+    # bind, and we'd fall through to the /health check and verify against the
+    # DIFFERENT process already on $PORT — a false success. (This is the
+    # squatted-9080 case the README warns about, e.g. macOS "Code Helper".)
+    if python3 -c "import socket,sys; s=socket.socket(); s.settimeout(1); rc=s.connect_ex(('127.0.0.1', $PORT)); s.close(); sys.exit(0 if rc==0 else 1)" 2>/dev/null; then
+      fail "port $PORT is already in use — refusing to start. Stop whatever holds it (a stale agent, another service, or a squatter), or re-run with BARE_PORT=<free port>."
+    fi
     if [ "$FOREGROUND" = "yes" ]; then
       info "running in foreground (Ctrl+C to stop)"
       exec env ENVIRONMENT=local PYTHONPATH="$PYTHONPATH" python3 -m uvicorn src.app:app \
-        --host 0.0.0.0 --port 9080 --workers 1 --timeout-keep-alive 120
+        --host 0.0.0.0 --port "$PORT" --workers 1 --timeout-keep-alive 120
     else
       nohup env ENVIRONMENT=local PYTHONPATH="$PYTHONPATH" python3 -m uvicorn src.app:app \
-        --host 0.0.0.0 --port 9080 --workers 1 --timeout-keep-alive 120 \
+        --host 0.0.0.0 --port "$PORT" --workers 1 --timeout-keep-alive 120 \
         > "$REPO_ROOT/$LOG_FILE" 2>&1 &
       echo $! > "$REPO_ROOT/$PID_FILE"
       info "uvicorn started in background (pid $(cat "$PID_FILE"))"


### PR DESCRIPTION
Closes #123.

## Problem
`scripts/setup.sh` hardcoded `--port 9080` in its own uvicorn launch (and `BASE_URL`), **ignoring `BARE_PORT`**. On a machine where 9080 is occupied (e.g. macOS "Code Helper", the squat the README warns about), setup.sh either bind-failed opaquely or — worse — **reported a false success**: the `/health` check and verify pass hit a *different* process already on 9080. This is the root cause of a real onboarding session that spiraled.

## Fix (root cause, not a port-patch bandaid)
- Resolve `PORT=${BARE_PORT:-9080}` **once**; thread it through the uvicorn launch, the **exported** `BASE_URL` (so `setup-mcp.sh` + `verify_quickstart.sh` target the same port), and the success message.
- **Pre-launch port-in-use check**: if `$PORT` is already occupied, **fail loudly** with a clear fix ("free it, or re-run with `BARE_PORT=<free port>`") instead of falling through to `/health` and verifying a stranger.
- Documented `BARE_PORT` in README + the SETUP.md "Port 9080 in use" troubleshooting.

(Filed the deeper setup.sh↔run-bare.sh start-logic duplication as a separate follow-up; this PR fixes the port bug with the smallest safe blast radius on the critical installer path.)

## Local E2E verification (fresh clone)
```
syntax: bash -n scripts/setup.sh — ok

SUCCESS  BARE_PORT=9089 ./scripts/setup.sh --yes --no-mcp
  → bound :9089, success message "running at http://localhost:9089",
    verify_quickstart ran against :9089 (95 tools). Main agent on :9080 untouched.

BIND-GUARD  BARE_PORT=9080 ./scripts/setup.sh  (9080 occupied)
  → ✗ "port 9080 is already in use — refusing to start. … re-run with BARE_PORT=<free port>."
    Non-zero exit. No false success.
```
Shell-only change (no pytest impact); verified by the runs above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)