### PR TITLE
docs(backtest): async-backed run() knowledge + quick-mode caveat; pin mangroveai >=1.14

### DIFF
--- a/.claude/skills/backtest/SKILL.md
+++ b/.claude/skills/backtest/SKILL.md
@@ -105,6 +105,16 @@ Tell the user the resolved window before running: "Backtesting on
 
 Call `backtest_strategy(strategy_id, mode="full", start_date=..., end_date=...)`. Mode is always `"full"` for this skill (quick mode is for the bulk-candidate flow in `/create-strategy` Phase B-bulk).
 
+> **Quick-mode caveat.** `mode="quick"` is a signal-frequency screen with **no
+> risk management** — no stop-loss, no take-profit, no time-based exits. An
+> entry-only strategy there holds a single position until end-of-window, so
+> quick-mode metrics are NOT comparable to full-mode metrics and must never be
+> quoted as performance. This is a quick-mode artifact only: in `full` mode,
+> entry-only strategies are first-class — every position carries a system
+> ATR stop-loss/take-profit bracket plus time-based exits from
+> `execution_config`, so exit signals are optional refinement, not a
+> requirement (523/1000 reference strategies are entry-only by design).
+
 Set expectations on latency:
 
 - 5m × 14d (~4000 bars): a few seconds

--- a/.claude/skills/backtest/SKILL.md
+++ b/.claude/skills/backtest/SKILL.md
@@ -70,12 +70,17 @@ timeframe:
 | 4h | 6 | **12–30 months** (default: 18mo) |
 | 1d | 1 | **5–14 years** (default: 5y, capped by provider history) |
 
-> **Upstream timeout ceiling.** A single backtest runs against the cloud
-> engine under `MANGROVE_SDK_TIMEOUT_SECONDS` (default 180s). Very long
-> intraday windows can exceed it and return a `504`/`SDK_ERROR` — e.g. a
-> **12-month 1h** run (~8,760 bars) reliably times out. Staying in the table's
-> ranges (≤~6mo on 1h) keeps you well under it; for longer spans use
-> `oracle_backtest_async` + poll, or walk several shorter windows.
+> **Long windows are fine (SDK ≥1.14).** `backtest_strategy` is async-backed:
+> the SDK submits to the async surface (`POST /api/v2/backtests/`) and polls
+> status internally, so there is **no gateway timeout ceiling** — a 12-month
+> 1h run (~8,760 bars) completes normally (verified: `num_days=370`). Warm
+> windows return in seconds; a *cold* long window (first request for that
+> asset/range) can take tens of seconds while historical data is fetched —
+> that is the SDK polling, not a hang. The SDK gives up after its poll
+> `timeout` (default 600s) with a `TimeoutError`. The old advice to walk
+> shorter windows or drop to `oracle_backtest_async` for long spans is
+> obsolete; pick the window the table recommends for *statistical* reasons,
+> not transport ones.
 
 The table is the default. Override reasons:
 

--- a/server/src/mcp/tools.py
+++ b/server/src/mcp/tools.py
@@ -2257,6 +2257,13 @@ def _register_strategy(server: FastMCP) -> None:
     ) -> str:
         """Run a backtest against an existing strategy (mode=quick|full).
 
+        Async-backed (SDK >=1.14): the SDK submits to the async surface and
+        polls status internally, so long windows work -- there is no gateway
+        timeout ceiling. Warm windows return in seconds; a cold long window
+        (first request for that asset/range) can take tens of seconds while
+        historical data is fetched. Pick windows for statistical coverage,
+        not transport limits.
+
         Window resolution (first non-null wins):
           start_date+end_date > lookback_hours > lookback_days
           > lookback_months > timeframes.recommended_lookback_months
@@ -2287,7 +2294,10 @@ def _register_strategy(server: FastMCP) -> None:
     register_tool(ToolEntry(
         name="backtest_strategy",
         description=(
-            "Backtest a strategy (quick or full). Window precedence: "
+            "Backtest a strategy (quick or full). Async-backed (SDK >=1.14: "
+            "submit + poll under the hood), so long windows work — no "
+            "gateway timeout; cold long windows may take tens of seconds. "
+            "Window precedence: "
             "start+end > hours > days > months > timeframe-aware auto "
             "(5m-1h=3mo, 4h=6mo, 1d=12mo). `config` is a single dict "
             "that merges over trading_defaults.json — use it for "

--- a/server/src/mcp/tools.py
+++ b/server/src/mcp/tools.py
@@ -2264,6 +2264,15 @@ def _register_strategy(server: FastMCP) -> None:
         historical data is fetched. Pick windows for statistical coverage,
         not transport limits.
 
+        Mode semantics: `full` runs the real engine -- every position gets a
+        system ATR stop-loss/take-profit bracket plus time-based exits from
+        execution_config, so entry-only strategies (empty exit list) are
+        first-class and close positions normally. `quick` is a
+        signal-frequency screen with NO risk management (no SL/TP/time
+        exits): entry-only strategies there hold one position to
+        end-of-window, so quick metrics are for relative screening only --
+        never quote them as performance.
+
         Window resolution (first non-null wins):
           start_date+end_date > lookback_hours > lookback_days
           > lookback_months > timeframes.recommended_lookback_months


### PR DESCRIPTION
Two knowledge updates for the agent, now that mangroveai **v1.14.0 is live on PyPI**:

## 1. Backtests are async-backed (finishes the MangroveAI#808 arc)
SDK v1.14 makes `backtesting.run()` submit + poll under the hood — no more ~15s gateway ceiling on long/cold windows. Updated every agent surface that encoded the old limitation:
- `.claude/skills/backtest/SKILL.md` — the "upstream timeout ceiling / walk shorter windows" workaround replaced with the async reality (long windows fine; cold windows can take tens of seconds; SDK poll timeout 600s; pick windows for statistics, not transport).
- `backtest_strategy` MCP docstring + registered tool description — what the agent LLM actually reads.
- `server/requirements.txt`: `mangroveai` floor `1.7.2` → `1.14.0` (verified live on PyPI).

## 2. Quick-mode caveat (from the re-scoped https://github.com/MangroveTechnologies/MangroveAI/issues/801)
`mode="quick"` has **no risk management** (no SL/TP/time exits) — entry-only strategies there hold one position to end-of-window, so quick metrics are relative-screening only. In `full` mode entry-only strategies are first-class: system ATR stop-loss/take-profit brackets + time exits close positions (523/1000 reference strategies are entry-only by design). Both the skill and the tool description now state this, so the agent never mistakes a quick screen for performance or invents an "exit signals required" rule.

## Verification
- 415 server tests pass, ruff clean.
- SDK v1.14.0 `run()` E2E-verified on the SDK PR (12-month run in 8.5s via `1× POST /api/v2/backtests/` + status polls, zero v1 sync hits).
- Engine facts source-verified (six close paths, one signal-dependent) — evidence on https://github.com/MangroveTechnologies/MangroveAI/issues/801.

🤖 Generated with [Claude Code](https://claude.com/claude-code)