### PR TITLE
feat(cex): keyless 'connect kraken' OAuth path (sibling to BYOK)

### DIFF
--- a/.claude/skills/connect-kraken/SKILL.md
+++ b/.claude/skills/connect-kraken/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: connect-kraken
+description: >-
+  Use when the user wants to connect their Kraken account to trade through the
+  agent WITHOUT creating or handling an API key — "connect Kraken with OAuth",
+  "log in with Kraken", "connect Kraken without a key", "I don't want to manage
+  a Kraken key". This is the KEYLESS (OAuth) mode: the user consents once in a
+  browser and the Mangrove platform holds the grant and trades on their behalf.
+  It is the sibling of the BYOK `setup-kraken` skill — if the user is willing to
+  create and hold their own key locally, use setup-kraken instead; if they want
+  Mangrove to manage access, use this.
+---
+
+# Connect Kraken (keyless, OAuth)
+
+The agent's job here: connect the user's **Kraken account** for trading through
+the agent **without the user ever creating, copying, or holding an API key**.
+
+## The model — say this up front
+
+- **No key, ever.** The user consents once on Kraken's own site (a browser
+  OAuth screen). Mangrove's platform holds the resulting grant, KMS-encrypted,
+  and mints a short-lived, scoped key **per order** — nothing long-lived exists
+  anywhere, and no credential is ever pasted in chat or stored on this machine.
+- **You choose what you authorize.** At connect time you pick a mode:
+  - **view** — read-only: balances and history. (default)
+  - **execute** — view **plus** order placement/cancellation.
+  The choice drives what Kraken's consent screen grants; Mangrove can never do
+  more than you approved. Deposits/withdrawals are never requested.
+- **Revocable two ways.** Disconnect in Mangrove, or revoke the app under
+  Kraken's Connected Apps settings.
+- **Contrast with BYOK (`setup-kraken`):** that mode keeps your own key on your
+  machine and talks to Kraken directly, no Mangrove account needed. This mode
+  needs a Mangrove account but never asks you to touch a key.
+
+## Step 1 — Start the connect
+
+Call `POST /api/v1/agent/cex/oauth/connect-start` with `{"mode": "view"}` or
+`{"mode": "execute"}`. It returns `{authorize_url, state}`.
+
+Show the user the `authorize_url` and tell them: **open this in your browser,
+sign in to Kraken, and approve.** If they chose `execute`, the consent screen
+will list trading permissions; if `view`, it won't. That screen is the consent
+— read it before approving.
+
+## Step 2 — Wait for the connection
+
+Poll `GET /api/v1/agent/cex/oauth/status` until `connected` is true. Confirm the
+returned `connection.mode` matches what they intended (`view` vs `execute`).
+
+## Step 3 — Use it
+
+- `GET /api/v1/agent/cex/oauth/balances` — balances (works in either mode).
+- `POST /api/v1/agent/cex/oauth/orders` — place or dry-run an order. Always run
+  once with `"validate_only": true` first and show the user the venue's own
+  description of what would execute; place the live order only on their explicit
+  go-ahead. An `execute`-mode connection is required — a `view` connection is
+  refused by the platform.
+
+## Guardrails — never
+
+- Never ask the user for a Kraken API key or secret in this flow. If they want
+  to provide one, that's the **other** skill (`setup-kraken`), not this one.
+- Never place a live order without a preceding validate-only preview the user
+  approved.
+- Never claim a trade is attributed/placed without echoing the returned
+  `tx_ids` and venue description.
+
+## Where this fits
+
+`setup-kraken` (BYOK) and `connect-kraken` (OAuth) are siblings. Pick by the
+user's preference: hold-your-own-key-locally vs let-Mangrove-manage-access.
+Everything downstream (validate-then-place, telemetry) is the same.

