### PR TITLE
fix(docs): live-catalog tool count (#136) + restore onboarding-tour suppression (#137)

### DIFF
--- a/.claude/rules/trading-bot-workflow.md
+++ b/.claude/rules/trading-bot-workflow.md
@@ -36,7 +36,9 @@ mcp__mangrove-agent__status, list_tools, list_signals, list_wallets, create_wall
 
 ## Stage 0 -- platform tour (no wallet required)
 
-**Trigger:** first interaction in a fresh clone, OR user asks for a tour. Don't skip -- workshop attendees need to see the product work before being asked to commit a key. Paper trading runs without a wallet; the full author -> backtest -> paper -> evaluate loop is reachable with zero on-chain exposure.
+**Trigger:** first interaction in a fresh clone (the `.claude/.onboarded` marker is **absent**), OR the user asks for a tour. Don't skip on a genuine fresh clone -- workshop attendees need to see the product work before being asked to commit a key. Paper trading runs without a wallet; the full author -> backtest -> paper -> evaluate loop is reachable with zero on-chain exposure.
+
+**Suppression (respect the marker):** if `.claude/.onboarded` **exists**, do NOT auto-fire the tour -- the user has already seen it or opted out. Go straight to Stage 1. The user can still replay it any time by asking ("give me the tour") or by removing the marker (`rm .claude/.onboarded`). A user who wants to skip up front can pass `./scripts/setup.sh --skip-tour`, which writes the marker before Claude Code first launches. The marker is gitignored (per-user, never committed).
 
 ### 0.1 Greeting
 Greet as the persona in `CLAUDE.md`'s Project Context, or default to a concise, security-conscious voice. One-liner: "Local Mangrove-powered trading bot. Strategy engine and KB live in the cloud; your keys, DB, and agent process live on this machine."
@@ -44,7 +46,7 @@ Greet as the persona in `CLAUDE.md`'s Project Context, or default to a concise, 
 ### 0.2 Live demo beats (one tool call + 1-2 sentences each, fits in one message)
 
 1. `status` -- "Bot is alive. Version X, uptime Y, N active cron jobs, DB at `./agent-data/agent.db`."
-2. `list_tools` -- group for the user (wallet / market data / swaps / strategies / monitoring / KB), don't dump all 95.
+2. `list_tools` -- group for the user (wallet / market data / swaps / strategies / monitoring / KB), don't dump the whole catalog (100+ tools as of 2026-07; `list_tools` returns the live count).
 3. `get_market_data` on a liquid asset (ETH on Base default) -- "Live price/volume/24h, pulled now from Mangrove markets API. Every backtest/evaluation prices off this."
 4. `kb_search` on a real concept (e.g. `"MACD crossover"`, `"Bollinger squeeze"`) -- "Knowledge base. Every recommendation cites entries here -- no vibes."
 5. `search_reference_strategies` with just an asset -- "Reference library. We start from already-backtested templates, not blank slate."
@@ -61,6 +63,9 @@ If any beat fails (bad key, unreachable URL, empty KB), surface the error and st
 - Strategy idea -> Stage 1/2.
 - Asks about wallets/funds upfront -> jump to Stage 4.5, return to authoring after.
 - Wants to keep poking -> offer next beats (`list_signals`, `kb_list_indicators`, more `kb_search`, `get_ohlcv`).
+
+### 0.5 Mark it done (so it doesn't re-fire)
+Once the tour has been delivered -- or the user declines/asks to skip it -- write the marker so subsequent sessions go straight to Stage 1: create an empty `.claude/.onboarded` file (`touch .claude/.onboarded`). Do this quietly, don't make it a beat. It's gitignored, so it stays per-user and never lands in a commit. If the user later wants the tour again, they ask or `rm .claude/.onboarded`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Wallet setup and live trading are in Chapters 06 and 07 of the tutorial. The sum
 
 ## What the agent can do
 
-95 MCP tools (including the `hello_mangrove` x402 demo). Rough grouping:
+100+ MCP tools as of 2026-07 (including the `hello_mangrove` x402 demo) — run `list_tools` for the live catalog, which is authoritative. Rough grouping:
 
 | Category | Tools |
 |---|---|

--- a/SETUP.md
+++ b/SETUP.md
@@ -4,7 +4,7 @@ Get from zero to a running trading agent. Every step has Mac and Windows instruc
 
 **What you will end up with:**
 - A local trading agent running at `http://localhost:9080`
-- Claude Code connected to it with 95 trading tools
+- Claude Code connected to it with 100+ trading tools (run `list_tools` for the live catalog)
 - A working paper strategy you can watch evaluate in real time
 
 ---
@@ -427,8 +427,9 @@ When it finishes successfully you will see:
     PID:   12345  (agent-data/bare.pid)
     Logs:  agent-data/bare.log
 
-    Restart Claude Code in this directory to load the 95 mangrove-agent
-    tools. Then try: "Status check. List my wallets and strategies."
+    Restart Claude Code in this directory to load the mangrove-agent
+    tools (run list_tools for the live catalog). Then try: "Status
+    check. List my wallets and strategies."
 ```
 
 ---
@@ -473,7 +474,7 @@ Wait 10–20 seconds. The agent should run a **platform tour automatically** —
 
 ## You are all set
 
-If you made it this far and the tour fired, everything is working — the server is running, Claude Code is connected, and all 95 trading tools are loaded.
+If you made it this far and the tour fired, everything is working — the server is running, Claude Code is connected, and all the trading tools are loaded (run `list_tools` for the live catalog).
 
 Here is what you can do right now:
 

--- a/docs/verification-checklist.md
+++ b/docs/verification-checklist.md
@@ -61,11 +61,14 @@ pointing at whatever port `scripts/setup-mcp.sh` configured.)
 
 ### 0.4 — Fresh-clone Stage 0 greeter fires
 
-This checks the session-start hook (`.claude/hooks/check-onboard.sh`).
+This checks the fresh-clone tour gate in `.claude/rules/trading-bot-workflow.md`
+(Stage 0). The tour is model-driven — there is no session-start hook — and it
+respects the `.claude/.onboarded` marker: absent → the tour fires, present →
+it's suppressed.
 
 **Do:** Nothing — on session start with no `.claude/.onboarded` marker,
 the agent should deliver the Stage 0 greeter (security primer + wallet
-question).
+question), then write `.claude/.onboarded` so it doesn't re-fire.
 
 **Expect (if fresh clone):**
 - Brief intro as the mangrove-agent

--- a/docs/workshop/run-of-show.md
+++ b/docs/workshop/run-of-show.md
@@ -222,7 +222,7 @@
 - 27: Client / server / transport · 90 sec
 - 28: `claude mcp add` example · 90 sec
 - 29: Learn more · 30 sec
-- ● **Land:** "Claude Code doesn't know about trading out of the box. MCP is how it gets to. One register command = 95 new tools."
+- ● **Land:** "Claude Code doesn't know about trading out of the box. MCP is how it gets to. One register command = 100+ new tools."
 
 #### Slides 30–34 — PLUGINS (5 slides, ~5 min)
 - 30: Section divider · 30 sec

--- a/scripts/setup-mcp.sh
+++ b/scripts/setup-mcp.sh
@@ -92,7 +92,7 @@ claude mcp add --transport http --scope local "$SERVER_NAME" "$BASE_URL/mcp/" --
 ok "registered"
 
 echo
-printf "${GREEN}Done.${CLR} Restart Claude Code in this directory to load the mangrove-agent tools (95 total).\n\n"
+printf "${GREEN}Done.${CLR} Restart Claude Code in this directory to load the mangrove-agent tools. Run list_tools for the live catalog.\n\n"
 echo "  cd $(pwd)"
 echo "  claude"
 echo

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -50,6 +50,7 @@ DO_MCP="yes"
 DO_VERIFY="yes"
 ASSUME_YES="no"
 FOREGROUND="no"
+SKIP_TOUR="no"
 API_KEY_ARG=""
 MARKETS_URL_DEFAULT="https://mangrovemarkets-pcqgpciucq-uc.a.run.app"
 MARKETS_URL_ARG=""
@@ -87,6 +88,9 @@ Options:
                         Default: background via nohup, logs in $LOG_FILE.
   --no-mcp              Skip Claude Code MCP registration.
   --no-verify           Skip the final verify pass.
+  --skip-tour           Suppress the first-run platform tour by writing the
+                        .claude/.onboarded marker before Claude Code launches.
+                        Replay it later by asking or 'rm .claude/.onboarded'.
   --api-key KEY         Non-interactive: set MANGROVE_API_KEY.
   --markets-url URL     Non-interactive: set MANGROVEMARKETS_BASE_URL.
                         Default: $MARKETS_URL_DEFAULT
@@ -104,6 +108,7 @@ while [ $# -gt 0 ]; do
     --foreground) FOREGROUND="yes"; shift ;;
     --no-mcp) DO_MCP="no"; shift ;;
     --no-verify) DO_VERIFY="no"; shift ;;
+    --skip-tour) SKIP_TOUR="yes"; shift ;;
     --api-key) API_KEY_ARG="$2"; shift 2 ;;
     --markets-url) MARKETS_URL_ARG="$2"; shift 2 ;;
     --yes) ASSUME_YES="yes"; shift ;;
@@ -206,6 +211,14 @@ if [ ! -d agent-data ]; then
   mkdir -p agent-data
   chmod 700 agent-data
   info "created agent-data/ (chmod 700)"
+fi
+
+# --skip-tour: write the (gitignored, per-user) marker the trading-bot-workflow
+# rule gates on, so the first-run platform tour is suppressed. Replay it later
+# by asking the agent or removing the marker.
+if [ "$SKIP_TOUR" = "yes" ] && [ ! -f .claude/.onboarded ]; then
+  touch .claude/.onboarded
+  info "wrote .claude/.onboarded — first-run tour suppressed (rm to replay)"
 fi
 # Bare-metal only: a prior Docker run bind-mounts agent-data/ as root, which a
 # non-root bare-metal run then can't write. (Docker mode legitimately owns it as
@@ -313,9 +326,15 @@ fi
 echo
 printf "${GREEN}Done.${CLR} mangrove-agent is running at $BASE_URL\n\n"
 echo "Next:"
-echo "  - Restart Claude Code in this directory. The agent will greet you"
-echo "    and walk through wallet setup + security. It will refuse to"
-echo "    accept pasted private keys in chat — if you want to import an"
-echo "    existing wallet, the agent will tell you to run"
-echo "    ./scripts/stash-secret.sh first."
+if [ "$SKIP_TOUR" = "yes" ]; then
+  echo "  - Restart Claude Code in this directory. The first-run tour is"
+  echo "    suppressed (.claude/.onboarded present) — ask for it any time"
+  echo "    or 'rm .claude/.onboarded' to replay it."
+else
+  echo "  - Restart Claude Code in this directory. The agent will greet you"
+  echo "    and walk through wallet setup + security. It will refuse to"
+  echo "    accept pasted private keys in chat — if you want to import an"
+  echo "    existing wallet, the agent will tell you to run"
+  echo "    ./scripts/stash-secret.sh first."
+fi
 echo

--- a/tutorials/trading-app/02-overview.md
+++ b/tutorials/trading-app/02-overview.md
@@ -21,7 +21,7 @@ Mangrove (behind an API key), and on the public blockchain.
 │                ▼                                                   │
 │  ┌─────────────────────────────────────────────────┐               │
 │  │ mangrove-agent (uvicorn process, port 9080)         │               │
-│  │   • 95 MCP tools + REST API                     │               │
+│  │   • 100+ MCP tools + REST API                   │               │
 │  │   • APScheduler (in-process cron)               │               │
 │  │   • Fernet-encrypted wallet keys                │               │
 │  │   • SQLite DB: strategies, trades, evaluations  │               │
@@ -57,7 +57,8 @@ four things:
    these directly from a terminal if you want. There's also a free
    `/health` endpoint for "is it up?"
 2. **Serves MCP endpoints** under `/mcp/` — this is what Claude Code
-   talks to for the 95 trading tools. Everything the REST API
+   talks to for the trading tools (100+ as of 2026-07; run
+   `list_tools` for the live catalog). Everything the REST API
    exposes, the MCP tools expose too, and vice versa. They share
    the service layer.
 3. **Runs the scheduler** — APScheduler, in-process, using the same

--- a/tutorials/trading-app/03-setup.md
+++ b/tutorials/trading-app/03-setup.md
@@ -79,8 +79,9 @@ If everything went well, the last thing you see is:
     PID:   12345  (agent-data/bare.pid)
     Logs:  agent-data/bare.log
 
-    Restart Claude Code in this directory to load the 95 mangrove-agent
-    tools. Then try: "Status check. List my wallets and strategies."
+    Restart Claude Code in this directory to load the mangrove-agent
+    tools (run list_tools for the live catalog). Then try: "Status
+    check. List my wallets and strategies."
 ```
 
 ### If something went wrong
@@ -183,7 +184,8 @@ claude
 ```
 
 Claude Code detects the `.mcp.json` and the local registration, loads
-the 95 tools, and runs a **platform tour** automatically. The tour is
+the tools (100+ as of 2026-07 — run `list_tools` for the live
+catalog), and runs a **platform tour** automatically. The tour is
 a sequence of five live tool calls with one-sentence commentary each —
 the bot is showing you the product works before asking you to do
 anything. You'll see roughly:
@@ -242,14 +244,15 @@ Usually one of three things:
    "ToolSearch" call that returns nothing, or a "the mangrove-agent MCP
    server isn't connected" message, go back to step 4 and fix the
    MCP registration.
-2. **You've already onboarded in this session.** If `.claude/.onboarded`
-   exists, the greeter won't fire (it's designed for fresh clones).
+2. **You've already onboarded.** If `.claude/.onboarded` exists, the
+   greeter won't fire (it's designed for fresh clones, and is written
+   once the tour completes or when you pass `setup.sh --skip-tour`).
    `rm .claude/.onboarded` to reset.
 3. **Claude Code was started from the wrong directory.** MCP local
    registrations are keyed to the project directory. Make sure
    you're in `~/Desktop/mangrove-agent` (or wherever you cloned).
 
-### "I see fewer than 95 tools"
+### "I see fewer tools than expected"
 
 You're on an older version of the repo. `git pull` to sync with
 the branch you cloned from, then restart the server:

--- a/tutorials/trading-app/08-monitor-troubleshoot-extend.md
+++ b/tutorials/trading-app/08-monitor-troubleshoot-extend.md
@@ -232,7 +232,7 @@ response. No business logic.
 ### MCP tools
 
 ```
-server/src/mcp/tools.py   ← one big file, ~1500 lines, 95 tools
+server/src/mcp/tools.py   ← one big file, ~1500 lines, 100+ tools
 ```
 
 Organized by domain with `_register_*` helpers. If you want to add


### PR DESCRIPTION
## Bottom line
Two docs-drift bugs from the developer-focus-group audit, fixed in one PR.

- **#136 — tool count stale (docs said 95, live catalog registers 100).** Root cause: hardcoded counts drift every time a tool is added (the CEX OAuth merge #134 added 5). Fix: replace hardcoded numbers with a **"run `list_tools` for the live catalog"** reference — the same drift-proof pattern `scripts/verify_quickstart.sh` and `docs/verification-checklist.md` already use — or an explicitly-approximate **"100+ tools as of 2026-07"** where a number reads better in prose.
- **#137 — onboarding tour couldn't be skipped, and the docs described a suppression mechanism that no longer exists.** Root cause: the `.claude/.onboarded` marker + `check-onboard.sh` SessionStart hook were deleted in `7b52455` (May 2026), but `SETUP.md`, `tutorials/trading-app/03-setup.md`, and `docs/verification-checklist.md` still documented them. Fix: restore a real, **hook-free** suppression — the Stage 0 tour rule gates on the (gitignored) `.claude/.onboarded` marker and writes it at tour completion — plus an optional `setup.sh --skip-tour` flag, and reconcile all three doc references.

Fixes #136
Fixes #137

## What changed

### #136 — live-catalog references (no more hardcoded count)
| File | Before → After |
|---|---|
| `README.md` | "95 MCP tools" → "100+ MCP tools as of 2026-07 … run `list_tools` for the live catalog" |
| `SETUP.md` (×3) | "95 trading tools" → "100+ … (run `list_tools` …)" / dropped the count from the setup-output example |
| `scripts/setup-mcp.sh` | "load the … tools (95 total)" → "… Run list_tools for the live catalog" |
| `.claude/rules/trading-bot-workflow.md` | tour beat "don't dump all 95" → "don't dump the whole catalog (100+ … `list_tools` returns the live count)" |
| `docs/workshop/run-of-show.md` | "95 new tools" → "100+ new tools" |
| `tutorials/trading-app/02-overview.md` (×2), `03-setup.md` (×3), `08-…md` | same treatment |

`list_tools` delegates to the discovery route, which iterates the live `_tools` registry — so it always reflects the true count. Pointing docs there is drift-proof by design.

### #137 — real tour suppression
- `.claude/rules/trading-bot-workflow.md`: Stage 0 **Trigger** now fires only when `.claude/.onboarded` is **absent**; a new **Suppression** paragraph says present → skip to Stage 1; new **§0.5** tells the agent to `touch .claude/.onboarded` at tour completion.
- `scripts/setup.sh`: new `--skip-tour` flag writes the marker before Claude Code launches (idempotent; the "Next:" hint adapts).
- Docs reconciled: `verification-checklist.md` §0.4 no longer references the deleted `check-onboard.sh` hook; `SETUP.md` and `03-setup.md` marker instructions are now accurate again.
- `.claude/.onboarded` is already in `.gitignore` (line 49) — per-user, never committed.

## Verification

**Live tool count (#136)** — ran the registry in-process against a fresh checkout of this branch:
```
$ ENVIRONMENT=test python -c "<register all tool groups>; print(len(list_tools()))"
live catalog tool count: 100
unique names: 100
```
Confirms docs were stale at 95 and that `list_tools` returns the real count dynamically.

**`--skip-tour` marker (#137)** — exercised the exact branch from `setup.sh` in a throwaway repo-shaped dir:
```
default (no flag)          -> no marker written
--skip-tour, fresh         -> wrote .claude/.onboarded
--skip-tour, already present-> no-op (idempotent)
.gitignore:49:.claude/.onboarded   (confirmed ignored)
```
`bash -n scripts/setup.sh` and `scripts/setup-mcp.sh` both pass; `--help` renders the new flag.

**Repo lint/test (no regression)** — the changed files are docs / `.claude` / shell (CI's `ruff` + `pytest` don't cover them), but ran both anyway on this branch:
```
ruff check server/src/   → All checks passed!
pytest server/tests/     → 431 passed, 2 skipped
```

**Honest scope note:** the executable change (`--skip-tour`) and the live-count claim are verified as above. The Stage 0 tour-gating itself is a **model-facing rule** (prompt instruction in `trading-bot-workflow.md`), not runtime code, so it's verified by inspection — there is no process to exercise for it.

## Claude session
```
Session: c910d110-1fd8-467e-8818-2987f5e293a0
Resume:  claude --resume c910d110-1fd8-467e-8818-2987f5e293a0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
