### PR TITLE
fix(docker): run a single uvicorn worker (#142)

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -18,4 +18,13 @@ COPY pyproject.toml ./
 ENV PORT=8080
 EXPOSE 8080
 
-CMD ["sh", "-c", "cp -n src/config/local-example-config.json src/config/local-config.json 2>/dev/null; exec uvicorn src.app:app --host 0.0.0.0 --port 8080 --workers 2 --timeout-keep-alive 120"]
+# Single worker, on purpose (#142). Two of this app's core services are
+# per-process state that breaks with N>1 workers:
+#   - SecretVault is in-process memory: stash lands in worker A, the
+#     import that consumes the vault_token hits worker B -> "vault_token
+#     is unknown or has expired" ~50% of the time.
+#   - Each worker starts its own APScheduler against the SAME SQLite
+#     jobstore (max_instances=1 is per-scheduler, not cross-process), so
+#     strategy cron ticks can double-fire -> duplicate live trades.
+# This is a local single-user agent; one worker is the correct shape.
+CMD ["sh", "-c", "cp -n src/config/local-example-config.json src/config/local-config.json 2>/dev/null; exec uvicorn src.app:app --host 0.0.0.0 --port 8080 --workers 1 --timeout-keep-alive 120"]


### PR DESCRIPTION
## Summary

Closes https://github.com/MangroveTechnologies/mangrove-agent/issues/142. The container ran `uvicorn --workers 2`, but two core services are per-process state:

- **SecretVault** (in-process memory): `stash-secret` lands in worker A, the `import` consuming the `vault_token` hits worker B → `vault_token is unknown or has expired` ~50% of the time. Reproduced live during #122 verification.
- **APScheduler**: each worker starts its own scheduler against the same SQLite jobstore (`max_instances=1` is per-scheduler, not cross-process) → strategy cron ticks can double-fire → duplicate evaluations and potentially **duplicate live trades**.

The bare-metal launchers (`scripts/setup.sh`, `scripts/run-bare.sh`) already use `--workers 1`; only the Dockerfile diverged.

## Verification (container rebuilt from this branch)

- `/health` healthy on an isolated container (port 9183).
- **6/6 consecutive stash→import round-trips succeeded** with throwaway random keys — the exact surface that failed ~50% of the time on 2 workers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)