--- a/scripts/stash-kraken-secret.sh
+++ b/scripts/stash-kraken-secret.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# stash-kraken-secret.sh — connect a Kraken account WITHOUT the API key or
+# secret passing through Claude Code's conversation context.
+#
+# Flow:
+#   1. You run this in a terminal (VSCode integrated terminal is fine).
+#   2. It prompts for the Kraken API key + private key via `read -s` (no echo).
+#   3. It POSTs them to the agent's localhost REST endpoint.
+#   4. The agent stashes them in an in-process vault and returns a short
+#      `vault_token`.
+#   5. You tell the agent (in Claude Code): "connect kraken vault_token <ID>".
+#      The agent calls cex/connect, which persists the creds ENCRYPTED at rest
+#      (Fernet, agent-data/cex-kraken.enc) and consumes the vault entry.
+#
+# The key + secret go terminal -> bash -> localhost HTTP -> agent memory ->
+# encrypted file. They never touch Claude Code's conversation or Anthropic's API.
+#
+# Least privilege: create the Kraken key with Query + Create/Cancel Orders only.
+# Leave WITHDRAW FUNDS OFF. See the setup-kraken skill.
+#
+# Prereqs: agent running (./setup.sh); config has an API_KEYS entry.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+LOCAL_AGENT_URL="${LOCAL_AGENT_URL:-http://localhost:9080}"
+CONFIG_FILE="server/src/config/local-config.json"
+
+GREEN="\033[32m"; RED="\033[31m"; YELLOW="\033[33m"; DIM="\033[2m"; CLR="\033[0m"
+step() { printf "${YELLOW}==>${CLR} %s\n" "$1"; }
+ok()   { printf "${GREEN}  ✓${CLR} %s\n" "$1"; }
+fail() { printf "${RED}  ✗${CLR} %s\n" "$1" >&2; exit 1; }
+info() { printf "${DIM}    %s${CLR}\n" "$1"; }
+
+[ -f "$CONFIG_FILE" ] || fail "$CONFIG_FILE not found. Run ./setup.sh first."
+
+API_KEY="$(python3 -c "
+import json
+raw = json.load(open('$CONFIG_FILE')).get('API_KEYS', '')
+print(next((k.strip() for k in raw.split(',') if k.strip()), ''))
+")"
+[ -n "$API_KEY" ] || fail "No API key in $CONFIG_FILE (API_KEYS field)."
+
+curl -fsS -m 5 "$LOCAL_AGENT_URL/health" >/dev/null 2>&1 \
+  || fail "$LOCAL_AGENT_URL/health not responding. Is the agent running? (./setup.sh)"
+
+echo
+echo "Connect your Kraken account. Input is hidden — nothing will echo."
+echo "Create the key at Kraken > Settings > API with LEAST privilege"
+echo "(Query + Create/Cancel Orders). Leave WITHDRAW FUNDS OFF."
+echo
+
+printf "Kraken API key: "
+read -rs KR_KEY
+echo
+printf "Kraken private key (secret): "
+read -rs KR_SECRET
+echo
+
+[ -n "$KR_KEY" ] && [ -n "$KR_SECRET" ] || fail "Empty key or secret. Aborted."
+
+step "Stashing in the agent's in-process vault"
+export KR_KEY KR_SECRET API_KEY LOCAL_AGENT_URL
+RESPONSE="$(python3 - <<'PY'
+import json, os, sys, urllib.request, urllib.error
+body = json.dumps({"api_key": os.environ["KR_KEY"], "api_secret": os.environ["KR_SECRET"]}).encode()
+req = urllib.request.Request(
+    os.environ["LOCAL_AGENT_URL"] + "/api/v1/agent/cex/stash-kraken",
+    data=body, method="POST",
+    headers={"Content-Type": "application/json", "X-API-Key": os.environ["API_KEY"]},
+)
+try:
+    with urllib.request.urlopen(req, timeout=10) as r:
+        print(r.read().decode())
+except urllib.error.HTTPError as e:
+    sys.stderr.write(f"HTTP {e.code}: {e.read().decode()}\n")
+    sys.exit(1)
+PY
+)"
+KR_KEY=""; KR_SECRET=""; unset KR_KEY KR_SECRET
+
+VAULT_TOKEN="$(printf '%s' "$RESPONSE" | python3 -c "import json,sys; print(json.loads(sys.stdin.read())['vault_token'])")"
+TTL="$(printf '%s' "$RESPONSE" | python3 -c "import json,sys; print(json.loads(sys.stdin.read())['secret_ttl_seconds'])")"
+
+ok "stashed"
+info "vault_token: $VAULT_TOKEN"
+info "expires in: ${TTL}s (single-read)"
+echo
+printf "${GREEN}Next:${CLR} in Claude Code, say:\n\n"
+echo "    connect kraken vault_token $VAULT_TOKEN"
+echo
+echo "The agent calls cex/connect, persists the creds encrypted, and consumes"
+echo "the token. Your key never enters the conversation or the transcript."
+echo

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -49,7 +49,9 @@ mangroveai>=1.7.2,<2.0.0
 # server-side to local. Pinning to >=1.0.2 guarantees the leak-surface
 # fix is in place. See post-mortem: docs/incidents/2026-04-24-eip7702-drain.md
 # Same dist-name-vs-import-name story as mangroveai above.
-mangrovemarkets>=1.0.2,<2.0.0
+# >=1.1.0 carries KrakenClient (BYOK) + TradeRecord + broker attribution
+# (SDK PR #50), which the CEX BYOK + OAuth paths depend on.
+mangrovemarkets>=1.1.0,<2.0.0
 apscheduler[sqlalchemy]>=3.10
 cryptography>=42
 keyring>=24

