### PR TITLE
docs: repoint docs links to mangrove.io/docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Every tool has a mirrored REST endpoint at `/api/v1/agent/*`. Both call the same
 | **SIEVE** (`sieve_score`) | Scores up to 99 strategy ideas in milliseconds and tells you which are worth testing. | You have *many* ideas and want to skip the duds. |
 | **Sweep** (`oracle_*_experiment`) | Runs many backtests in one managed experiment (`create → validate → launch → results`) and ranks them. | You want the *best* config out of many. |
 
-Example asks: *"Score these 40 variations and tell me which are worth testing"* (`/sieve`), *"Sweep the RSI window from 7 to 21 on BTC 1h and rank them"* (`/sweep`). Full walkthrough: [`docs/getting-started.md`](docs/getting-started.md); deeper dives in the KB [SIEVE guide](https://docs.mangrovedeveloper.ai/guides/using-sieve-prefilter) and [Experiments reference](https://docs.mangrovedeveloper.ai/api-reference/experiments).
+Example asks: *"Score these 40 variations and tell me which are worth testing"* (`/sieve`), *"Sweep the RSI window from 7 to 21 on BTC 1h and rank them"* (`/sweep`). Full walkthrough: [`docs/getting-started.md`](docs/getting-started.md); deeper dives in the KB [SIEVE guide](https://mangrove.io/docs/guides/using-sieve-prefilter) and [Experiments reference](https://mangrove.io/docs/api-reference/experiments).
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -113,9 +113,9 @@ you ask. They're listed so you know what's happening under the hood.
 ## Go deeper
 
 - **SIEVE, in depth** — tutorial [chapter 09](../tutorials/trading-app/09-oracle-strategies.md),
-  and the KB guides [Filtering with SIEVE](https://docs.mangrovedeveloper.ai/guides/using-sieve-prefilter)
-  and [SIEVE end-to-end](https://docs.mangrovedeveloper.ai/guides/sieve-end-to-end-workflow).
-- **Sweeps / experiments** — KB [Experiments reference](https://docs.mangrovedeveloper.ai/api-reference/experiments).
+  and the KB guides [Filtering with SIEVE](https://mangrove.io/docs/guides/using-sieve-prefilter)
+  and [SIEVE end-to-end](https://mangrove.io/docs/guides/sieve-end-to-end-workflow).
+- **Sweeps / experiments** — KB [Experiments reference](https://mangrove.io/docs/api-reference/experiments).
 - **The full trading workflow** the bot follows — [`trading-bot-workflow.md`](../.claude/rules/trading-bot-workflow.md).
 - **The SDK** behind it all (if you want to script directly) — the
   `mangroveai` Python package, `client.oracle.*`.

--- a/tutorials/trading-app/09-oracle-strategies.md
+++ b/tutorials/trading-app/09-oracle-strategies.md
@@ -149,9 +149,9 @@ the model is overconfident. Always backtest before promoting to paper.
   `oracle_backtest_bulk`) in addition to `client.oracle.*` if you script
   against the SDK directly.
 - The API reference for `client.oracle.*` lives in the
-  [mangrove-ai SDK docs](https://docs.mangrovedeveloper.ai/sdks/mangroveai),
+  [mangrove-ai SDK docs](https://mangrove.io/docs/sdks/mangroveai),
   and the worked SDK walkthroughs are the KB guides
-  [SIEVE end-to-end](https://docs.mangrovedeveloper.ai/guides/sieve-end-to-end-workflow)
-  and [Experiments](https://docs.mangrovedeveloper.ai/api-reference/experiments).
+  [SIEVE end-to-end](https://mangrove.io/docs/guides/sieve-end-to-end-workflow)
+  and [Experiments](https://mangrove.io/docs/api-reference/experiments).
 - The full corpus schema (98 fields on the `results` table) is
   documented at `MangroveOracle/infra/terraform/schemas/results.json`.


### PR DESCRIPTION
docs.mangrovedeveloper.ai was decommissioned today (service, domain mapping, DNS removed; docs now at https://mangrove.io/docs -- see https://github.com/MangroveTechnologies/MangroveAI/issues/831). Repoints the SIEVE/Experiments/SDK links in README.md, docs/getting-started.md, and tutorials/trading-app/09-oracle-strategies.md. Target pages verified live (ported in https://github.com/MangroveTechnologies/mangrove-platform-frontend-web/pull/1337).

🤖 Generated with [Claude Code](https://claude.com/claude-code)