### PR TITLE
fix(orders): map engine-shaped new_orders to OrderIntents; asset-unit sizing + allocation cap (#139)

### DIFF
--- a/server/src/models/domain.py
+++ b/server/src/models/domain.py
@@ -34,8 +34,14 @@ class OrderIntent(BaseModel):
     action: Literal["enter", "exit"]
     side: Literal["buy", "sell"]
     symbol: str
+    # ASSET units for cron/engine intents (the engine's position_size).
+    # For user-initiated /dex/swap intents (explicit token addresses) this
+    # is the input-token amount, used verbatim.
     amount: float
     reason: str = ""  # which signal fired, or "user-initiated" for /dex/swap
+    # Engine's evaluation-time market price. Lets the live executor convert
+    # asset units -> input-token (USDC) spend without a second price fetch.
+    ref_price: float | None = None
     stop_loss: float | None = None
     take_profit: float | None = None
     # Explicit chain-level addresses for live execution. Both or neither.

--- a/server/src/services/order_executor.py
+++ b/server/src/services/order_executor.py
@@ -153,15 +153,24 @@ def _validate_slippage(slippage_pct: float | None) -> None:
 
 
 def _resolve_tokens(intent: OrderIntent) -> tuple[str, str, float]:
-    """Determine input/output token addresses and amount from an OrderIntent.
+    """Determine input/output tokens and the INPUT amount from an OrderIntent.
 
-    Prefers explicit token addresses (user-initiated swaps via /dex/swap);
-    falls back to USDC+symbol convention for cron strategy intents.
+    Prefers explicit token addresses (user-initiated swaps via /dex/swap),
+    where `amount` is already the input-token amount and is used verbatim.
+
+    Cron/engine intents carry `amount` in ASSET units (the engine's
+    position_size, #139). The DEX swap API takes the INPUT amount:
+    - buy  (USDC -> asset): input = amount * price, using the engine's
+      evaluation-time `ref_price` (fallback: current mark price). Same
+      convention as _paper_fill, so paper and live take the same economic
+      exposure for the same intent.
+    - sell (asset -> USDC): the input IS the asset qty — pass through.
     """
     if intent.input_token_address and intent.output_token_address:
         return intent.input_token_address, intent.output_token_address, intent.amount
     if intent.side == "buy":
-        return "USDC", intent.symbol, intent.amount
+        price = intent.ref_price or _fetch_mark_price(intent.symbol)
+        return "USDC", intent.symbol, intent.amount * price
     return intent.symbol, "USDC", intent.amount
 
 
@@ -213,6 +222,7 @@ def _live_swap(
     chain_id: int | None = None,
     venue_id: str | None = None,
     slippage_pct: float | None = None,
+    max_input_amount: float | None = None,
 ) -> Trade:
     """Execute the full 6-step live swap flow.
 
@@ -238,6 +248,20 @@ def _live_swap(
 
     client = mangrove_markets_client()
     input_token, output_token, input_amount = _resolve_tokens(intent)
+
+    # Allocation cap: cron intents are sized by the ENGINE off its own
+    # simulated account, not off the user's allocation block. Never spend
+    # more input than the allocation allows (defense for the funds path;
+    # user-initiated /dex/swap passes no cap — the user typed the amount).
+    if max_input_amount is not None and input_amount > max_input_amount:
+        _log.warning(
+            "order.live.amount_capped",
+            strategy_id=strategy_id,
+            symbol=intent.symbol,
+            requested_input=input_amount,
+            allocation_cap=max_input_amount,
+        )
+        input_amount = max_input_amount
 
     # 1. Quote — via dex_service, the single human<->base-units boundary.
     # `input_amount` is HUMAN units (the agent's convention everywhere);
@@ -342,6 +366,7 @@ def execute_one(
     chain_id: int | None = None,
     venue_id: str | None = None,
     slippage_pct: float | None = None,
+    max_input_amount: float | None = None,
 ) -> Trade:
     """Execute a single OrderIntent.
 
@@ -375,6 +400,7 @@ def execute_one(
             chain_id=chain_id,
             venue_id=venue_id,
             slippage_pct=slippage_pct,
+            max_input_amount=max_input_amount,
         )
     raise SigningError(f"Unknown mode: {mode}")
 
@@ -388,6 +414,7 @@ def execute_many(
     chain_id: int | None = None,
     venue_id: str | None = None,
     slippage_pct: float | None = None,
+    max_input_amount: float | None = None,
 ) -> list[Trade]:
     """Execute N intents in order. Failures on one do not abort the batch.
 
@@ -408,6 +435,7 @@ def execute_many(
                 chain_id=chain_id,
                 venue_id=venue_id,
                 slippage_pct=slippage_pct,
+                max_input_amount=max_input_amount,
             )
             results.append(t)
         except Exception as e:  # noqa: BLE001

--- a/server/src/services/strategy_service.py
+++ b/server/src/services/strategy_service.py
@@ -112,7 +112,7 @@ def _extract_order_intents(
             order_intents.append(o)
         elif isinstance(o, dict):
             try:
-                order_intents.append(OrderIntent.model_validate(o))
+                order_intents.append(OrderIntent.model_validate(_map_engine_order(o)))
             except Exception as e:  # noqa: BLE001
                 _log.warning(
                     "strategy.tick.order_intent.skipped",
@@ -125,11 +125,44 @@ def _extract_order_intents(
     return order_intents
 
 
-def _get_live_allocation(strategy_id: str) -> tuple[str | None, int | None, float | None]:
-    """Return (wallet_address, chain_id, slippage_pct) from the active allocation, or Nones."""
+def _map_engine_order(o: dict) -> dict:
+    """Translate a MangroveAI engine order into OrderIntent field names.
+
+    The engine's evaluate() emits `new_orders` as
+    ``{order_id, asset: "ETH-USD", side: "enter_long"|"exit_long",
+    order_type, status, price, position_size, position_id, ...}``
+    (managers OrderResponse; `position_size` is in ASSET units), which
+    shares no required field with OrderIntent — before this mapping,
+    every real engine order failed validation and was skipped, so
+    cron-driven strategies never traded (#139). Dicts already in
+    OrderIntent shape pass through untouched.
+    """
+    side = o.get("side")
+    if side not in ("enter_long", "exit_long") or "position_size" not in o:
+        return o
+    symbol = (o.get("asset") or "").split("-")[0] or (o.get("asset") or "")
+    return {
+        "action": "enter" if side == "enter_long" else "exit",
+        "side": "buy" if side == "enter_long" else "sell",
+        "symbol": symbol,
+        "amount": float(o["position_size"]),
+        "reason": f"engine {o.get('order_type', 'market')} order {o.get('order_id', '')}".strip(),
+        "ref_price": o.get("price"),
+        "stop_loss": o.get("stop_loss_price"),
+        "take_profit": o.get("take_profit_price"),
+    }
+
+
+def _get_live_allocation(
+    strategy_id: str,
+) -> tuple[str | None, int | None, float | None, float | None]:
+    """Return (wallet_address, chain_id, slippage_pct, amount) from the
+    active allocation, or Nones. `amount` caps the input-token spend of any
+    single live swap (#139: engine intents are sized off the engine's own
+    simulated account, not the user's allocation)."""
     active_alloc = allocation_service.get_active_allocation(strategy_id)
     if not active_alloc:
-        return None, None, None
+        return None, None, None, None
     wallet_address = active_alloc.wallet_address
     slippage_pct = active_alloc.slippage_pct
     wrow = get_connection().execute(
@@ -137,7 +170,7 @@ def _get_live_allocation(strategy_id: str) -> tuple[str | None, int | None, floa
         (wallet_address,),
     ).fetchone()
     chain_id = wrow["chain_id"] if wrow else None
-    return wallet_address, chain_id, slippage_pct
+    return wallet_address, chain_id, slippage_pct, active_alloc.amount
 
 
 # -- Pydantic request/response models ---------------------------------------
@@ -585,8 +618,11 @@ def tick(strategy_id: str) -> None:
         wallet_address = None
         chain_id = None
         slippage_pct = None
+        allocation_amount = None
         if mode == "live":
-            wallet_address, chain_id, slippage_pct = _get_live_allocation(strategy_id)
+            wallet_address, chain_id, slippage_pct, allocation_amount = (
+                _get_live_allocation(strategy_id)
+            )
 
         # Log the evaluation FIRST so trades can FK-reference it. The
         # evaluation describes the SDK call outcome, not the downstream
@@ -610,6 +646,7 @@ def tick(strategy_id: str) -> None:
                 evaluation_id=evaluation_id,
                 wallet_address=wallet_address, chain_id=chain_id,
                 slippage_pct=slippage_pct,
+                max_input_amount=allocation_amount,
             )
 
         _log.info("strategy.tick.completed",

--- a/server/tests/integration/test_strategy_service.py
+++ b/server/tests/integration/test_strategy_service.py
@@ -337,6 +337,67 @@ def test_tick_paper_mode_logs_simulated_trade(temp_db, mock_ai_sdk, monkeypatch)
     assert trades[0].status == "simulated"
 
 
+def test_tick_maps_engine_shaped_orders(temp_db, mock_ai_sdk, monkeypatch):
+    """#139 regression: the REAL engine emits new_orders shaped
+    {order_id, asset: 'ETH-USD', side: 'enter_long', position_size, price}
+    — no OrderIntent field among them. Before the mapping, every real
+    engine order failed validation and was silently skipped, so cron
+    strategies never traded. An engine-shaped order must produce a trade
+    sized in ASSET units (position_size)."""
+    from src.services.strategy_service import (
+        StrategyManualRequest,
+        StrategyStatusUpdate,
+        create_manual,
+        tick,
+        update_status,
+    )
+    from src.services.trade_log import list_trades
+
+    eval_resp = MagicMock()
+    eval_resp.new_orders = [{
+        "order_id": "o-42",
+        "asset": "ETH-USD",
+        "side": "enter_long",
+        "order_type": "market",
+        "status": "pending",
+        "price": 2500.0,
+        "position_size": 0.04,
+        "position_id": "p-7",
+    }]
+    eval_resp.order_intents = None
+    eval_resp.orders = None
+    eval_resp.model_dump.return_value = {}
+    mock_ai_sdk.execution.evaluate.return_value = eval_resp
+
+    md = MagicMock()
+    md.data = {"current_price": 2500.0}
+    mock_ai_sdk.crypto_assets.get_market_data.return_value = md
+    monkeypatch.setattr("src.services.order_executor.mangrove_ai_client",
+                        lambda: mock_ai_sdk)
+
+    s = create_manual(StrategyManualRequest(
+        name="engine-shape", asset="ETH", timeframe="1h",
+        entry=[{"name": "rsi_oversold", "signal_type": "TRIGGER", "timeframe": "1h"}],
+    ))
+    update_status(s.id, StrategyStatusUpdate(status="inactive"))
+    update_status(s.id, StrategyStatusUpdate(status="paper"))
+
+    tick(s.id)
+
+    trades = list_trades(s.id)
+    assert len(trades) == 1, "engine-shaped order must NOT be skipped"
+    t = trades[0]
+    assert t.mode == "paper"
+    # amount is ASSET units: buys 0.04 ETH, spending 0.04 * 2500 = 100 USDC
+    assert t.output_token == "ETH"
+    assert t.output_amount == pytest.approx(0.04)
+    assert t.input_token == "USDC"
+    assert t.input_amount == pytest.approx(100.0)
+    assert t.order_intent.action == "enter"
+    assert t.order_intent.side == "buy"
+    assert t.order_intent.ref_price == pytest.approx(2500.0)
+
+
 def test_tick_catches_sdk_errors(temp_db, mock_ai_sdk):
     """SDK failure during tick logs evaluation with status=error, does NOT raise."""
     from src.services.strategy_service import (

--- a/server/tests/unit/test_order_executor.py
+++ b/server/tests/unit/test_order_executor.py
@@ -88,7 +88,7 @@ def mock_markets(monkeypatch):
     quote.quote_id = "q-123"
     quote.model_dump.return_value = {
         "quote_id": "q-123",
-        "input_amount": 100_000,                  # 0.1 USDC (6 decimals)
+        "input_amount": 100_000_000,              # 100 USDC (6 decimals)
         "output_amount": 40_000_000_000_000_000,  # 0.04 ETH in wei
         "exchange_rate": 2500.0,
         "venue_fee": 1.0,
@@ -217,14 +217,15 @@ def test_live_full_flow_with_approval(temp_db, mock_mangroveai, mock_markets, st
 
 
 def test_live_quotes_in_base_units(temp_db, mock_mangroveai, mock_markets, stub_sign):
-    """#122 regression: the live path must convert the HUMAN intent amount
-    to base units before dex.get_quote (0.1 USDC @ 6 decimals -> 100_000),
-    and record the quote's output_amount converted back to human units
-    (4e16 wei -> 0.04 ETH) — not the raw base-units value."""
+    """#122 + #139 regression: a cron buy intent's amount is ASSET units
+    (engine position_size). Buying 0.04 ETH at the 2500 mark price spends
+    100 USDC, which must reach dex.get_quote in BASE units (100_000_000
+    @ 6 decimals), and the trade must record human amounts + a real
+    fill price — not raw base-units values."""
     from src.services.order_executor import execute_one
 
     trade = execute_one(
-        _intent("buy", "ETH", 0.1),
+        _intent("buy", "ETH", 0.04),
         mode="live",
         strategy_id="s1",
         wallet_address="0xabc",
@@ -232,15 +233,36 @@ def test_live_quotes_in_base_units(temp_db, mock_mangroveai, mock_markets, stub_
         slippage_pct=0.002,
     )
     _, kwargs = mock_markets.dex.get_quote.call_args
-    assert kwargs["amount"] == 100_000
-    assert trade.input_amount == pytest.approx(0.1)
+    assert kwargs["amount"] == 100_000_000
+    assert trade.input_amount == pytest.approx(100.0)
     assert trade.output_amount == pytest.approx(0.04)
-    # fill_price is derived from the HUMAN amounts (0.1 USDC / 0.04 ETH),
-    # NOT the quote's exchange_rate (a base-units ratio, 2500.0 here).
-    assert trade.fill_price == pytest.approx(2.5)
+    # fill_price derived from HUMAN amounts (100 USDC / 0.04 ETH = 2500),
+    # NOT the quote's exchange_rate (a base-units ratio).
+    assert trade.fill_price == pytest.approx(2500.0)
     # prepare_swap must still be driven by the returned quote_id.
     _, prep_kwargs = mock_markets.dex.prepare_swap.call_args
     assert prep_kwargs["quote_id"] == "q-123"
+
+
+def test_live_buy_uses_ref_price_and_allocation_cap(temp_db, mock_mangroveai, mock_markets, stub_sign):
+    """#139: the engine's evaluation-time ref_price converts asset units to
+    USDC spend without a mark-price fetch, and the allocation amount caps
+    the spend (the engine sizes off its own simulated account, not the
+    user's allocation)."""
+    from src.models.domain import OrderIntent
+    from src.services.order_executor import execute_one
+
+    intent = OrderIntent(action="enter", side="buy", symbol="ETH",
+                         amount=0.1, ref_price=2000.0, reason="engine order")
+    execute_one(
+        intent, mode="live", strategy_id="s1", wallet_address="0xabc",
+        chain_id=8453, slippage_pct=0.002,
+        max_input_amount=50.0,  # 0.1 ETH * 2000 = 200 USDC, capped to 50
+    )
+    _, kwargs = mock_markets.dex.get_quote.call_args
+    assert kwargs["amount"] == 50_000_000  # 50 USDC in base units
+    # ref_price supplied -> no mark-price lookup on the live path
+    assert not mock_mangroveai.crypto_assets.get_market_data.called
 
 
 def test_live_sell_quotes_asset_side_in_base_units(temp_db, mock_mangroveai, mock_markets, stub_sign):
@@ -268,7 +290,8 @@ def test_live_rejects_dust_amount(temp_db, mock_mangroveai, mock_markets, stub_s
 
     with pytest.raises(ValidationError, match="too small to quote"):
         execute_one(
-            _intent("buy", "ETH", 0.0000001),  # < 1e-6 USDC -> 0 base units
+            # sell of 1e-19 ETH -> less than 1 wei -> 0 base units
+            _intent("sell", "ETH", 1e-19),
             mode="live",
             strategy_id="s1",
             wallet_address="0xabc",


### PR DESCRIPTION
## Summary

Closes https://github.com/MangroveTechnologies/mangrove-agent/issues/139 — and the investigation found the root cause is bigger than the issue described (full detail in https://github.com/MangroveTechnologies/mangrove-agent/issues/139#issuecomment-4951768898):

**Every real engine order was silently dropped.** The engine emits `new_orders` as `{order_id, asset: "ETH-USD", side: "enter_long"|"exit_long", price, position_size, ...}`; the SDK passes raw dicts through; `OrderIntent.model_validate` requires `{action, side: buy/sell, symbol, amount}` → 4 validation errors → skipped with a warning. **Cron-driven paper AND live strategies never traded**, indistinguishable from "strategy didn't fire". Existing tests used hand-built agent-shaped dicts the engine never emits, masking it.

## Changes

1. **`_map_engine_order`** — engine shape → OrderIntent (`enter_long`→enter/buy, `exit_long`→exit/sell, `asset "ETH-USD"`→symbol, `amount = position_size` in **asset units**, `price`→new `OrderIntent.ref_price`, stop/take-profit carried). Agent-shaped dicts pass through untouched.
2. **Live buy sizing** (the original #139 ask): cron buys convert asset units → USDC input via `ref_price` (fallback: current mark price), matching `_paper_fill`'s convention — **paper and live now take the same economic exposure for the same intent**.
3. **Allocation cap**: the engine sizes positions off its own simulated account (live-verified: `execution_state.cash_balance: 10000.0`), and the allocation `amount` was previously **never consulted at execution time**. `_live_swap` now clamps input spend to it, with an `order.live.amount_capped` warning.

## Verification

- **433 passed, 2 skipped**; ruff clean. New: engine-shape fixture regression (`test_tick_maps_engine_shaped_orders` — exact engine dict → paper trade in asset units), `ref_price` + cap unit test; two #122-era tests updated to asset-unit semantics with coherent numbers.
- **Live E2E** (container rebuilt from branch, real MangroveAI engine): manual paper strategy created, promoted, evaluated — `success: true, current_price: 1819.51`, evaluation logged `ok`, **zero `order_intent.skipped` warnings**.
- Honest limit: a live engine *order firing* is market-dependent (TRIGGER signals only fire on their bar — attempted with complementary ROC filters, but entry composition requires a TRIGGER). Mapping mechanics are proven by the fixture, which mirrors MangroveAI's `OrderResponse` model (`managers/routes.py`) and the live response envelope captured today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)