--- a/server/src/api/router.py
+++ b/server/src/api/router.py
@@ -6,6 +6,7 @@
 """
 from fastapi import APIRouter
 
+from src.api.routes.cex import router as cex_router
 from src.api.routes.dex import router as dex_router
 from src.api.routes.discovery import router as discovery_router
 from src.api.routes.hello_mangrove import router as hello_mangrove_router
@@ -26,6 +27,7 @@ api_router = APIRouter(prefix="/api/v1")
 agent_router = APIRouter(prefix="/agent")
 agent_router.include_router(discovery_router, tags=["discovery"])
 agent_router.include_router(wallet_router)
+agent_router.include_router(cex_router)
 agent_router.include_router(dex_router)
 agent_router.include_router(market_router)
 agent_router.include_router(on_chain_router)

--- a/server/src/api/routes/cex.py
+++ b/server/src/api/routes/cex.py
@@ -1,0 +1,99 @@
+"""CEX (Kraken) BYOK routes — auth-gated.
+
+- POST /api/v1/agent/cex/stash-kraken   stash {api_key, api_secret} -> vault_token
+                                        (called by scripts/stash-kraken-secret.sh)
+- POST /api/v1/agent/cex/connect        consume vault_token -> persist creds (encrypted)
+- GET  /api/v1/agent/cex/status         connected?
+- GET  /api/v1/agent/cex/balances       Kraken balances (BYOK, direct to Kraken)
+- POST /api/v1/agent/cex/validate-order Kraken AddOrder validate=true (dry-run)
+- POST /api/v1/agent/cex/sync-fills     pull Kraken fills -> emit to telemetry
+
+The Kraken key never enters chat: it's stashed out-of-band via the script and
+this server keeps it encrypted at rest. Fills are emitted to the markets server
+(authed by the Mangrove key); the Kraken key never leaves this machine.
+"""
+from __future__ import annotations
+
+import json
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel, Field
+
+from src.config import app_config
+from src.services import cex_service
+from src.services.secret_vault import vault
+from src.shared.auth.dependency import require_api_key
+from src.shared.errors import SdkError
+
+router = APIRouter(
+    prefix="/cex",
+    dependencies=[Depends(require_api_key)],
+    tags=["cex"],
+)
+
+
+class StashKrakenRequest(BaseModel):
+    api_key: str = Field(..., description="Kraken API key (never logged/echoed)")
+    api_secret: str = Field(..., description="Kraken private key / secret")
+
+
+class ConnectRequest(BaseModel):
+    vault_token: str = Field(..., description="From POST /cex/stash-kraken")
+
+
+class ValidateOrderRequest(BaseModel):
+    pair: str
+    side: str  # buy | sell
+    volume: float
+    ordertype: str = "market"
+    price: float | None = None
+
+
+class SyncFillsRequest(BaseModel):
+    mode: str = "live"
+
+
+@router.post("/stash-kraken", summary="Stash Kraken creds out-of-band (returns vault_token)")
+async def stash_kraken(req: StashKrakenRequest) -> dict:
+    token = vault.stash(json.dumps({"api_key": req.api_key, "api_secret": req.api_secret}))
+    return {"vault_token": token, "secret_ttl_seconds": int(getattr(app_config, "SECRET_VAULT_TTL_SECONDS", 300))}
+
+
+@router.post("/connect", summary="Connect Kraken by consuming a stashed vault_token")
+async def connect(req: ConnectRequest) -> dict:
+    try:
+        return cex_service.connect_from_vault(req.vault_token)
+    except KeyError as e:
+        raise SdkError(f"vault_token unknown or expired: {e}") from e
+
+
+@router.get("/status", summary="Is a Kraken account connected?")
+async def status() -> dict:
+    return cex_service.status()
+
+
+@router.get("/balances", summary="Kraken balances (BYOK)")
+async def balances() -> dict:
+    try:
+        return {"balances": cex_service.get_balances()}
+    except Exception as e:  # noqa: BLE001
+        raise SdkError(f"cex balances failed: {e}") from e
+
+
+@router.post("/validate-order", summary="Dry-run a Kraken order (validate=true)")
+async def validate_order(req: ValidateOrderRequest) -> dict:
+    try:
+        return cex_service.validate_order(
+            pair=req.pair, side=req.side, volume=req.volume,
+            ordertype=req.ordertype, price=req.price,
+        )
+    except Exception as e:  # noqa: BLE001
+        raise SdkError(f"cex validate-order failed: {e}") from e
+
+
+@router.post("/sync-fills", summary="Pull Kraken fills and emit them to telemetry")
+async def sync_fills(req: SyncFillsRequest) -> dict:
+    try:
+        return cex_service.sync_fills(mode=req.mode)
+    except Exception as e:  # noqa: BLE001
+        raise SdkError(f"cex sync-fills failed: {e}") from e

--- a/server/src/api/routes/cex.py
+++ b/server/src/api/routes/cex.py
@@ -20,7 +20,7 @@ from fastapi import APIRouter, Depends
 from pydantic import BaseModel, Field
 
 from src.config import app_config
-from src.services import cex_service
+from src.services import cex_oauth_service, cex_service
 from src.services.secret_vault import vault
 from src.shared.auth.dependency import require_api_key
 from src.shared.errors import SdkError
@@ -97,3 +97,59 @@ async def sync_fills(req: SyncFillsRequest) -> dict:
         return cex_service.sync_fills(mode=req.mode)
     except Exception as e:  # noqa: BLE001
         raise SdkError(f"cex sync-fills failed: {e}") from e
+
+
+# --- OAuth (keyless) path: /cex/oauth/* -------------------------------------
+# The sibling to BYOK. No key ever handled locally — the platform holds the
+# OAuth grant and executes; we proxy through the MangroveMarkets MCP server
+# authed by the user's Mangrove key. See .claude/skills/connect-kraken.
+
+
+class OAuthConnectRequest(BaseModel):
+    mode: str = Field("view", description="view (read-only) | execute (+trading)")
+
+
+class OAuthOrderRequest(BaseModel):
+    base: str
+    quote: str
+    side: str  # buy | sell
+    volume: str
+    order_type: str = "market"
+    limit_price: str | None = None
+    validate_only: bool = False
+
+
+@router.post("/oauth/connect-start", summary="Begin keyless Kraken OAuth connect (returns authorize URL)")
+async def oauth_connect_start(req: OAuthConnectRequest) -> dict:
+    try:
+        return cex_oauth_service.connect_start(mode=req.mode)
+    except Exception as e:  # noqa: BLE001
+        raise SdkError(f"cex oauth connect-start failed: {e}") from e
+
+
+@router.get("/oauth/status", summary="Keyless connection status (mode: view|execute)")
+async def oauth_status() -> dict:
+    try:
+        return cex_oauth_service.connect_status()
+    except Exception as e:  # noqa: BLE001
+        raise SdkError(f"cex oauth status failed: {e}") from e
+
+
+@router.get("/oauth/balances", summary="Kraken balances via the platform (keyless)")
+async def oauth_balances() -> dict:
+    try:
+        return cex_oauth_service.get_balances()
+    except Exception as e:  # noqa: BLE001
+        raise SdkError(f"cex oauth balances failed: {e}") from e
+
+
+@router.post("/oauth/orders", summary="Place/validate a Kraken order via the platform (keyless)")
+async def oauth_place_order(req: OAuthOrderRequest) -> dict:
+    try:
+        return cex_oauth_service.place_order(
+            base=req.base, quote=req.quote, side=req.side, volume=req.volume,
+            order_type=req.order_type, limit_price=req.limit_price,
+            validate_only=req.validate_only,
+        )
+    except Exception as e:  # noqa: BLE001
+        raise SdkError(f"cex oauth place-order failed: {e}") from e

--- a/server/src/mcp/tools.py
+++ b/server/src/mcp/tools.py
@@ -453,6 +453,113 @@ def _register_dex(server: FastMCP) -> None:
         parameters=[_APIKEY],
     ))
 
+    # -- CEX (Kraken) BYOK tools --------------------------------------------
+    def _cex_err(e: Exception) -> str:
+        return json.dumps({"error": True, "code": "CEX_ERROR", "message": str(e)})
+
+    @server.tool()
+    async def cex_status(api_key: str = "") -> str:
+        """Is a Kraken (CEX) account connected on this machine? Free of Kraken key."""
+        if not _require(api_key):
+            return _auth_error()
+        from src.services import cex_service
+        return json.dumps(cex_service.status())
+
+    register_tool(ToolEntry(
+        name="cex_status", description="Whether a Kraken account is connected (BYOK).",
+        access="auth", parameters=[_APIKEY],
+    ))
+
+    @server.tool()
+    async def cex_connect_kraken(vault_token: str, api_key: str = "") -> str:
+        """Connect Kraken by consuming a vault_token from scripts/stash-kraken-secret.sh.
+        The key is persisted ENCRYPTED at rest; it never enters this chat."""
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            from src.services import cex_service
+            return json.dumps(cex_service.connect_from_vault(vault_token))
+        except Exception as e:  # noqa: BLE001
+            return _cex_err(e)
+
+    register_tool(ToolEntry(
+        name="cex_connect_kraken",
+        description="Connect Kraken via a vault_token (creds stashed out-of-band, stored encrypted).",
+        access="auth",
+        parameters=[
+            ToolParam(name="vault_token", type="string", required=True, description="From scripts/stash-kraken-secret.sh"),
+            _APIKEY,
+        ],
+    ))
+
+    @server.tool()
+    async def cex_balances(api_key: str = "") -> str:
+        """Kraken balances (BYOK — talks to Kraken directly with the local key)."""
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            from src.services import cex_service
+            return json.dumps({"balances": cex_service.get_balances()})
+        except Exception as e:  # noqa: BLE001
+            return _cex_err(e)
+
+    register_tool(ToolEntry(
+        name="cex_balances", description="Kraken balances (BYOK).",
+        access="auth", parameters=[_APIKEY],
+    ))
+
+    @server.tool()
+    async def cex_validate_order(
+        pair: str, side: str, volume: float,
+        ordertype: str = "market", price: float | None = None, api_key: str = "",
+    ) -> str:
+        """Dry-run a Kraken order (validate=true) — no fill. Use before any live order."""
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            from src.services import cex_service
+            return json.dumps(cex_service.validate_order(
+                pair=pair, side=side, volume=volume, ordertype=ordertype, price=price,
+            ))
+        except Exception as e:  # noqa: BLE001
+            return _cex_err(e)
+
+    register_tool(ToolEntry(
+        name="cex_validate_order",
+        description="Dry-run a Kraken order (validate=true, no fill).",
+        access="auth",
+        parameters=[
+            ToolParam(name="pair", type="string", required=True, description="Kraken pair, e.g. XBTUSD"),
+            ToolParam(name="side", type="string", required=True, description="buy | sell"),
+            ToolParam(name="volume", type="number", required=True, description="Order volume in base units"),
+            ToolParam(name="ordertype", type="string", required=False, description="market (default) | limit"),
+            ToolParam(name="price", type="number", required=False, description="Limit price (for limit orders)"),
+            _APIKEY,
+        ],
+    ))
+
+    @server.tool()
+    async def cex_sync_fills(mode: str = "live", api_key: str = "") -> str:
+        """Pull the user's Kraken fills and emit them to telemetry (authed by the
+        Mangrove key). The Kraken key never leaves this machine."""
+        if not _require(api_key):
+            return _auth_error()
+        try:
+            from src.services import cex_service
+            return json.dumps(cex_service.sync_fills(mode=mode))
+        except Exception as e:  # noqa: BLE001
+            return _cex_err(e)
+
+    register_tool(ToolEntry(
+        name="cex_sync_fills",
+        description="Pull Kraken fills and emit them to per-user telemetry.",
+        access="auth",
+        parameters=[
+            ToolParam(name="mode", type="string", required=False, description="live (default) | paper | validate"),
+            _APIKEY,
+        ],
+    ))
+
     @server.tool()
     async def get_swap_quote(
         input_token: str, output_token: str, amount: float,

--- a/server/src/services/cex_credentials.py
+++ b/server/src/services/cex_credentials.py
@@ -1,0 +1,55 @@
+"""Encrypted-at-rest store for CEX (Kraken) BYOK API credentials.
+
+The user's API key + secret are Fernet-encrypted with the agent's master key
+and written to ``agent-data/cex-<venue>.enc`` (chmod 600). They never leave the
+machine and never enter chat. Mirrors the wallet-secret custody model, but
+file-based so it needs no DB migration.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from src.config import app_config
+from src.shared.crypto import fernet
+
+
+def _agent_data_dir() -> Path:
+    db_path = str(getattr(app_config, "DB_PATH", "./agent-data/agent.db"))
+    return Path(db_path).parent
+
+
+def _path(venue: str) -> Path:
+    return _agent_data_dir() / f"cex-{venue}.enc"
+
+
+def save(venue: str, api_key: str, api_secret: str) -> None:
+    if not api_key or not api_secret:
+        raise ValueError("api_key and api_secret are both required")
+    blob = json.dumps({"api_key": api_key, "api_secret": api_secret}).encode()
+    enc = fernet.encrypt(blob)
+    p = _path(venue)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_bytes(enc)
+    p.chmod(0o600)
+
+
+def load(venue: str) -> tuple[str, str] | None:
+    """Return (api_key, api_secret) or None if not connected."""
+    p = _path(venue)
+    if not p.exists():
+        return None
+    data = json.loads(fernet.decrypt(p.read_bytes()))
+    return data["api_key"], data["api_secret"]
+
+
+def is_connected(venue: str) -> bool:
+    return _path(venue).exists()
+
+
+def disconnect(venue: str) -> bool:
+    p = _path(venue)
+    if p.exists():
+        p.unlink()
+        return True
+    return False

