### PR TITLE
fix(dex): route live swaps through dex_service base-units boundary (#122)

### DIFF
--- a/server/src/services/order_executor.py
+++ b/server/src/services/order_executor.py
@@ -5,7 +5,7 @@ Takes an OrderIntent and executes it:
   build a simulated Trade row with mode=paper, status=simulated,
   tx_hash=None.
 - Live mode: full 6-step DEX swap via mangrovemarkets:
-    1. dex.get_quote
+    1. dex_service.get_quote (human amount -> base units at the boundary)
     2. dex.approve_token (may return None if allowance already set)
     3. If approval returned: wallet_manager.sign → dex.broadcast → poll tx_status
     4. dex.prepare_swap
@@ -30,7 +30,7 @@ from typing import Any, Literal
 
 from src.config import app_config
 from src.models.domain import OrderIntent, Trade
-from src.services import trade_log
+from src.services import dex_service, trade_log
 from src.services.wallet_manager import sign as wallet_sign
 from src.shared.clients.mangrove import mangrove_ai_client, mangrove_markets_client
 from src.shared.errors import SdkError, SigningError
@@ -239,26 +239,27 @@ def _live_swap(
     client = mangrove_markets_client()
     input_token, output_token, input_amount = _resolve_tokens(intent)
 
-    # 1. Quote
-    try:
-        quote = client.dex.get_quote(
-            input_token=input_token,
-            output_token=output_token,
-            amount=input_amount,
-            chain_id=chain_id,
-            venue_id=venue_id,
-        )
-    except Exception as e:  # noqa: BLE001
-        raise SdkError(f"dex.get_quote failed: {e}") from e
+    # 1. Quote — via dex_service, the single human<->base-units boundary.
+    # `input_amount` is HUMAN units (the agent's convention everywhere);
+    # dex_service resolves the token's decimals, converts to the base
+    # units the backend expects, rejects dust that rounds to 0, and
+    # converts the returned amounts back to human units.
+    quote = dex_service.get_quote(
+        input_token=input_token,
+        output_token=output_token,
+        amount=input_amount,
+        chain_id=chain_id,
+        venue_id=venue_id,
+    )
 
     _log.info("order.executing", trade_symbol=intent.symbol, side=intent.side,
               input_token=input_token, output_token=output_token,
-              input_amount=input_amount, quote_id=getattr(quote, "quote_id", None))
+              input_amount=input_amount, quote_id=quote.get("quote_id"))
 
     fees: dict[str, Any] = {
-        "venue_fee": getattr(quote, "venue_fee", 0.0),
-        "mangrove_fee": getattr(quote, "mangrove_fee", 0.0),
-        "price_impact_percent": getattr(quote, "price_impact_percent", 0.0),
+        "venue_fee": quote.get("venue_fee", 0.0),
+        "mangrove_fee": quote.get("mangrove_fee", 0.0),
+        "price_impact_percent": quote.get("price_impact_percent", 0.0),
     }
 
     # 2-3. Conditional token approval
@@ -273,7 +274,7 @@ def _live_swap(
     sdk_slippage = slippage_pct * 100.0  # type: ignore[operator]
     try:
         swap_tx = client.dex.prepare_swap(
-            quote_id=quote.quote_id,
+            quote_id=quote["quote_id"],
             wallet_address=wallet_address,
             slippage=sdk_slippage,
         )
@@ -298,6 +299,19 @@ def _live_swap(
     _log.info("order.live.confirmed", tx_hash=tx_hash, status=status_str,
               block_number=final.get("block_number"))
 
+    # dex_service already converted output_amount back to human units
+    # (the raw value is quote["output_amount_base_units"]).
+    output_amount = float(quote.get("output_amount", 0.0))
+
+    # Fill price in the paper-mode convention: the price of intent.symbol
+    # in the counter-token (input per output on a buy, output per input on
+    # a sell). The quote's raw exchange_rate is a BASE-UNITS ratio (e.g.
+    # 1.79e-9 for WETH->USDC), not a human price — never store it as one.
+    if intent.side == "buy":
+        fill_price = (input_amount / output_amount) if output_amount else 0.0
+    else:
+        fill_price = (output_amount / input_amount) if input_amount else 0.0
+
     trade = Trade(
         id=str(uuid.uuid4()),
         strategy_id=strategy_id,
@@ -308,8 +322,8 @@ def _live_swap(
         input_token=input_token,
         input_amount=input_amount,
         output_token=output_token,
-        output_amount=float(getattr(quote, "output_amount", 0.0)),
-        fill_price=float(getattr(quote, "exchange_rate", 0.0)),
+        output_amount=output_amount,
+        fill_price=fill_price,
         fees={**fees, "approval_tx_hash": approval_tx_hash},
         status=trade_status,
         executed_at=trade_log.now_utc(),
@@ -331,10 +345,10 @@ def execute_one(
 ) -> Trade:
     """Execute a single OrderIntent.
 
-    `slippage_pct` is a DECIMAL (0.005 = 0.5%). User-initiated swaps
-    require it (enforced at the MCP / REST boundary). Cron callers may
-    pass None — _live_swap falls back to 1% with a log warning until
-    the allocation schema carries slippage_pct (future work).
+    `slippage_pct` is a DECIMAL (0.005 = 0.5%). REQUIRED for live mode —
+    there is no fallback; _validate_slippage raises without it. Direct
+    callers pass it in the request body, cron callers pull it from the
+    active allocation (migration 004).
 
     strategy_id defaults to "user-initiated" for /dex/swap-style callers;
     cron-driven callers pass the real strategy UUID.

--- a/server/tests/integration/test_dex_routes.py
+++ b/server/tests/integration/test_dex_routes.py
@@ -39,14 +39,16 @@ def client(tmp_path, monkeypatch):
     pair.model_dump.return_value = {"from_token": "USDC", "to_token": "ETH"}
     sdk.dex.supported_pairs.return_value = [pair]
 
+    # The backend quotes in BASE units (dex_service converts both ways):
+    # 100 USDC in (6 decimals), 0.04 ETH out (18 decimals).
     quote = MagicMock()
     quote.model_dump.return_value = {
-        "quote_id": "q-1", "input_amount": 100.0, "output_amount": 0.04,
+        "quote_id": "q-1",
+        "input_amount": 100_000_000,
+        "output_amount": 40_000_000_000_000_000,
         "exchange_rate": 2500.0,
     }
     quote.quote_id = "q-1"
-    quote.output_amount = 0.04
-    quote.exchange_rate = 2500.0
     quote.venue_fee = 0.0
     quote.mangrove_fee = 0.0
     quote.price_impact_percent = 0.0
@@ -90,6 +92,22 @@ def client(tmp_path, monkeypatch):
         return ti
 
     sdk.dex.token_info.side_effect = _token_info
+
+    # token_search backs dex_service.resolve_decimals for bare SYMBOLS —
+    # the /dex/swap tests pass "USDC"/"ETH" (the cron-intent convention).
+    # Without this stub a raw MagicMock silently yields decimals=1.
+    _SYMBOLS = {"USDC": 6, "ETH": 18, "WETH": 18}
+
+    def _token_search(chain_id, query):
+        dec = _SYMBOLS.get(query.upper())
+        if dec is None:
+            return []
+        m = MagicMock()
+        m.symbol = query.upper()
+        m.decimals = dec
+        return [m]
+
+    sdk.dex.token_search.side_effect = _token_search
 
     spot_price = MagicMock()
     spot_price.model_dump.return_value = {
@@ -293,6 +311,29 @@ def test_swap_happy_path(client):
     assert body["input_token"] == "USDC"
     assert body["output_token"] == "ETH"
     assert "trade_log_id" in body
+    # #122: the backend must receive BASE units (100 USDC @ 6 decimals),
+    # and the recorded amounts must be HUMAN units.
+    _, kwargs = client.app_sdk.dex.get_quote.call_args
+    assert kwargs["amount"] == 100_000_000
+    assert body["input_amount"] == pytest.approx(100.0)
+    assert body["output_amount"] == pytest.approx(0.04)
+
+
+def test_swap_rejects_dust_amount(client):
+    """#122: a live-path amount that rounds to 0 base units is refused
+    before any quote/approval/signing — same guard as /dex/quote."""
+    r = client.post(
+        "/api/v1/agent/dex/swap",
+        headers=_auth(),
+        json={
+            "input_token": "USDC", "output_token": "ETH", "amount": 0.0000001,
+            "chain_id": 84532, "wallet_address": "0xabc",
+            "slippage_pct": 0.002, "confirm": True,
+        },
+    )
+    assert r.status_code == 400
+    assert r.json()["code"] == "VALIDATION_ERROR"
+    assert not client.app_sdk.dex.broadcast.called
 
 
 def test_auth_required_on_dex_endpoints(client):

--- a/server/tests/unit/test_order_executor.py
+++ b/server/tests/unit/test_order_executor.py
@@ -62,16 +62,39 @@ def mock_mangroveai(monkeypatch):
 
 @pytest.fixture
 def mock_markets(monkeypatch):
-    """Stub mangrove_markets_client (used in live mode)."""
+    """Stub mangrove_markets_client (used in live mode).
+
+    Patched for BOTH order_executor and dex_service: _live_swap quotes
+    through dex_service (the human<->base-units boundary, #109/#122),
+    which builds its own client.
+    """
     client = MagicMock()
 
+    # dex_service.resolve_decimals resolves bare symbols (the cron-intent
+    # convention) via token_search exact-symbol match.
+    def _token(symbol: str, decimals: int) -> MagicMock:
+        t = MagicMock()
+        t.symbol = symbol
+        t.decimals = decimals
+        return t
+
+    _TOKENS = {"USDC": _token("USDC", 6), "ETH": _token("ETH", 18)}
+    client.dex.token_search.side_effect = (
+        lambda chain_id, query: [_TOKENS[query.upper()]] if query.upper() in _TOKENS else []
+    )
+
+    # The backend quotes in BASE units; dex_service converts them back.
     quote = MagicMock()
     quote.quote_id = "q-123"
-    quote.output_amount = 0.04
-    quote.exchange_rate = 2500.0
-    quote.venue_fee = 1.0
-    quote.mangrove_fee = 0.5
-    quote.price_impact_percent = 0.05
+    quote.model_dump.return_value = {
+        "quote_id": "q-123",
+        "input_amount": 100_000,                  # 0.1 USDC (6 decimals)
+        "output_amount": 40_000_000_000_000_000,  # 0.04 ETH in wei
+        "exchange_rate": 2500.0,
+        "venue_fee": 1.0,
+        "mangrove_fee": 0.5,
+        "price_impact_percent": 0.05,
+    }
     client.dex.get_quote.return_value = quote
 
     # Default: approval already in place (None returned).
@@ -92,6 +115,7 @@ def mock_markets(monkeypatch):
     client.dex.tx_status.return_value = status
 
     monkeypatch.setattr("src.services.order_executor.mangrove_markets_client", lambda: client)
+    monkeypatch.setattr("src.services.dex_service.mangrove_markets_client", lambda: client)
     return client
 
 
@@ -190,6 +214,70 @@ def test_live_full_flow_with_approval(temp_db, mock_mangroveai, mock_markets, st
     # broadcast called twice (approval + swap)
     assert mock_markets.dex.broadcast.call_count == 2
     assert trade.fees["approval_tx_hash"] == "0xdeadbeef"
+
+
+def test_live_quotes_in_base_units(temp_db, mock_mangroveai, mock_markets, stub_sign):
+    """#122 regression: the live path must convert the HUMAN intent amount
+    to base units before dex.get_quote (0.1 USDC @ 6 decimals -> 100_000),
+    and record the quote's output_amount converted back to human units
+    (4e16 wei -> 0.04 ETH) — not the raw base-units value."""
+    from src.services.order_executor import execute_one
+
+    trade = execute_one(
+        _intent("buy", "ETH", 0.1),
+        mode="live",
+        strategy_id="s1",
+        wallet_address="0xabc",
+        chain_id=8453,
+        slippage_pct=0.002,
+    )
+    _, kwargs = mock_markets.dex.get_quote.call_args
+    assert kwargs["amount"] == 100_000
+    assert trade.input_amount == pytest.approx(0.1)
+    assert trade.output_amount == pytest.approx(0.04)
+    # fill_price is derived from the HUMAN amounts (0.1 USDC / 0.04 ETH),
+    # NOT the quote's exchange_rate (a base-units ratio, 2500.0 here).
+    assert trade.fill_price == pytest.approx(2.5)
+    # prepare_swap must still be driven by the returned quote_id.
+    _, prep_kwargs = mock_markets.dex.prepare_swap.call_args
+    assert prep_kwargs["quote_id"] == "q-123"
+
+
+def test_live_sell_quotes_asset_side_in_base_units(temp_db, mock_mangroveai, mock_markets, stub_sign):
+    """Sell: input is the asset (ETH, 18 decimals) — 0.1 ETH -> 1e17 wei."""
+    from src.services.order_executor import execute_one
+
+    execute_one(
+        _intent("sell", "ETH", 0.1),
+        mode="live",
+        strategy_id="s1",
+        wallet_address="0xabc",
+        chain_id=8453,
+        slippage_pct=0.002,
+    )
+    _, kwargs = mock_markets.dex.get_quote.call_args
+    assert kwargs["amount"] == 100_000_000_000_000_000
+
+
+def test_live_rejects_dust_amount(temp_db, mock_mangroveai, mock_markets, stub_sign):
+    """#122: an amount that rounds to 0 base units must be refused with a
+    clear error BEFORE any quote/approval/signing happens — not sent
+    upstream to come back as a misleading INSUFFICIENT_LIQUIDITY."""
+    from src.services.order_executor import execute_one
+    from src.shared.errors import ValidationError
+
+    with pytest.raises(ValidationError, match="too small to quote"):
+        execute_one(
+            _intent("buy", "ETH", 0.0000001),  # < 1e-6 USDC -> 0 base units
+            mode="live",
+            strategy_id="s1",
+            wallet_address="0xabc",
+            chain_id=8453,
+            slippage_pct=0.002,
+        )
+    assert not mock_markets.dex.get_quote.called
+    assert not mock_markets.dex.approve_token.called
+    assert not mock_markets.dex.broadcast.called
 
 
 def test_live_requires_slippage_pct(temp_db, mock_mangroveai, mock_markets, stub_sign):


### PR DESCRIPTION
## Summary

Closes #122. `_live_swap` (the funds-moving path used by `execute_swap`, `POST /dex/swap`, and cron-driven live strategies) passed the caller's **human** amount straight to `dex.get_quote`, so the backend read 1 USDC as 1 base unit — sub-cent dust — and every live swap died with `INSUFFICIENT_LIQUIDITY`. Same root cause as #108; #109 fixed only the standalone quote path.

Per the issue's "no bandaid" prescription, the quote step now goes through `dex_service.get_quote` — the shared, tested human↔base-units boundary from #109 — which brings decimals resolution (0x addresses *and* the bare symbols cron intents carry), the dust guard (clear `VALIDATION_ERROR` **before** any quote/approval/signing), and human-converted return amounts.

Two `Trade`-record fields also stored base-units values as if human:
- `output_amount` recorded the quote's raw wei → now the converted human amount.
- `fill_price` recorded the backend's `exchange_rate`, which a live probe showed is a **base-units ratio** (1.79e-9 for WETH→USDC with ETH ≈ $1,790) → now derived from the human amounts, matching the paper-mode convention.

Plus: fixed the `execute_one` docstring that claimed a nonexistent 1% slippage fallback (`_validate_slippage` raises).

## Tests

- `test_live_quotes_in_base_units` — 0.1 USDC reaches `dex.get_quote` as `100_000`; `Trade.output_amount`/`fill_price` are human (`0.04` / `2.5`).
- `test_live_sell_quotes_asset_side_in_base_units` — 0.1 ETH → `1e17`.
- `test_live_rejects_dust_amount` — refused before any SDK call.
- `/dex/swap` integration: base-units assertion on the happy path + dust-rejection case; fixture now stubs `token_search` (symbol decimals) and quotes in base units like the real backend.

Full suite: **431 passed, 2 skipped**. Ruff clean on `server/src/`.

## Live E2E (container rebuilt from this branch)

Isolated container (`mangrove-agent:122-e2e`, port 9182) against the **hosted MangroveMarkets server**, real Base mainnet data:

- `POST /dex/quote` 0.001 WETH→USDC: `output_amount: 1.790797` USDC, `input_amount_base_units: 1e15`, decimals 18/6. ✅
- `POST /dex/swap` 1 USDC→ETH from a fresh **unfunded** throwaway wallet: quote step now succeeds through `_live_swap` (`amount_base_units=1000000`, real 1inch quote_id `1inch-5e79a9b7…`), proceeds through approval prepare + local signing, and fails only at broadcast for lack of gas — zero funds at risk. Pre-fix, this exact call failed at step 1 with `INSUFFICIENT_LIQUIDITY`.

## Remaining verification (issue requirement)

The issue calls for an on-chain swap before merge. Note: 1inch has no Base Sepolia deployment, so the "testnet swap" as written isn't executable through this path; the equivalent proof is a ~$1 USDC→ETH mainnet swap from a funded, backup-confirmed wallet. Blocked on a funded wallet — see PR conversation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)