### PR TITLE
fix(orders): only execute FILLED engine orders — skip resting brackets (#149)

### DIFF
--- a/server/src/services/strategy_service.py
+++ b/server/src/services/strategy_service.py
@@ -111,8 +111,21 @@ def _extract_order_intents(
         if isinstance(o, OrderIntent):
             order_intents.append(o)
         elif isinstance(o, dict):
+            mapped = _map_engine_order(o)
+            if mapped is None:
+                # Resting engine order (pending bracket etc.) — normal, not
+                # an error; the engine re-emits it as `filled` when it
+                # actually triggers (#149).
+                _log.info(
+                    "strategy.tick.order_intent.resting",
+                    strategy_id=strategy_id,
+                    tick_id=tick_id,
+                    order_type=o.get("order_type"),
+                    order_status=o.get("status"),
+                )
+                continue
             try:
-                order_intents.append(OrderIntent.model_validate(_map_engine_order(o)))
+                order_intents.append(OrderIntent.model_validate(mapped))
             except Exception as e:  # noqa: BLE001
                 _log.warning(
                     "strategy.tick.order_intent.skipped",
@@ -125,7 +138,7 @@ def _extract_order_intents(
     return order_intents
 
 
-def _map_engine_order(o: dict) -> dict:
+def _map_engine_order(o: dict) -> dict | None:
     """Translate a MangroveAI engine order into OrderIntent field names.
 
     The engine's evaluate() emits `new_orders` as
@@ -136,10 +149,20 @@ def _map_engine_order(o: dict) -> dict:
     every real engine order failed validation and was skipped, so
     cron-driven strategies never traded (#139). Dicts already in
     OrderIntent shape pass through untouched.
+
+    Returns None for RESTING engine orders — anything not `status ==
+    "filled"`. A tick that opens a position emits the entry as `filled`
+    PLUS its bracket exits (stop_loss / take_profit) as `pending`;
+    executing those brackets immediately would exit the position the
+    moment it entered (#149, observed live 2026-07-12). The engine
+    re-emits a bracket as `filled` on the tick where it actually
+    triggers.
     """
     side = o.get("side")
     if side not in ("enter_long", "exit_long") or "position_size" not in o:
         return o
+    if o.get("status") != "filled":
+        return None
     symbol = (o.get("asset") or "").split("-")[0] or (o.get("asset") or "")
     return {
         "action": "enter" if side == "enter_long" else "exit",

--- a/server/src/services/strategy_service.py
+++ b/server/src/services/strategy_service.py
@@ -612,9 +612,17 @@ def tick(strategy_id: str) -> None:
             return
 
         try:
-            persist = mode == "live"
+            # persist=True for BOTH paper and live (#149/#150): the engine
+            # only saves the position (and therefore only re-evaluates its
+            # stop_loss/take_profit/time exits on later ticks) when persist
+            # is set — get_open_positions loads from its DB. With
+            # persist=False, a paper entry was forgotten the moment it was
+            # emitted, so bracket exits NEVER arrived and paper positions
+            # never closed. Paper-vs-live parity requires the same engine
+            # bookkeeping; paper stays simulation-only on OUR side (no
+            # wallet, no broadcast).
             sdk_resp = mangrove_ai_client().execution.evaluate(
-                row["mangrove_id"], persist=persist,
+                row["mangrove_id"], persist=True,
             )
         except Exception as e:  # noqa: BLE001
             duration_ms = int((time.monotonic() - start_ns) * 1000)

--- a/server/tests/integration/test_strategy_service.py
+++ b/server/tests/integration/test_strategy_service.py
@@ -359,7 +359,7 @@ def test_tick_maps_engine_shaped_orders(temp_db, mock_ai_sdk, monkeypatch):
         "asset": "ETH-USD",
         "side": "enter_long",
         "order_type": "market",
-        "status": "pending",
+        "status": "filled",
         "price": 2500.0,
         "position_size": 0.04,
         "position_id": "p-7",
@@ -396,6 +396,59 @@ def test_tick_maps_engine_shaped_orders(temp_db, mock_ai_sdk, monkeypatch):
     assert t.order_intent.action == "enter"
     assert t.order_intent.side == "buy"
     assert t.order_intent.ref_price == pytest.approx(2500.0)
+
+
+def test_tick_skips_resting_bracket_orders(temp_db, mock_ai_sdk, monkeypatch):
+    """#149 regression, mirroring the exact live payload (2026-07-12): a
+    tick that opens a position emits the FILLED entry plus its bracket
+    exits (stop_loss / take_profit) with status=pending. Only the filled
+    entry may execute — running the pending brackets would exit the
+    position the moment it entered."""
+    from src.services.strategy_service import (
+        StrategyManualRequest,
+        StrategyStatusUpdate,
+        create_manual,
+        tick,
+        update_status,
+    )
+    from src.services.trade_log import list_trades
+
+    eval_resp = MagicMock()
+    eval_resp.new_orders = [
+        {"order_id": "e850f1d1", "asset": "BTC", "side": "enter_long",
+         "order_type": "limit", "status": "filled",
+         "price": 64176.77, "position_size": 0.14023765, "position_id": "p-1"},
+        {"order_id": "7527afcd", "asset": "BTC", "side": "exit_long",
+         "order_type": "stop_loss", "status": "pending",
+         "price": 63855.88615, "position_size": 0.14023765, "position_id": "p-1"},
+        {"order_id": "7d9df96a", "asset": "BTC", "side": "exit_long",
+         "order_type": "take_profit", "status": "pending",
+         "price": 64818.5377, "position_size": 0.14023765, "position_id": "p-1"},
+    ]
+    eval_resp.order_intents = None
+    eval_resp.orders = None
+    eval_resp.model_dump.return_value = {}
+    mock_ai_sdk.execution.evaluate.return_value = eval_resp
+
+    md = MagicMock()
+    md.data = {"current_price": 64084.0}
+    mock_ai_sdk.crypto_assets.get_market_data.return_value = md
+    monkeypatch.setattr("src.services.order_executor.mangrove_ai_client",
+                        lambda: mock_ai_sdk)
+
+    s = create_manual(StrategyManualRequest(
+        name="brackets", asset="BTC", timeframe="1h",
+        entry=[{"name": "rsi_cross_up", "signal_type": "TRIGGER", "timeframe": "1h"}],
+    ))
+    update_status(s.id, StrategyStatusUpdate(status="inactive"))
+    update_status(s.id, StrategyStatusUpdate(status="paper"))
+
+    tick(s.id)
+
+    trades = list_trades(s.id)
+    assert len(trades) == 1, "only the FILLED entry may execute, not resting brackets"
+    assert trades[0].order_intent.action == "enter"
+    assert trades[0].order_intent.side == "buy"
 
 
 def test_tick_catches_sdk_errors(temp_db, mock_ai_sdk):

--- a/server/tests/integration/test_strategy_service.py
+++ b/server/tests/integration/test_strategy_service.py
@@ -450,6 +450,13 @@ def test_tick_skips_resting_bracket_orders(temp_db, mock_ai_sdk, monkeypatch):
     assert trades[0].order_intent.action == "enter"
     assert trades[0].order_intent.side == "buy"
 
+    # Paper ticks MUST persist engine state — with persist=False the engine
+    # forgets the position immediately (get_open_positions loads from its
+    # DB), so the resting brackets we just skipped would NEVER re-emit as
+    # filled and paper positions would never close.
+    _, ev_kwargs = mock_ai_sdk.execution.evaluate.call_args
+    assert ev_kwargs.get("persist") is True
+
 
 def test_tick_catches_sdk_errors(temp_db, mock_ai_sdk):
     """SDK failure during tick logs evaluation with status=error, does NOT raise."""


### PR DESCRIPTION
## Summary

Closes https://github.com/MangroveTechnologies/mangrove-agent/issues/149. The very first real engine-order firing after #147 (2026-07-12 16:35Z, paper) revealed it: the engine emits the **filled entry plus its resting bracket exits** (`stop_loss`/`take_profit`, `status: "pending"`) on the same tick, and the mapping executed all three — enter 0.1402 BTC, instantly exit twice. **On live this would market-sell a position the moment it entered.**

`_map_engine_order` now returns `None` for any engine order whose `status != "filled"` (logged at info as `order_intent.resting`); the engine re-emits a bracket as `filled` on the tick where it actually triggers, which is when it should execute.

## Verification

- **434 passed, 2 skipped**, ruff clean. New regression test mirrors the exact live payload (filled limit entry + pending stop_loss + pending take_profit → exactly one trade, the entry). The #147 fixture updated to `status: "filled"` (its old `"pending"` value now correctly produces zero trades — which is the fix working).
- Container rebuilt from this branch; real-engine evaluation smoke on a fresh 5m strategy: `status: ok`, zero skipped/resting anomalies in logs.
- The user-visible paper trades that motivated this (`139-live-proof-rsi_cross_up`: 1 entry + 2 simultaneous exits at the same fill) remain in the local trade log as the incident record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)