### PR TITLE
feat(model): extend Trade for venue-agnostic CEX/DEX records

### DIFF
--- a/server/src/models/domain.py
+++ b/server/src/models/domain.py
@@ -62,24 +62,43 @@ class Evaluation(BaseModel):
 
 
 class Trade(BaseModel):
-    """A single order execution — live or paper."""
+    """A single order execution — live, paper, or validate (dry-run).
+
+    Venue-agnostic. A DEX swap uses ``input_token``/``output_token``; a CEX
+    fill (e.g. Kraken) uses ``base``/``quote``/``side``/``qty``. The venue +
+    identity fields are all optional, so one record represents a DEX swap, a
+    CEX fill, or a paper sim. ``strategy_id``/``order_intent`` are null for
+    venue-direct trades (e.g. CEX BYOK) that aren't driven by a strategy.
+    """
 
     id: str
-    strategy_id: str
+    strategy_id: str | None = None
     evaluation_id: str | None = None  # null for user-initiated swaps
-    order_intent: OrderIntent
-    mode: Literal["live", "paper"]
-    tx_hash: str | None = None  # null for paper
-    input_token: str
-    input_amount: float
-    output_token: str
-    output_amount: float
+    order_intent: OrderIntent | None = None  # null for venue-direct (CEX) trades
+    mode: Literal["live", "paper", "validate"]
+    tx_hash: str | None = None  # on-chain (DEX) only; null for CEX spot / paper
+    # DEX token in/out (optional aliases); CEX fills use base/quote/side/qty below.
+    input_token: str | None = None
+    input_amount: float | None = None
+    output_token: str | None = None
+    output_amount: float | None = None
     fill_price: float
     fees: dict = Field(default_factory=dict)  # gas, protocol, slippage
     status: Literal["pending", "confirmed", "failed", "simulated"]
     executed_at: datetime
     confirmed_at: datetime | None = None
     p_and_l: float | None = None  # filled when the position closes
+
+    # -- venue + identity (CEX / telemetry; null for legacy DEX strategy trades) --
+    venue: str | None = None            # kraken | 1inch | xpmarket | jupiter
+    user_id: str | None = None          # server-stamped on ingestion; never client-set
+    venue_order_ref: str | None = None  # e.g. Kraken ordertxid
+    venue_trade_ref: str | None = None  # e.g. Kraken trade_id
+    # CEX amount shape (DEX uses input/output_token above)
+    base: str | None = None
+    quote: str | None = None
+    side: Literal["buy", "sell"] | None = None
+    qty: float | None = None
 
 
 class Position(BaseModel):

--- a/server/tests/unit/test_domain.py
+++ b/server/tests/unit/test_domain.py
@@ -1,0 +1,76 @@
+"""Contract tests for the Trade model — venue-agnostic shape.
+
+Trade represents a DEX swap (input/output_token), a CEX fill
+(base/quote/side/qty, e.g. Kraken), or a paper sim. The venue + identity
+fields are optional so one record covers all three. These tests pin that
+contract; DB persistence of the CEX fields is a separate migration step.
+"""
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+
+os.environ.setdefault("ENVIRONMENT", "test")
+
+import pytest  # noqa: E402
+from pydantic import ValidationError  # noqa: E402
+
+from src.models.domain import OrderIntent, Trade  # noqa: E402
+
+
+def _now() -> datetime:
+    return datetime(2026, 6, 27, tzinfo=timezone.utc)
+
+
+def test_legacy_dex_trade_still_valid():
+    """The pre-existing DEX strategy-trade shape must keep validating."""
+    t = Trade(
+        id="t1",
+        strategy_id="s1",
+        order_intent=OrderIntent(action="enter", side="buy", symbol="ETH", amount=100.0),
+        mode="paper",
+        input_token="USDC",
+        input_amount=100.0,
+        output_token="ETH",
+        output_amount=0.04,
+        fill_price=2500.0,
+        status="simulated",
+        executed_at=_now(),
+    )
+    assert t.venue is None and t.user_id is None
+    assert t.base is None and t.qty is None
+
+
+def test_cex_kraken_fill_shape():
+    """A strategy-less CEX fill: base/quote/side/qty + venue refs, no tx_hash."""
+    t = Trade(
+        id="t2",
+        mode="live",
+        venue="kraken",
+        user_id="u_123",            # server-stamped at ingestion
+        venue_order_ref="OABC12-...",   # Kraken ordertxid
+        venue_trade_ref="TQLM2-...",    # Kraken trade_id
+        base="BTC",
+        quote="USD",
+        side="buy",
+        qty=0.01,
+        fill_price=64000.0,
+        status="confirmed",
+        executed_at=_now(),
+    )
+    assert t.strategy_id is None and t.order_intent is None
+    assert t.tx_hash is None          # CEX spot has no chain hash
+    assert t.venue_trade_ref == "TQLM2-..."
+    assert t.input_token is None      # DEX aliases unused for CEX
+
+
+def test_validate_mode_accepted():
+    t = Trade(id="t3", mode="validate", venue="kraken", base="BTC", quote="USD",
+              side="sell", qty=0.5, fill_price=0.0, status="pending", executed_at=_now())
+    assert t.mode == "validate"
+
+
+def test_bad_side_rejected():
+    with pytest.raises(ValidationError):
+        Trade(id="t4", mode="live", side="long", fill_price=1.0,  # type: ignore[arg-type]
+              status="pending", executed_at=_now())


### PR DESCRIPTION
## What

Extends the agent's existing `Trade` model (`server/src/models/domain.py`) so one record
represents a **DEX swap**, a **CEX fill** (e.g. Kraken), or a **paper/validate** sim — per the
CEX BYOK + trade-telemetry design (MangroveTechnologies/MangroveMarkets#48). **No new "family"
class** — just nullable extensions to the model we already have.

- nullable identity/venue: `user_id` (server-stamped, never client-set), `venue`,
  `venue_order_ref`, `venue_trade_ref`
- CEX amount shape: `base`/`quote`/`side`/`qty`; DEX `input_token`/`output_token` kept as
  optional aliases
- `strategy_id` / `order_intent` now optional (a venue-direct CEX trade has neither)
- `mode` gains `validate` (dry-run orders)
- `tx_hash` stays nullable — on-chain (DEX) only; **null for CEX spot**

## Scope

**Model contract only** — the shape the SDK emits and the server validates (steps 2–3 of the
plan; neither touches the agent's SQLite). Backward-compatible: every addition is
optional/defaulted; existing DEX strategy-trade construction and the `trade_log` DB round-trip
are unchanged.

**Deliberately NOT in this PR:** persisting the CEX fields to the local `trades` table. That
table has `NOT NULL` + an FK on `strategy_id` and `NOT NULL` on `order_intent_json`/`input_*`/
`output_*` — a strategy-less CEX fill can't satisfy them, so it needs a SQLite **table-rebuild
migration** on the live `agent.db`. Flagged as its own step rather than done silently here.

## Verification

`419 passed, 2 skipped` (full suite); `ruff` clean. New `tests/unit/test_domain.py` pins the
contract: legacy DEX trade still valid, CEX Kraken-fill shape valid (no `tx_hash`, no
`strategy_id`), `validate` mode accepted, bad `side` rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
