### PR TITLE
fix(config): point prod/dev MANGROVEMARKETS_BASE_URL at the hosted markets server (#120)

### DIFF
--- a/server/src/config/dev-config.json
+++ b/server/src/config/dev-config.json
@@ -2,7 +2,7 @@
   "AUTH_ENABLED": true,
   "API_KEYS": "secret:app-config-dev:api_keys",
   "MANGROVE_API_KEY": "secret:app-config-dev:mangrove_api_key",
-  "MANGROVEMARKETS_BASE_URL": "http://localhost:9081",
+  "MANGROVEMARKETS_BASE_URL": "https://mangrovemarkets-pcqgpciucq-uc.a.run.app",
   "LOCAL_AGENT_URL": "http://localhost:9080",
   "DB_PATH": "./agent-data/agent.db",
   "MASTER_KEY_PATH": "./agent-data/master.key",

--- a/server/src/config/prod-config.json
+++ b/server/src/config/prod-config.json
@@ -2,7 +2,7 @@
   "AUTH_ENABLED": true,
   "API_KEYS": "secret:app-config-prod:api_keys",
   "MANGROVE_API_KEY": "secret:app-config-prod:mangrove_api_key",
-  "MANGROVEMARKETS_BASE_URL": "http://localhost:9081",
+  "MANGROVEMARKETS_BASE_URL": "https://mangrovemarkets-pcqgpciucq-uc.a.run.app",
   "LOCAL_AGENT_URL": "http://localhost:9080",
   "DB_PATH": "./agent-data/agent.db",
   "MASTER_KEY_PATH": "./agent-data/master.key",


### PR DESCRIPTION
## Problem (#120 footgun)

`prod-config.json` and `dev-config.json` shipped
`"MANGROVEMARKETS_BASE_URL": "http://localhost:9081"`. A deployed prod/dev
agent loading those routes every DEX call (quote / prepare / broadcast /
balances / tx_status) at **localhost** → fails. Fresh `local` installs are
unaffected (setup.sh rewrites the placeholder), but the deployed configs were a
latent footgun.

## Change

`prod` + `dev` → the hosted markets server
`https://mangrovemarkets-pcqgpciucq-uc.a.run.app`.

**Left intentionally unchanged** (documented in the commit):
- `test-config.json` — tests mock `mangrove_markets_client`; localhost means a
  *missing* mock fails locally instead of silently hitting the live server.
- `local-example-config.json` — `setup.sh`'s install-time rewrite keys off the
  exact string `http://localhost:9081`, so the local template keeps the placeholder.

## Verification

Same hosted URL already proven E2E in #109 — live 1inch quotes returned through
`/api/v1/agent/dex/quote` (`1.0 USDC → 0.000641 WETH`, real `quote_id`). This PR
just makes the deployed configs point at that verified endpoint.

Switches to `api.mangrovemarkets.com` once #119 (DNS) is live.

Refs #120.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