--- a/server/src/services/cex_oauth_service.py
+++ b/server/src/services/cex_oauth_service.py
@@ -1,0 +1,87 @@
+"""CEX (Kraken) OAuth-connect service — the KEYLESS path.
+
+Unlike the BYOK path (`cex_service`, which stashes a Kraken key locally and
+talks to Kraken directly), this service holds NO venue credential. It calls the
+MangroveMarkets MCP server's authenticated exchange-proxy routes with the
+user's Mangrove API key; the platform holds the OAuth grant and executes.
+
+Flow: connect_start -> the user opens the returned authorize URL and consents
+in a browser (picking view or execute mode) -> poll status until connected ->
+place/validate orders, all keyless.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from src.config import app_config
+
+_BASE_PATH = "/api/v1/exchanges/kraken"
+_TIMEOUT = 30.0
+
+
+def _base_url() -> str:
+    return str(app_config.MANGROVEMARKETS_BASE_URL).rstrip("/")
+
+
+def _headers() -> dict[str, str]:
+    # The user's Mangrove API key authenticates us to the markets server, which
+    # derives the user_id server-side. No Kraken credential is involved.
+    return {
+        "Authorization": f"Bearer {app_config.MANGROVE_API_KEY}",
+        "Accept": "application/json",
+    }
+
+
+def _request(method: str, path: str, *, json_body: dict[str, Any] | None = None,
+             http: httpx.Client | None = None) -> dict[str, Any]:
+    url = f"{_base_url()}{_BASE_PATH}{path}"
+    client = http or httpx.Client(timeout=_TIMEOUT)
+    try:
+        resp = client.request(method, url, headers=_headers(), json=json_body)
+    finally:
+        if http is None:
+            client.close()
+    try:
+        body = resp.json()
+    except ValueError:
+        body = {}
+    if resp.status_code >= 400:
+        detail = body.get("detail") if isinstance(body, dict) else None
+        raise RuntimeError(f"markets exchange proxy {resp.status_code}: {detail or body}")
+    return body
+
+
+def connect_start(*, mode: str = "view", http: httpx.Client | None = None) -> dict[str, Any]:
+    """Begin an OAuth connect. Returns {authorize_url, state}; the user opens the
+    URL and consents. mode = 'view' (read-only) or 'execute' (+trading)."""
+    return _request("POST", "/connect", json_body={"mode": mode}, http=http)
+
+
+def connect_status(*, http: httpx.Client | None = None) -> dict[str, Any]:
+    """Poll connection status: {connected, connection:{mode, alias, ...}}."""
+    return _request("GET", "/status", http=http)
+
+
+def get_balances(*, http: httpx.Client | None = None) -> dict[str, Any]:
+    return _request("GET", "/balances", http=http)
+
+
+def place_order(*, base: str, quote: str, side: str, volume: str,
+                order_type: str = "market", limit_price: str | None = None,
+                validate_only: bool = False, http: httpx.Client | None = None) -> dict[str, Any]:
+    """Place (or validate_only=True dry-run) an order through the platform.
+    Requires an execute-mode connection; a view-only connection is refused
+    upstream."""
+    body: dict[str, Any] = {
+        "base": base, "quote": quote, "side": side,
+        "order_type": order_type, "volume": volume, "validate_only": validate_only,
+    }
+    if limit_price is not None:
+        body["limit_price"] = limit_price
+    return _request("POST", "/orders", json_body=body, http=http)
+
+
+def open_orders(*, http: httpx.Client | None = None) -> dict[str, Any]:
+    return _request("GET", "/orders", http=http)

--- a/server/src/services/cex_service.py
+++ b/server/src/services/cex_service.py
@@ -18,8 +18,6 @@ from __future__ import annotations
 import json
 from typing import Any, Callable
 
-from mangrove_markets import KrakenClient
-
 from src.config import app_config
 from src.services import cex_credentials
 from src.services.secret_vault import vault
@@ -44,6 +42,13 @@ def _client(client_factory: ClientFactory | None = None) -> Any:
     api_key, api_secret = creds
     if client_factory is not None:
         return client_factory(api_key, api_secret)
+    # Imported lazily: KrakenClient ships in the mangrovemarkets SDK release that
+    # carries the BYOK client. Keeping the import here (not module-level) means
+    # importing this module — and app boot, and test collection — never depends
+    # on that release; only an actual BYOK call without the SDK raises, and with
+    # a clear message. Tests inject client_factory and never reach this line.
+    from mangrove_markets import KrakenClient
+
     return KrakenClient(api_key, api_secret, base_url=_kraken_base())
 
 

--- a/server/src/services/cex_service.py
+++ b/server/src/services/cex_service.py
@@ -1,0 +1,100 @@
+"""CEX (Kraken) BYOK service.
+
+Flow:
+  1. `connect_from_vault(vault_token)` — reveal the {api_key, api_secret} blob
+     the user stashed out-of-band (scripts/stash-kraken-secret.sh) and persist
+     it encrypted (cex_credentials). The key never enters chat.
+  2. Build a SDK `KrakenClient` from the stored creds and talk to Kraken
+     DIRECTLY (BYOK) — balances, validate-only orders.
+  3. `sync_fills()` — pull the user's Kraken fills and EMIT them to the markets
+     server's telemetry via the SDK (authed by the Mangrove key). The Kraken
+     key is never sent to a Mangrove server; only the trade statistics are.
+
+`client_factory` / `telemetry` are injectable for tests + the local mock-Kraken
+E2E (no real key needed until the user connects one).
+"""
+from __future__ import annotations
+
+import json
+from typing import Any, Callable
+
+from mangrove_markets import KrakenClient
+
+from src.config import app_config
+from src.services import cex_credentials
+from src.services.secret_vault import vault
+from src.shared.clients.mangrove import mangrove_markets_client
+
+_VENUE = "kraken"
+
+ClientFactory = Callable[[str, str], Any]
+
+
+def _kraken_base() -> str:
+    return str(getattr(app_config, "KRAKEN_API_URL", "https://api.kraken.com"))
+
+
+def _client(client_factory: ClientFactory | None = None) -> Any:
+    creds = cex_credentials.load(_VENUE)
+    if not creds:
+        raise RuntimeError(
+            "No Kraken credentials connected. Run scripts/stash-kraken-secret.sh "
+            "in a terminal, then connect with the returned vault_token."
+        )
+    api_key, api_secret = creds
+    if client_factory is not None:
+        return client_factory(api_key, api_secret)
+    return KrakenClient(api_key, api_secret, base_url=_kraken_base())
+
+
+def connect_from_vault(vault_token: str) -> dict:
+    """Reveal the stashed Kraken creds blob (single-read) and persist encrypted."""
+    blob = vault.reveal(vault_token)
+    data = json.loads(blob)
+    cex_credentials.save(_VENUE, data["api_key"], data["api_secret"])
+    return {"venue": _VENUE, "connected": True}
+
+
+def status() -> dict:
+    return {"venue": _VENUE, "connected": cex_credentials.is_connected(_VENUE)}
+
+
+def disconnect() -> dict:
+    return {"venue": _VENUE, "disconnected": cex_credentials.disconnect(_VENUE)}
+
+
+def get_balances(*, client_factory: ClientFactory | None = None) -> dict:
+    return _client(client_factory).balance()
+
+
+def validate_order(
+    *,
+    pair: str,
+    side: str,
+    volume: float,
+    ordertype: str = "market",
+    price: float | None = None,
+    client_factory: ClientFactory | None = None,
+) -> dict:
+    """Dry-run an order (Kraken AddOrder validate=true). No fill."""
+    return _client(client_factory).add_order(
+        pair=pair, side=side, ordertype=ordertype, volume=volume,
+        price=price, validate=True,
+    )
+
+
+def sync_fills(
+    *,
+    mode: str = "live",
+    client_factory: ClientFactory | None = None,
+    telemetry: Any | None = None,
+) -> dict:
+    """Pull the user's Kraken fills, map to TradeRecords, emit to telemetry.
+
+    Sends the trade STATISTICS to the markets server (authed by the Mangrove
+    key); the Kraken key stays local. Returns what was emitted.
+    """
+    records = _client(client_factory).trades_as_records(mode=mode)
+    tel = telemetry if telemetry is not None else mangrove_markets_client().telemetry
+    results = tel.report_trades(records)
+    return {"emitted": len(results), "trade_ids": [r.id for r in records]}

--- a/server/tests/unit/test_cex_oauth_service.py
+++ b/server/tests/unit/test_cex_oauth_service.py
@@ -1,0 +1,75 @@
+"""Unit tests for the keyless CEX OAuth service.
+
+Verifies the agent proxies to the markets server with the Mangrove key as
+Bearer (never a venue key), forwards the chosen mode, and surfaces proxy
+errors. No Kraken credential is ever involved.
+"""
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("ENVIRONMENT", "test")
+
+import httpx
+import pytest
+
+from src.config import app_config
+from src.services import cex_oauth_service
+
+
+def _transport(handler):
+    return httpx.Client(transport=httpx.MockTransport(handler))
+
+
+def test_connect_start_uses_bearer_and_forwards_mode(monkeypatch):
+    monkeypatch.setattr(app_config, "MANGROVE_API_KEY", "mgv_test_key", raising=False)
+    monkeypatch.setattr(app_config, "MANGROVEMARKETS_BASE_URL", "http://markets.local", raising=False)
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        import json
+        seen["auth"] = request.headers.get("Authorization")
+        seen["url"] = str(request.url)
+        seen["body"] = json.loads(request.content)
+        return httpx.Response(200, json={"authorize_url": "https://id.kraken.com/x", "state": "s"})
+
+    with _transport(handler) as http:
+        out = cex_oauth_service.connect_start(mode="execute", http=http)
+
+    assert seen["auth"] == "Bearer mgv_test_key"  # Mangrove key, NOT a Kraken key
+    assert seen["url"].endswith("/api/v1/exchanges/kraken/connect")
+    assert seen["body"]["mode"] == "execute"
+    assert out["authorize_url"].startswith("https://id.kraken.com")
+
+
+def test_place_order_forwards_fields(monkeypatch):
+    monkeypatch.setattr(app_config, "MANGROVE_API_KEY", "mgv_test_key", raising=False)
+    monkeypatch.setattr(app_config, "MANGROVEMARKETS_BASE_URL", "http://markets.local", raising=False)
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        import json
+        seen["body"] = json.loads(request.content)
+        return httpx.Response(200, json={"pair": "XRPUSDC", "validate_only": True, "tx_ids": []})
+
+    with _transport(handler) as http:
+        out = cex_oauth_service.place_order(
+            base="XRP", quote="USDC", side="buy", volume="5", validate_only=True, http=http,
+        )
+    assert seen["body"] == {
+        "base": "XRP", "quote": "USDC", "side": "buy",
+        "order_type": "market", "volume": "5", "validate_only": True,
+    }
+    assert out["pair"] == "XRPUSDC"
+
+
+def test_proxy_error_raises(monkeypatch):
+    monkeypatch.setattr(app_config, "MANGROVE_API_KEY", "mgv_test_key", raising=False)
+    monkeypatch.setattr(app_config, "MANGROVEMARKETS_BASE_URL", "http://markets.local", raising=False)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(403, json={"detail": "connection is view-only"})
+
+    with _transport(handler) as http:
+        with pytest.raises(RuntimeError, match="view-only"):
+            cex_oauth_service.place_order(base="XRP", quote="USDC", side="buy", volume="5", http=http)

--- a/server/tests/unit/test_cex_oauth_service.py
+++ b/server/tests/unit/test_cex_oauth_service.py
@@ -7,6 +7,7 @@ errors. No Kraken credential is ever involved.
 from __future__ import annotations
 
 import os
+from urllib.parse import urlparse
 
 os.environ.setdefault("ENVIRONMENT", "test")
 
@@ -39,7 +40,10 @@ def test_connect_start_uses_bearer_and_forwards_mode(monkeypatch):
     assert seen["auth"] == "Bearer mgv_test_key"  # Mangrove key, NOT a Kraken key
     assert seen["url"].endswith("/api/v1/exchanges/kraken/connect")
     assert seen["body"]["mode"] == "execute"
-    assert out["authorize_url"].startswith("https://id.kraken.com")
+    # Compare the parsed host exactly, not a URL prefix (prefix checks are the
+    # "incomplete URL substring sanitization" anti-pattern CodeQL flags).
+    parsed = urlparse(out["authorize_url"])
+    assert (parsed.scheme, parsed.netloc) == ("https", "id.kraken.com")
 
 
 def test_place_order_forwards_fields(monkeypatch):

--- a/server/tests/unit/test_cex_service.py
+++ b/server/tests/unit/test_cex_service.py
@@ -78,7 +78,7 @@ class _FakeTelemetry:
 
 def test_balances_and_validate_use_byok_client(tmp_env):
     cex_credentials.save("kraken", "K", "S")
-    factory = lambda k, s: _FakeKraken(k, s)  # noqa: E731
+    factory = _FakeKraken
     assert cex_service.get_balances(client_factory=factory)["ZUSD"] == "100.0"
     out = cex_service.validate_order(pair="XBTUSD", side="buy", volume=0.01, client_factory=factory)
     assert "descr" in out
@@ -87,7 +87,7 @@ def test_balances_and_validate_use_byok_client(tmp_env):
 def test_sync_fills_emits_to_telemetry(tmp_env):
     cex_credentials.save("kraken", "K", "S")
     tel = _FakeTelemetry()
-    out = cex_service.sync_fills(client_factory=lambda k, s: _FakeKraken(k, s), telemetry=tel)
+    out = cex_service.sync_fills(client_factory=_FakeKraken, telemetry=tel)
     assert out == {"emitted": 1, "trade_ids": ["kraken:T1"]}
     assert tel.sent[0].venue == "kraken"
     assert tel.sent[0].tx_hash is None      # CEX spot — no chain hash
@@ -95,4 +95,4 @@ def test_sync_fills_emits_to_telemetry(tmp_env):
 
 def test_operations_without_creds_raise(tmp_env):
     with pytest.raises(RuntimeError):
-        cex_service.get_balances(client_factory=lambda k, s: _FakeKraken(k, s))
+        cex_service.get_balances(client_factory=_FakeKraken)

--- a/server/tests/unit/test_cex_service.py
+++ b/server/tests/unit/test_cex_service.py
@@ -1,0 +1,98 @@
+"""CEX (Kraken) BYOK service + encrypted-creds tests. No real key/network."""
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+
+os.environ.setdefault("ENVIRONMENT", "test")
+
+import pytest
+
+from src.config import app_config
+from src.services import cex_credentials, cex_service
+from src.services.secret_vault import vault
+from src.shared.crypto import fernet
+
+
+@pytest.fixture
+def tmp_env(tmp_path, monkeypatch):
+    # Temp master key (no real keychain) + temp agent-data dir.
+    monkeypatch.setattr("keyring.get_password", lambda s, u: None)
+    monkeypatch.setattr("keyring.set_password", lambda s, u, p: None)
+    monkeypatch.setattr(app_config, "MASTER_KEY_PATH", str(tmp_path / "master.key"), raising=False)
+    monkeypatch.setattr(app_config, "DB_PATH", str(tmp_path / "agent.db"), raising=False)
+    fernet.reset_master_key_cache()
+    vault.clear()
+    yield tmp_path
+    fernet.reset_master_key_cache()
+    vault.clear()
+
+
+def test_credentials_roundtrip_encrypted_at_rest(tmp_env):
+    cex_credentials.save("kraken", "K-API-KEY", "S-SECRET-VALUE")
+    assert cex_credentials.is_connected("kraken")
+    enc = (tmp_env / "cex-kraken.enc").read_bytes()
+    assert b"K-API-KEY" not in enc and b"S-SECRET-VALUE" not in enc   # ciphertext
+    assert cex_credentials.load("kraken") == ("K-API-KEY", "S-SECRET-VALUE")
+    assert cex_credentials.disconnect("kraken") is True
+    assert cex_credentials.load("kraken") is None
+
+
+def test_connect_from_vault_consumes_token(tmp_env):
+    token = vault.stash(json.dumps({"api_key": "K", "api_secret": "S"}))
+    assert cex_service.connect_from_vault(token)["connected"] is True
+    assert cex_service.status() == {"venue": "kraken", "connected": True}
+    with pytest.raises(KeyError):       # single-read: token now consumed
+        vault.reveal(token)
+
+
+class _FakeKraken:
+    def __init__(self, key, secret):
+        self.key, self.secret = key, secret
+
+    def balance(self):
+        return {"ZUSD": "100.0"}
+
+    def add_order(self, **kw):
+        assert kw["validate"] is True   # service must dry-run
+        return {"descr": {"order": "buy 0.01 XBTUSD @ market"}}
+
+    def trades_as_records(self, *, mode="live"):
+        from mangrove_markets import TradeRecord
+        return [TradeRecord(
+            id="kraken:T1", mode=mode, status="confirmed", venue="kraken",
+            venue_trade_ref="T1", side="buy", base="XXBTZUSD", qty=0.01,
+            fill_price=64000.0, executed_at=datetime(2026, 6, 27, tzinfo=timezone.utc),
+        )]
+
+
+class _FakeTelemetry:
+    def __init__(self):
+        self.sent = []
+
+    def report_trades(self, records):
+        self.sent.extend(records)
+        return [{"stored": True, "id": r.id} for r in records]
+
+
+def test_balances_and_validate_use_byok_client(tmp_env):
+    cex_credentials.save("kraken", "K", "S")
+    factory = lambda k, s: _FakeKraken(k, s)  # noqa: E731
+    assert cex_service.get_balances(client_factory=factory)["ZUSD"] == "100.0"
+    out = cex_service.validate_order(pair="XBTUSD", side="buy", volume=0.01, client_factory=factory)
+    assert "descr" in out
+
+
+def test_sync_fills_emits_to_telemetry(tmp_env):
+    cex_credentials.save("kraken", "K", "S")
+    tel = _FakeTelemetry()
+    out = cex_service.sync_fills(client_factory=lambda k, s: _FakeKraken(k, s), telemetry=tel)
+    assert out == {"emitted": 1, "trade_ids": ["kraken:T1"]}
+    assert tel.sent[0].venue == "kraken"
+    assert tel.sent[0].tx_hash is None      # CEX spot — no chain hash
+
+
+def test_operations_without_creds_raise(tmp_env):
+    with pytest.raises(RuntimeError):
+        cex_service.get_balances(client_factory=lambda k, s: _FakeKraken(k, s))


### PR DESCRIPTION
Implements https://github.com/MangroveTechnologies/mangrove-agent/issues/133 — step 3 of the CEX OAuth-proxy epic https://github.com/MangroveTechnologies/MangroveMarkets/issues/55 (design https://github.com/MangroveTechnologies/MangroveMarkets/pull/54).

## What

The keyless counterpart to the BYOK `setup-kraken` path. The user connects Kraken **without creating, pasting, or storing any API key**: they consent once in a browser, the Mangrove platform holds the OAuth grant and trades on their behalf.

- `cex_oauth_service` — httpx to the MangroveMarkets MCP server's exchange-proxy routes, authed by the user's **Mangrove API key** (Bearer). No `KrakenClient`, no local key — contrast with the BYOK `cex_service`.
- `/api/v1/agent/cex/oauth/{connect-start,status,balances,orders}` — view/execute mode, validate-then-place. Coexists with the BYOK `/cex/*` routes (no changes to them).
- `.claude/skills/connect-kraken/SKILL.md` — sibling to `setup-kraken` (the OAuth path that skill explicitly defers to). Picks view vs execute; requires a validate-only preview before any live order.

## Verified live (full local E2E, real connected Kraken account)

The exact outbound call this service makes drove **agent-shape → MCP server → platform delegated lane → Kraken**:
```
connect-start {mode:execute} → real id.kraken.com authorize URL, trades-modify present, funds-withdraw absent
status   → {connected:true, mode:"execute", alias:"Kraken Main", account AA62 N84G 6C7C K6LI}
balances → 24 assets (XRP top)
POST orders {XRP/USDC buy 5.0, validate_only} → Kraken accepted "buy 5.00000 XRPUSDC @ market", broker-attributed, nothing placed
```
No venue credential existed anywhere in the agent or MCP server at any point.

Unit tests assert the Bearer is the **Mangrove** key (never a venue key), mode forwarding, and error propagation. `ruff` clean.

## Dependency chain (per the epic)
- platform delegated lane: https://github.com/MangroveTechnologies/mangrove-platform-backend/pull/1035
- MCP proxy routes: https://github.com/MangroveTechnologies/MangroveMarkets-MCP-Server/pull/82
- SDK `KrakenClient` (for the BYOK sibling + install): https://github.com/MangroveTechnologies/MangroveMarkets/pull/50
- This PR branches off #131 (`feat/cex-kraken-wiring`); land that first, or this retargets to main once it merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
