### PR TITLE
feat(state): agent persists its own positions + execution_state, always (#151 Phase 0)

### DIFF
--- a/.claude/rules/trading-bot-workflow.md
+++ b/.claude/rules/trading-bot-workflow.md
@@ -32,6 +32,16 @@ mcp__mangrove-agent__status, list_tools, list_signals, list_wallets, create_wall
 6. Small first allocation: 10-20% of balance, regardless of backtest numbers.
 7. Wallet secrets NEVER in chat. See `wallet-presentation.md` for SecretVault + reveal-secret.sh flow. If user pastes a key, the harness hook blocks -- don't work around it.
 
+## How this bot operates (state & evaluation model)
+
+Know thyself — when the user asks "where does X live" or "who decides Y", this is the answer:
+
+- **This agent owns the tick.** APScheduler in THIS process fires every strategy evaluation on the strategy's timeframe. MangroveAI never schedules anything for the agent.
+- **The MangroveAI engine owns the trading decision.** Each tick calls the engine, which evaluates signals, sizes the position off its execution state, manages stop_loss/take_profit brackets, and returns orders. Only orders with `status: "filled"` execute here — `pending` brackets are the engine's to track and re-emit as filled on the tick they trigger.
+- **The evaluation lane is a per-strategy choice** (`evaluation_lane`): `server` (default) = by-id evaluation, engine DB authoritative for engine position state; `stateless` = object-lane, the agent supplies `execution_state` + `open_positions` from its own DB and persists what comes back (available once MangroveAI#840 ships).
+- **The agent persists its own record in ALL cases** — every trade, evaluation, position (opened on entry fills, closed with P&L on exit fills, keyed to the engine's position id), and per-strategy `execution_state`, all in local SQLite (`agent-data/agent.db`). The local DB is a complete standalone audit trail even when the `server` lane is in use. `list_trades` / `list_evaluations` read it; positions via `trade_log.list_positions`.
+- **Execution is the agent's job**: paper fills simulate locally; live swaps quote/sign/broadcast from this machine, capped by the allocation block.
+
 ---
 
 ## Stage 0 -- platform tour (no wallet required)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,8 @@ A local Mangrove-powered trading bot. Author strategies, backtest, paper-trade, 
 
 **Service-layer pattern:** Routes and MCP tools both call shared services in `server/src/services/`. Never duplicate business logic.
 
+**State ownership:** THIS agent owns the tick and the record. APScheduler here fires every strategy evaluation (MangroveAI never schedules for the agent), and the local SQLite (`agent-data/agent.db`) persists every trade, evaluation, position, and per-strategy `execution_state` — unconditionally, regardless of evaluation lane. Evaluation itself (signals, sizing, exits) happens in the MangroveAI engine via `evaluation_lane`: `server` (default — by-id; engine DB is authoritative for engine position state) or `stateless` (object-lane; the agent supplies and receives all state — pending MangroveAI#840). The engine decides *what* to trade; the agent decides *when to ask*, executes, and keeps the books.
+
 ## Conventions
 
 - Routes in `server/src/api/routes/` -- one file per resource

--- a/docs/strategy-lifecycle.md
+++ b/docs/strategy-lifecycle.md
@@ -42,6 +42,25 @@ Key properties:
 - **Invariant: as long as uvicorn is running, strategies tick.**
   Close the laptop or kill the process → nothing fires.
 
+### What the agent persists locally, in all cases
+
+Every tick leaves a complete local record in `agent.db`, regardless of
+evaluation lane (#151):
+
+| Table | Written by | What |
+|---|---|---|
+| `evaluations` | `strategy_service.tick` | Verbatim engine response per tick, incl. `execution_state` |
+| `strategies.execution_state_json` | `strategy_service.tick` (migration 005) | Latest engine account/risk state per strategy — the value the stateless lane round-trips |
+| `trades` | `order_executor` | Every fill, paper or live; exit trades carry `p_and_l` |
+| `positions` | `order_executor._maintain_position` | Opened on entry fills (keyed to the engine's position id), closed with P&L on exit fills |
+
+The division of labor: the **engine decides what to trade** (signals,
+sizing, bracket exits — only `status: "filled"` engine orders execute
+here); the **agent decides when to ask** (its scheduler), executes, and
+keeps the books. `evaluation_lane` (`server` default | `stateless` once
+MangroveAI#840 ships) chooses where the engine's position state lives —
+the local record above exists either way.
+
 ## 2. Deploy to paper
 
 ```

--- a/server/src/models/domain.py
+++ b/server/src/models/domain.py
@@ -42,6 +42,11 @@ class OrderIntent(BaseModel):
     # Engine's evaluation-time market price. Lets the live executor convert
     # asset units -> input-token (USDC) spend without a second price fetch.
     ref_price: float | None = None
+    # The engine's position UUID for this order. Lets the executor key the
+    # LOCAL positions table to the engine's position exactly: the entry
+    # creates the local row under this id, the bracket/signal exit closes
+    # the same row (#151 — the agent persists its own positions).
+    engine_position_id: str | None = None
     stop_loss: float | None = None
     take_profit: float | None = None
     # Explicit chain-level addresses for live execution. Both or neither.

--- a/server/src/services/order_executor.py
+++ b/server/src/services/order_executor.py
@@ -29,7 +29,7 @@ import uuid
 from typing import Any, Literal
 
 from src.config import app_config
-from src.models.domain import OrderIntent, Trade
+from src.models.domain import OrderIntent, Position, Trade
 from src.services import dex_service, trade_log
 from src.services.wallet_manager import sign as wallet_sign
 from src.shared.clients.mangrove import mangrove_ai_client, mangrove_markets_client
@@ -379,8 +379,8 @@ def execute_one(
     cron-driven callers pass the real strategy UUID.
     """
     if mode == "paper":
-        return _paper_fill(intent, strategy_id=strategy_id, evaluation_id=evaluation_id)
-    if mode == "live":
+        trade = _paper_fill(intent, strategy_id=strategy_id, evaluation_id=evaluation_id)
+    elif mode == "live":
         if not wallet_address:
             raise SigningError(
                 "wallet_address is required for live execution.",
@@ -392,7 +392,7 @@ def execute_one(
         # not move real funds without it. Paper mode is exempt (above).
         from src.services.wallet_manager import require_backup_confirmed
         require_backup_confirmed(wallet_address)
-        return _live_swap(
+        trade = _live_swap(
             intent,
             strategy_id=strategy_id,
             evaluation_id=evaluation_id,
@@ -402,7 +402,87 @@ def execute_one(
             slippage_pct=slippage_pct,
             max_input_amount=max_input_amount,
         )
-    raise SigningError(f"Unknown mode: {mode}")
+    else:
+        raise SigningError(f"Unknown mode: {mode}")
+
+    _maintain_position(trade, strategy_id=strategy_id)
+    return trade
+
+
+def _maintain_position(trade: Trade, strategy_id: str) -> None:
+    """Keep the LOCAL positions table in sync with strategy fills (#151).
+
+    The agent persists its own positions in ALL cases — regardless of
+    which evaluation lane produced the intent or whether the engine also
+    tracks the position server-side. Entry fills open a row (keyed to the
+    engine's position id when the intent carries one), exit fills close
+    the matching row pro-rata and fill the exit trade's p_and_l.
+
+    Bookkeeping must never fail a trade: errors are logged, not raised.
+    User-initiated swaps (no strategy) are not positions — skipped.
+    """
+    intent = trade.order_intent
+    if intent is None or strategy_id == "user-initiated":
+        return
+    if trade.status == "failed":
+        return
+    try:
+        if intent.action == "enter":
+            # Asset quantity acquired: for a buy, the output leg.
+            entry_amount = trade.output_amount if intent.side == "buy" else trade.input_amount
+            trade_log.update_position(Position(
+                id=intent.engine_position_id or str(uuid.uuid4()),
+                strategy_id=strategy_id,
+                asset=intent.symbol,
+                entry_trade_id=trade.id,
+                entry_price=trade.fill_price,
+                entry_amount=float(entry_amount or 0.0),
+                entry_time=trade.executed_at,
+                status="open",
+                stop_loss=intent.stop_loss,
+                take_profit=intent.take_profit,
+            ))
+            return
+
+        # Exit: close the engine-keyed row, else oldest open (FIFO).
+        position = None
+        if intent.engine_position_id:
+            position = trade_log.get_position(intent.engine_position_id)
+        if position is None or position.status != "open":
+            position = trade_log.find_open_position(strategy_id, intent.symbol)
+        if position is None:
+            _log.warning(
+                "position.exit.unmatched",
+                strategy_id=strategy_id,
+                symbol=intent.symbol,
+                engine_position_id=intent.engine_position_id,
+                trade_id=trade.id,
+            )
+            return
+
+        # Asset quantity sold: for a sell, the input leg.
+        exit_amount = float((trade.input_amount if intent.side == "sell" else trade.output_amount) or 0.0)
+        position.exit_trade_id = trade.id
+        position.exit_price = trade.fill_price
+        position.exit_amount = exit_amount
+        position.exit_time = trade.executed_at
+        position.status = "closed"
+        trade_log.update_position(position)
+
+        # P&L on the exit trade, pro-rata for partial exits.
+        closed_fraction = (
+            min(exit_amount / position.entry_amount, 1.0) if position.entry_amount else 1.0
+        )
+        entry_cost = position.entry_price * position.entry_amount * closed_fraction
+        exit_proceeds = trade.fill_price * exit_amount
+        trade_log.set_trade_pnl(trade.id, exit_proceeds - entry_cost)
+    except Exception as e:  # noqa: BLE001
+        _log.error(
+            "position.bookkeeping.errored",
+            strategy_id=strategy_id,
+            trade_id=trade.id,
+            exception=str(e),
+        )
 
 
 def execute_many(

--- a/server/src/services/strategy_service.py
+++ b/server/src/services/strategy_service.py
@@ -171,6 +171,7 @@ def _map_engine_order(o: dict) -> dict | None:
         "amount": float(o["position_size"]),
         "reason": f"engine {o.get('order_type', 'market')} order {o.get('order_id', '')}".strip(),
         "ref_price": o.get("price"),
+        "engine_position_id": o.get("position_id"),
         "stop_loss": o.get("stop_loss_price"),
         "take_profit": o.get("take_profit_price"),
     }
@@ -670,6 +671,24 @@ def tick(strategy_id: str) -> None:
             duration_ms=duration_ms,
             status="ok",
         ))
+
+        # Persist the engine's execution_state first-class (#151) — the
+        # agent's own record of account/risk state per strategy, and the
+        # exact value the stateless evaluation lane (MangroveAI#840) will
+        # round-trip. Never fail the tick over bookkeeping.
+        exec_state = sdk_dump.get("execution_state")
+        if isinstance(exec_state, dict) and exec_state:
+            try:
+                conn = get_connection()
+                conn.execute(
+                    "UPDATE strategies SET execution_state_json = ?, updated_at = ? WHERE id = ?",
+                    (json.dumps(exec_state, default=str),
+                     trade_log.now_utc().isoformat(), strategy_id),
+                )
+                conn.commit()
+            except Exception as e:  # noqa: BLE001
+                _log.error("strategy.execution_state.persist_failed",
+                           strategy_id=strategy_id, exception=str(e))
 
         if order_intents:
             order_executor.execute_many(

--- a/server/src/services/trade_log.py
+++ b/server/src/services/trade_log.py
@@ -116,7 +116,68 @@ def update_position(position: Position) -> None:
     conn.commit()
 
 
+def set_trade_pnl(trade_id: str, p_and_l: float) -> None:
+    """Fill a trade's p_and_l after its position closes (exit trades)."""
+    conn = get_connection()
+    conn.execute("UPDATE trades SET p_and_l = ? WHERE id = ?", (p_and_l, trade_id))
+    conn.commit()
+
+
 # -- Query helpers -----------------------------------------------------------
+
+
+def _row_to_position(r) -> Position:
+    return Position(
+        id=r["id"],
+        strategy_id=r["strategy_id"],
+        asset=r["asset"],
+        entry_trade_id=r["entry_trade_id"],
+        exit_trade_id=r["exit_trade_id"],
+        entry_price=r["entry_price"],
+        entry_amount=r["entry_amount"],
+        entry_time=datetime.fromisoformat(r["entry_time"]),
+        exit_price=r["exit_price"],
+        exit_amount=r["exit_amount"],
+        exit_time=datetime.fromisoformat(r["exit_time"]) if r["exit_time"] else None,
+        status=r["status"],
+        stop_loss=r["stop_loss"],
+        take_profit=r["take_profit"],
+    )
+
+
+def get_position(position_id: str) -> Position | None:
+    r = get_connection().execute(
+        "SELECT * FROM positions WHERE id = ?", (position_id,)
+    ).fetchone()
+    return _row_to_position(r) if r else None
+
+
+def find_open_position(strategy_id: str, asset: str) -> Position | None:
+    """Oldest open position for (strategy, asset) — FIFO fallback for exits
+    whose intent carries no engine_position_id."""
+    r = get_connection().execute(
+        """SELECT * FROM positions
+           WHERE strategy_id = ? AND asset = ? AND status = 'open'
+           ORDER BY entry_time ASC LIMIT 1""",
+        (strategy_id, asset),
+    ).fetchone()
+    return _row_to_position(r) if r else None
+
+
+def list_positions(strategy_id: str, status: str | None = None, limit: int = 50) -> list[Position]:
+    if status:
+        rows = get_connection().execute(
+            """SELECT * FROM positions WHERE strategy_id = ? AND status = ?
+               ORDER BY entry_time DESC LIMIT ?""",
+            (strategy_id, status, limit),
+        ).fetchall()
+    else:
+        rows = get_connection().execute(
+            """SELECT * FROM positions WHERE strategy_id = ?
+               ORDER BY entry_time DESC LIMIT ?""",
+            (strategy_id, limit),
+        ).fetchall()
+    return [_row_to_position(r) for r in rows]
 
 
 def _row_to_evaluation(r) -> Evaluation:

--- a/server/src/shared/db/migrations/005_strategy_execution_state.sql
+++ b/server/src/shared/db/migrations/005_strategy_execution_state.sql
@@ -1,0 +1,5 @@
+-- #151: the agent persists its own engine execution_state per strategy,
+-- first-class (not only buried verbatim inside evaluations.sdk_response_json).
+-- Updated by strategy_service.tick after every successful evaluation; the
+-- stateless evaluation lane (MangroveAI#840) round-trips this value.
+ALTER TABLE strategies ADD COLUMN execution_state_json TEXT;

--- a/server/tests/integration/test_strategy_service.py
+++ b/server/tests/integration/test_strategy_service.py
@@ -366,7 +366,10 @@ def test_tick_maps_engine_shaped_orders(temp_db, mock_ai_sdk, monkeypatch):
     }]
     eval_resp.order_intents = None
     eval_resp.orders = None
-    eval_resp.model_dump.return_value = {}
+    eval_resp.model_dump.return_value = {
+        "execution_state": {"cash_balance": 9900.0, "account_value": 10000.0,
+                            "total_trades": 1, "num_open_positions": 1},
+    }
     mock_ai_sdk.execution.evaluate.return_value = eval_resp
 
     md = MagicMock()
@@ -396,6 +399,22 @@ def test_tick_maps_engine_shaped_orders(temp_db, mock_ai_sdk, monkeypatch):
     assert t.order_intent.action == "enter"
     assert t.order_intent.side == "buy"
     assert t.order_intent.ref_price == pytest.approx(2500.0)
+
+    # #151: the engine's position id keys the LOCAL position row...
+    from src.services.trade_log import get_position
+    pos = get_position("p-7")
+    assert pos is not None and pos.status == "open"
+    assert pos.entry_amount == pytest.approx(0.04)
+
+    # ...and the engine's execution_state persists first-class (migration 005).
+    import json as _json
+    from src.shared.db.sqlite import get_connection
+    row = get_connection().execute(
+        "SELECT execution_state_json FROM strategies WHERE id = ?", (s.id,)
+    ).fetchone()
+    state = _json.loads(row["execution_state_json"])
+    assert state["cash_balance"] == 9900.0
+    assert state["num_open_positions"] == 1
 
 
 def test_tick_skips_resting_bracket_orders(temp_db, mock_ai_sdk, monkeypatch):

--- a/server/tests/unit/test_order_executor.py
+++ b/server/tests/unit/test_order_executor.py
@@ -156,6 +156,64 @@ def test_paper_simulates_at_mark_price(temp_db, mock_mangroveai, mock_markets):
     assert fetched[0].mode == "paper"
 
 
+def test_position_lifecycle_paper_enter_exit(temp_db, mock_mangroveai, mock_markets):
+    """#151: entry fills open a LOCAL position row keyed to the engine's
+    position id; exit fills close it and stamp p_and_l on the exit trade."""
+    from src.models.domain import OrderIntent
+    from src.services.order_executor import execute_one
+    from src.services.trade_log import get_position, list_trades
+
+    enter = OrderIntent(action="enter", side="buy", symbol="ETH", amount=0.1,
+                        ref_price=2500.0, engine_position_id="engine-pos-1",
+                        stop_loss=2400.0, take_profit=2700.0, reason="t")
+    execute_one(enter, mode="paper", strategy_id="s1")
+
+    pos = get_position("engine-pos-1")
+    assert pos is not None and pos.status == "open"
+    assert pos.asset == "ETH"
+    assert pos.entry_amount == pytest.approx(0.1)
+    assert pos.entry_price == pytest.approx(2500.0)
+    assert pos.stop_loss == pytest.approx(2400.0)
+
+    # Exit at a higher mark: 0.1 ETH sold at 3000 vs entered at 2500 -> +50.
+    mock_mangroveai.crypto_assets.get_market_data.return_value.data = {"current_price": 3000.0}
+    exit_i = OrderIntent(action="exit", side="sell", symbol="ETH", amount=0.1,
+                         engine_position_id="engine-pos-1", reason="tp")
+    exit_trade = execute_one(exit_i, mode="paper", strategy_id="s1")
+
+    pos = get_position("engine-pos-1")
+    assert pos.status == "closed"
+    assert pos.exit_trade_id == exit_trade.id
+    assert pos.exit_price == pytest.approx(3000.0)
+    stored = [t for t in list_trades("s1") if t.id == exit_trade.id][0]
+    assert stored.p_and_l == pytest.approx(50.0)
+
+
+def test_position_exit_fifo_fallback_without_engine_id(temp_db, mock_mangroveai, mock_markets):
+    """Exits with no engine_position_id close the OLDEST open (strategy, asset) position."""
+    from src.models.domain import OrderIntent
+    from src.services.order_executor import execute_one
+    from src.services.trade_log import list_positions
+
+    for _ in range(2):
+        execute_one(OrderIntent(action="enter", side="buy", symbol="ETH",
+                                amount=0.1, reason="t"), mode="paper", strategy_id="s1")
+    execute_one(OrderIntent(action="exit", side="sell", symbol="ETH",
+                            amount=0.1, reason="t"), mode="paper", strategy_id="s1")
+
+    open_rows = list_positions("s1", status="open")
+    closed_rows = list_positions("s1", status="closed")
+    assert len(open_rows) == 1 and len(closed_rows) == 1
+
+
+def test_user_initiated_swaps_do_not_create_positions(temp_db, mock_mangroveai, mock_markets):
+    from src.services.order_executor import execute_one
+    from src.services.trade_log import list_positions
+
+    execute_one(_intent("buy"), mode="paper", strategy_id="user-initiated")
+    assert list_positions("user-initiated") == []
+
+
 def test_paper_sell_swaps_tokens(temp_db, mock_mangroveai, mock_markets):
     from src.services.order_executor import execute_one
 


### PR DESCRIPTION
## Summary

Phase 0 of the cross-repo plan on https://github.com/MangroveTechnologies/mangrove-agent/issues/151 — the parts that are unblocked today and that the stateless lane will build on. Invariant: **the agent owns the tick and the record** — local SQLite is a complete standalone audit trail in all cases, regardless of evaluation lane.

**Gap this closes:** `trades`/`evaluations` persisted, but the `positions` table had **zero rows ever** (`update_position` had no callers), and per-strategy engine `execution_state` existed only buried inside `sdk_response_json`.

- `OrderIntent.engine_position_id` — the engine's position UUID rides the mapped order; local positions key exactly to engine positions.
- `order_executor._maintain_position` — entry fills open a local position (paper + live); exit fills close the engine-keyed row (FIFO fallback for id-less intents), stamp exit fields, and fill the exit trade's `p_and_l` (pro-rata). Bookkeeping never fails a trade; user-initiated swaps excluded.
- `trade_log` readers: `get_position`, `find_open_position`, `list_positions`, plus `set_trade_pnl`.
- **Migration 005**: `strategies.execution_state_json`, written by `tick` after every successful evaluation — the exact value the stateless lane (https://github.com/MangroveTechnologies/MangroveAI/issues/840) round-trips.
- **Self-awareness** (per Tim): CLAUDE.md "State ownership" section, `trading-bot-workflow.md` "How this bot operates" (tick ownership, lane choice, filled-only engine orders, what persists where), `strategy-lifecycle.md` local-persistence table.

## Verification

- **437 passed, 2 skipped**, ruff clean. New tests: engine-id-keyed position lifecycle with P&L (+50 on a 2500→3000 exit), FIFO fallback, user-initiated exclusion, execution_state persisted in the engine-shape tick test.
- **Live E2E** (fresh container from this branch, real MangroveAI engine): migration 005 applied on boot; ONE real evaluation persisted the full `execution_state` (cash_balance, account_value, `risk_state` incl. cooldown/daily counters) into the local strategies row. Position rows populate on the next real fill — the live proof strategies will demonstrate post-merge (positions can't be forced deterministically; covered by exact-shape tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)