### PR TITLE
chore(deps): bump mangrovemarkets 1.0.2 -> 1.0.3 (TokenInfo.tags fix)

### DIFF
--- a/server/requirements.lock
+++ b/server/requirements.lock
@@ -69,7 +69,7 @@ jsonschema==4.26.0
 jsonschema-specifications==2025.9.1
 keyring==25.7.0
 mangroveai==1.10.0
-mangrovemarkets==1.0.2
+mangrovemarkets==1.0.3
 markdown-it-py==4.2.0
 MarkupSafe==3.0.3
 mcp==1.28.0


### PR DESCRIPTION
## What

Bump the `mangrovemarkets` lock pin `1.0.2 → 1.0.3`, closing the release chain
for MangroveTechnologies/MangroveMarkets#47.

1.0.3 ships the `TokenInfo.tags` fix: the live markets server returns `tags` as
`{provider,value}` objects, which 1.0.2 modelled as `list[str]` and rejected —
breaking `dex.token_info()` and the decimals lookup behind every swap quote.

`requirements.txt` is already a range (`>=1.0.2,<2.0.0`) and needs no change;
only the reproducible lock moves. With 1.0.3 the defense-in-depth fallback added
in #109 becomes redundant safety (token_info parses directly).

## Verification

Fresh `pip install mangrovemarkets==1.0.3` from PyPI parses the exact object-form
`tags` payload that `ValidationError`'d on 1.0.2:
```
decimals=6, tags[0].value='bluechip'
```
PyPI confirms `latest: 1.0.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
